### PR TITLE
feat(authz): per-docset grant model (ro/rw) + inbox publish plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,25 +201,25 @@ OpenLore is built on [Wish](https://github.com/charmbracelet/wish) from Charmbra
 
 | Command | Description |
 |---------|-------------|
-| `whoami` | Print your identity and lore |
+| `whoami` | Print your identity |
 | `lore` | Introspection dispatcher (run `lore` for subcommands) |
-| `lore docsets` | List the docsets you can access, their paths, and attributes |
+| `lore docsets` | List the docsets you can access, their grant, paths, and attributes |
 
 `lore docsets` prints an aligned, greppable table:
 
 ```
 $ lore docsets
-DOCSET    ACCESS  ATTRIBUTES     PATHS
-public    r       -              /docs/public,/docs/getting-started.md
-backend   rw      approval       /docs/backend,/docs/api
-home      rw      home,publish   /home/backend
+DOCSET    GRANT    ATTRIBUTES   PATHS
+public    ro       -            /docs/public,/docs/getting-started.md
+backend   rw       -            /docs/backend,/docs/api
+home      rw       home,inbox   /home/backend
 ```
 
-- `ACCESS` is `r` or `rw` — whether you can write to the docset **directly** with the
-  normal write verbs.
+- `GRANT` is the named grant you hold on the docset: `ro` (read the whole docset),
+  `rw` (read + write anywhere in it), or `publish` (read the whole docset, create/edit
+  only within its inbox, never delete).
 - `ATTRIBUTES` is a comma-joined set of tokens (`-` if none): `home` (your `$HOME`
-  docset), `publish` (the docset has a publish inbox), `approval` (some or all writes
-  are approval-gated).
+  docset), `inbox` (the docset declares an inbox folder).
 
 **Publishing**
 
@@ -227,10 +227,9 @@ home      rw      home,publish   /home/backend
 |---------|-------------|
 | `publish` | Publish content from stdin to a docset inbox (`echo "..." \| publish <docset> <path>`) |
 
-`publish` targets a docset's **publish inbox** (`publish_dir`) — a separate mechanism
-from direct writability, useful for submitting content to read-only docsets for
-curation. `lore docsets` surfaces only the *presence* of an inbox (the `publish`
-attribute); run `publish` with no args to list your inboxes.
+`publish` targets a docset's **inbox** folder — the write surface a `publish` grant
+confines create/edit to. `lore docsets` surfaces only the *presence* of an inbox (the
+`inbox` attribute); run `publish` with no args to list your inboxes.
 
 **Shell Syntax**
 
@@ -277,20 +276,27 @@ echo "# Research" | ssh -p 2222 server publish backend research/findings.md
 ssh -p 2222 server publish
 ```
 
-Enable publishing by adding `publish_dir` to a docset in your `lore.json`:
+Enable publishing by giving a docset an `inbox` folder in your `lore.json` and
+granting an identity `publish` (or `rw`) on it:
 
 ```json
 {
   "docsets": {
     "backend": {
       "paths": ["/docs/backend"],
-      "publish_dir": "./published/backend"
+      "inbox": "inbox"
     }
-  }
+  },
+  "identities": [
+    { "name": "contributor", "docsets": { "backend": "publish" } }
+  ]
 }
 ```
 
-Published files are written to the `publish_dir` on disk. If the directory is within the served tree, files appear in the VFS immediately.
+A `publish` grant lets the identity read the whole docset but only create/edit
+files within its `inbox` folder (here `/docs/backend/inbox`) — never delete. An
+`rw` grant can write anywhere in the docset. Published files appear in the VFS
+immediately.
 
 ## Writing
 
@@ -318,9 +324,10 @@ Key properties:
 - **Read-only by default.** The substrate boots read-only; writes require
   `readonly: false` (or per-identity write scope). Embedded-docs binaries can
   never be made writable.
-- **Scoped per identity.** A session can only write the docsets it's allowed to
-  `publish` to — everyone can read the shared lore, but each agent writes only
-  its own space.
+- **Scoped per identity.** Every write is authorized against the identity's
+  per-docset grant — an `rw` grant writes anywhere in its docset, a `publish`
+  grant only within the docset's inbox — so agents sharing a docset can't write
+  each other's space.
 - **Compare-and-swap by default.** Overwrites are rejected (not silently
   clobbered) if the file changed since you read it (`write_conflict_policy: hash`,
   overridable to `last_write_wins`). Append and `patch` are always CAS.
@@ -347,7 +354,7 @@ max_jobs: 8                  # bound concurrent async spawn jobs
   "docsets": {
     "ops": {
       "paths": ["/ops"],
-      "publish_dir": "./published/ops",
+      "inbox": "inbox",
       "write_conflict_policy": "hash",
       "requires_approval": [
         { "path": "/ops/policy.md", "capability": "approve@oncall" }
@@ -603,37 +610,42 @@ Create a `lore.json` to control access per public key:
   "allow_keyless": true,
   "unknown_identity": "allow",
   "default_cwd": "/docs",
-  "lore": {
-    "default": { "paths": ["/docs/public"] },
+  "docsets": {
+    "public": { "paths": ["/docs/public"] },
     "backend": {
       "paths": ["/docs/api", {"internal/specs": "/docs/specs"}]
-    },
-    "full-access": { "paths": ["/"] }
+    }
   },
+  "default": { "public": "ro" },
   "identities": [
     {
       "name": "backend-agent",
       "public_key": "ssh-ed25519 AAAA...",
-      "lore": "backend",
+      "docsets": { "public": "ro", "backend": "rw" },
       "home": "backend"
     }
   ]
 }
 ```
 
+Each identity holds a named **grant** on each docset it can access — `ro`
+(read), `rw` (read + write), or `publish` (read all, create/edit only in the
+docset's inbox, no deletes). The `default` map is the grant set for keyless /
+unrecognized callers.
+
 ### Home Directory
 
-An identity can name one of the docsets in its lore as its `home`. That
-docset's display path becomes the session's `$HOME`, enabling `~` and `~/path`
-expansion and letting `cd` with no arguments jump home. The session still
-starts in the default working directory (`default_cwd`) — `home` only sets
-`$HOME`, not where you land on connect:
+An identity can name one of its granted docsets as its `home`. That docset's
+display path becomes the session's `$HOME`, enabling `~` and `~/path` expansion
+and letting `cd` with no arguments jump home. The session still starts in the
+default working directory (`default_cwd`) — `home` only sets `$HOME`, not where
+you land on connect:
 
 ```json
 {
   "name": "backend-agent",
   "public_key": "ssh-ed25519 AAAA...",
-  "lore": "backend",
+  "docsets": { "public": "ro", "backend-home": "rw" },
   "home": "backend-home"
 }
 ```
@@ -644,8 +656,8 @@ ssh -p 2222 server "cat ~/notes.md"
 ssh -p 2222 server "cd && pwd"    # -> /home/backend
 ```
 
-The `home` docset must be one of the docsets in the identity's lore. Pair it
-with a `publish_dir` to give each agent its own writable personal space.
+The `home` docset must be one of the identity's granted docsets. Give it an
+`inbox` (with an `rw` grant) to hand each agent its own writable personal space.
 
 ### Managing Identities
 
@@ -653,15 +665,19 @@ with a `publish_dir` to give each agent its own writable personal space.
 openlore identity add \
   --name my-agent \
   --key "ssh-ed25519 AAAA..." \
-  --lore backend \
+  --docset backend \
+  --grant rw \
   --home backend \
   --auth ./lore.json
 ```
 
+The `--key` flag is optional: an identity can exist as a passkey/token-only
+login target with no SSH key.
+
 ### Unknown Identity Handling
 
 In `lore.json`:
-- `"unknown_identity": "allow"` (default) — unrecognized keys get the "default" lore spec
+- `"unknown_identity": "allow"` (default) — unrecognized keys get the `default` grant map
 - `"unknown_identity": "deny"` — reject unrecognized keys
 
 ## HTTP Front Page

--- a/assets/config/openlore.yml
+++ b/assets/config/openlore.yml
@@ -9,6 +9,12 @@ default_cwd: /
 auth_file: ./lore.json
 data_dir: ./data
 
+# Global write lock. The substrate boots read-only by default; set false to
+# enable the experimental writable substrate so authenticated identities can
+# create/overwrite files within their writable docsets (per-identity/per-docset
+# scoping still applies on top of this).
+readonly: false
+
 # How whole-file overwrites (>, tee, sed -i, publish) defend against concurrent
 # writers. "hash" (the default) makes them compare-and-swap: a write that would
 # clobber a change made since the file was read is rejected. "last_write_wins"
@@ -69,3 +75,5 @@ folders:
     path: ./published/zeb
   - name: adil
     path: ./published/adil
+  - name: alfie
+    path: ./published/alfie

--- a/cmd/openlore/main.go
+++ b/cmd/openlore/main.go
@@ -187,28 +187,30 @@ func main() {
 			case "add":
 				idCmd := flag.NewFlagSet("identity add", flag.ExitOnError)
 				name := idCmd.String("name", "", "identity name (required)")
-				key := idCmd.String("key", "", "SSH public key (required)")
-				loreName := idCmd.String("lore", "", "lore spec name (required)")
+				key := idCmd.String("key", "", "SSH public key (optional: an identity may be passkey/token-only)")
+				docset := idCmd.String("docset", "", "docset to grant access to (required)")
+				grant := idCmd.String("grant", "ro", "grant on the docset: ro, rw, or publish")
 				authPath := idCmd.String("auth", "./lore.json", "path to lore.json")
 				comment := idCmd.String("comment", "", "optional comment")
-				home := idCmd.String("home", "", "docset in the lore to use as the identity's home ($HOME)")
+				home := idCmd.String("home", "", "docset in the identity's grants to use as home ($HOME)")
 				idCmd.Usage = func() {
 					fmt.Fprintf(os.Stderr, "Usage: openlore identity add [flags]\n\n")
-					fmt.Fprintf(os.Stderr, "Add a public key identity to lore.json.\n\n")
+					fmt.Fprintf(os.Stderr, "Add an identity with a per-docset grant to lore.json.\n\n")
 					idCmd.PrintDefaults()
 				}
 				idCmd.Parse(os.Args[3:])
 
-				if *name == "" || *key == "" || *loreName == "" {
+				if *name == "" || *docset == "" || *grant == "" {
 					idCmd.Usage()
 					os.Exit(1)
 				}
 
-				// Validate the public key
-				_, _, _, _, err := gossh.ParseAuthorizedKey([]byte(*key))
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "error: invalid SSH public key: %v\n", err)
-					os.Exit(1)
+				// Validate the public key when one is given (it is optional).
+				if *key != "" {
+					if _, _, _, _, err := gossh.ParseAuthorizedKey([]byte(*key)); err != nil {
+						fmt.Fprintf(os.Stderr, "error: invalid SSH public key: %v\n", err)
+						os.Exit(1)
+					}
 				}
 
 				// Load or create auth config
@@ -223,55 +225,45 @@ func main() {
 					auth.Docsets = map[string]openlore.DocsetSpec{
 						"all": {Paths: []openlore.PathMapping{{Source: "/", Display: "/"}}},
 					}
-					auth.Lore = map[string][]string{
-						"default": {"all"},
-					}
 				} else {
 					fmt.Fprintf(os.Stderr, "error: reading %s: %v\n", *authPath, readErr)
 					os.Exit(1)
 				}
 
-				// Check lore name exists
-				loreDocsets, ok := auth.Lore[*loreName]
-				if !ok {
-					fmt.Fprintf(os.Stderr, "error: lore %q not found in %s\n", *loreName, *authPath)
-					fmt.Fprintf(os.Stderr, "Available lore: ")
-					for k := range auth.Lore {
+				// Check the docset exists.
+				if _, ok := auth.Docsets[*docset]; !ok {
+					fmt.Fprintf(os.Stderr, "error: docset %q not found in %s\n", *docset, *authPath)
+					fmt.Fprintf(os.Stderr, "Available docsets: ")
+					for k := range auth.Docsets {
 						fmt.Fprintf(os.Stderr, "%s ", k)
 					}
 					fmt.Fprintln(os.Stderr)
 					os.Exit(1)
 				}
 
-				// If a home docset is given, it must be one of the lore's docsets.
-				if *home != "" {
-					inLore := false
-					for _, ds := range loreDocsets {
-						if ds == *home {
-							inLore = true
-							break
-						}
-					}
-					if !inLore {
-						fmt.Fprintf(os.Stderr, "error: home docset %q is not in lore %q\n", *home, *loreName)
-						os.Exit(1)
-					}
+				// If a home docset is given, it must be the granted docset.
+				if *home != "" && *home != *docset {
+					fmt.Fprintf(os.Stderr, "error: home docset %q is not in the identity's grants\n", *home)
+					os.Exit(1)
 				}
 
-				// Check for duplicate keys
-				keyStr := strings.TrimSpace(*key) + "\n"
-				for _, ident := range auth.Identities {
-					if ident.PublicKey == keyStr || strings.TrimSpace(ident.PublicKey) == strings.TrimSpace(*key) {
-						fmt.Fprintf(os.Stderr, "error: public key already exists for identity %q\n", ident.Name)
-						os.Exit(1)
+				// Check for duplicate keys (only when a key is provided).
+				if *key != "" {
+					for _, ident := range auth.Identities {
+						if strings.TrimSpace(ident.PublicKey) == strings.TrimSpace(*key) {
+							fmt.Fprintf(os.Stderr, "error: public key already exists for identity %q\n", ident.Name)
+							os.Exit(1)
+						}
 					}
 				}
 
 				// Add identity
 				newIdent := openlore.AuthIdentity{
-					Name:      *name,
-					PublicKey: strings.TrimSpace(*key),
-					Lore:      *loreName,
+					Name:    *name,
+					Docsets: map[string]string{*docset: *grant},
+				}
+				if *key != "" {
+					newIdent.PublicKey = strings.TrimSpace(*key)
 				}
 				if *comment != "" {
 					newIdent.Comment = *comment
@@ -292,7 +284,7 @@ func main() {
 					os.Exit(1)
 				}
 
-				fmt.Printf("Added identity %q with lore spec %q to %s\n", *name, *loreName, *authPath)
+				fmt.Printf("Added identity %q with %s grant on docset %q to %s\n", *name, *grant, *docset, *authPath)
 				os.Exit(0)
 
 			default:
@@ -495,6 +487,11 @@ func main() {
 		slog.Error("failed to create server", "error", err)
 		os.Exit(1)
 	}
+
+	// The inbox plugin contributes the `publish` grant (read whole docset, no
+	// deletes, create/edit only within the docset's inbox). Registered by
+	// default so lore.json may use `"grant": "publish"`.
+	srv.RegisterPlugin(openlore.NewInboxPlugin())
 
 	cmds.VersionString = assets.Version()
 

--- a/docs/changeset-middleware-refactor.md
+++ b/docs/changeset-middleware-refactor.md
@@ -1,0 +1,447 @@
+# Refactor Plan: ChangeSet + Middleware Write System
+
+Status: **locked** (design agreed). Phases A–E implemented (SSH end-to-end
+proven; MCP unification deferred — see E3 note).
+
+Replaces the baked-in approval control plane with a minimal, generic mechanism:
+an ordered write log with compare-and-swap (CAS) at a serialized applier, a
+composable middleware chain on both the write and read paths, and a durable
+`ChangeSet` primitive. **All approval/policy concerns move out of go-openlore
+core into the knowledge-backend (KB).**
+
+This spans two repos:
+
+- `go-openlore` — the storage mechanism (this repo).
+- `knowledge-backend` — the policy consumer (`../knowledge-backend`, wired via
+  the `replace` directive in its `go.mod`).
+
+---
+
+## 1. Why
+
+Today go-openlore bakes an entire approval control plane into the storage core:
+`RequestStore` (persistence), `RequestsFS` (`/requests` render), `approvalFS`
+(write interception + docset-rule gating), `approvalBackend` (approve/reject +
+capability checks + CAS replay), `approve`/`reject` shell commands, and a
+`KindApprovalPending` event. None of it is wired in the KB deployment — the KB
+constructs the server with no `DataDir` and no docsets, so `approvalFS`/
+`RequestStore` never activate, and the KB enforces approvals entirely in its own
+DB layer (proposals → `ClassRequiresApproval` → `materializeProposal`).
+
+So the core carries dead, single-purpose primitives instead of a general seam a
+consumer can implement. This refactor collapses five overlapping concepts
+(approval FS, request store, request FS, approve/reject backend, event bus) into
+**one interception concept (middleware)** plus **one durable primitive
+(`ChangeSet`)**, and pushes every policy decision to the KB.
+
+---
+
+## 2. Target architecture
+
+```
+WRITE PATH
+ caller ─▶ [scope: fixed, deployment-owned]           ← auth/write isolation, non-bypassable
+        ─▶ [admission middleware chain (goroutine)]    ← approval (KB), pre-commit shellexec (can block)
+             │ admit                 │ gate
+             ▼                       ▼
+        append to ─────┐        persist held ChangeSet (KB file store)
+        ORDERED LOG    │             │ …human approve…
+             ▲         │             ▼
+             └─────────┼──── CommitChangeSet == append to LOG (skips admission; already admitted)
+                       │
+                       ▼
+        SERIALIZED APPLIER (sole input = the LOG): CAS vs current
+                       │
+                       ├──▶ substrate
+                       ├──▶ [post-commit hooks: sync] (fail_on_error=true, timeout, log keeps moving)
+                       └──▶ emit events → tailable filtered streams (KB routes; ephemeral; tail -f / SSE)
+
+READ PATH
+ caller ─▶ [read middleware chain]  ← pre_read shellexec (git pull, debounced, can block) ─▶ substrate
+```
+
+### 2.1 Ownership map (authoritative)
+
+Every component, where it lives today, and where it ends up. Four fates:
+**KEEP** (stays in go-openlore, unchanged), **NEW** (new go-openlore mechanism),
+**MOVE→KB** (capability rebuilt as a knowledge-backend OSS-staging package under
+`internal/openlore/…`, the same pattern as `scorer`/`notifier`/`policy`), and
+**DELETE** (removed; capability dropped or reborn differently).
+
+| Component | Today (go-openlore) | Fate | Ends up in |
+|---|---|---|---|
+| CAS primitives: `WriteOpts`, `RemoveOpts`, `TreeSnapshot`/`TreeOp`, `PreconditionError`, `TreeStaleError`, `WritableFS` | `pkg/vfs/vfs.go` | **KEEP** | go-openlore `pkg/vfs` |
+| Session-shell install seam: `buildSessionShell` / `shellForContext` | `pkg/openlore/server.go` | **KEEP** (extended with chains) | go-openlore `pkg/openlore` |
+| Auth-mode write scope: `scopedWriteFS` | `pkg/openlore/scoped_write_fs.go` | **KEEP** (fixed pre-chain layer; unused by KB) | go-openlore `pkg/openlore` |
+| `ChangeSet` / `WriteChange` / `DeleteChange` | — (coupled `ApprovalRequest`) | **NEW** | go-openlore `pkg/vfs` |
+| `CommitChangeSet` (CAS replay = append to log) | logic buried in `approvalBackend` | **NEW** (extracted) | go-openlore `pkg/vfs` |
+| `PendingChangeError` | `PendingApprovalError` in `pkg/vfs` | **NEW** (slimmed rename) | go-openlore `pkg/vfs` |
+| Ordered write log + serialized applier (CAS site) | — | **NEW** | go-openlore `pkg/openlore` |
+| Middleware chains (admission/post-commit/read) + `WriteMiddlewareProvider` + `Actor{ID}` | — | **NEW** | go-openlore `pkg/openlore` |
+| Tailable-stream mechanism (`tail -f`/SSE) + `Emit` interface | `Feed` fan-out via bus | **NEW** (mechanism kept, re-shaped) | go-openlore `pkg/openlore` |
+| `shellexec` default plugin (config-driven external commands) | shell `hooks` package | **NEW** (reborn as plugin) | go-openlore (default plugin) |
+| Held-changeset **store** (file-backed proposed bytes) | `RequestStore` in `approval.go` | **MOVE→KB** | KB `internal/openlore/approvals/` |
+| Gating **decision** (is this write approvable?) | `requiresApproval` + docset rules | **MOVE→KB** | KB (uses existing `ClassRequiresApproval`) |
+| Approve/reject **resolution** (minus CAS) + status/capabilities/approver/proposer | `approvalBackend` + `ApprovalRequest` fields | **MOVE→KB** | KB `internal/openlore/approvals/` + HTTP endpoint |
+| Approval **middleware** (fail-closed gate, path→partition, park+`PendingChangeError`) | `approvalFS` | **MOVE→KB** (as middleware) | KB `internal/openlore/approvals/` |
+| Event **writers** + stream routing/filtering | DBFS auto-publish + scattered KB publishes | **MOVE→KB** | KB (drives `Emit`) |
+| `kb publish --wait` coordination | bus `KindTopicRefreshed` + worker | **MOVE→KB** | KB `internal/openlore/publish` + worker |
+| `eventbus` fan-out | `pkg/openlore/eventbus` | **DELETE** | — (feed re-shaped as tailable streams) |
+| Shell `hooks` package | `pkg/openlore/hooks` | **DELETE** | — (capability → `shellexec` plugin) |
+| `RequestsFS` + `/requests` mount | `approval.go` | **DELETE** | — |
+| `approve`/`reject` shell cmds + `OPENLORE_CAPABILITIES` | `pkg/shell/cmds/approve.go` | **DELETE** | — (resolution is KB HTTP) |
+| Docset `RequiresApproval` / `ApprovalRule` config | `internal/config/config.go` | **DELETE** | — (gating is KB DB) |
+| `KindApprovalPending` | `pkg/openlore/eventbus/bus.go` | **DELETE** | — |
+
+**One-line summary:** go-openlore keeps *storage mechanism* (CAS, ordered log,
+middleware seams, tailable streams, `ChangeSet`); everything *policy* — the
+approver concept, gating decision, held-changeset store, resolution, and event
+routing — moves up into the knowledge-backend OSS packages; the approval CLI,
+event bus, shell-hooks package, and docset approval config are deleted outright.
+
+### go-openlore keeps (mechanism only)
+
+- **`vfs.ChangeSet`** — immutable, serializable description of one atomic
+  mutation: `{Target, Action(Write|Delete), Write{Bytes, Opts vfs.WriteOpts},
+  Delete{Opts vfs.RemoveOpts}}`. The payload carries the caller's own
+  `WriteOpts`/`RemoveOpts` verbatim, so it faithfully represents every write
+  mode — unconditional (last-write-wins), `IfMatch` CAS, `IfNoneMatch`
+  create-only, and snapshot-guarded vs unconditional delete — through both the
+  log and an approval hold. No approver / status / proposer / capability fields.
+- **`vfs.CommitChangeSet(fs, cs)`** — replay a held changeset by appending it to
+  the ordered log (CAS applied at the applier). CAS drift →
+  `PreconditionError` / `TreeStaleError`.
+- **`vfs.PendingChangeError{ChangeSet, Ref}`** — sentinel for a write handed off
+  to a middleware (lives in `vfs` to avoid the `cmds → vfs → openlore` cycle).
+- Existing CAS primitives (`WriteOpts`, `RemoveOpts`, `TreeSnapshot`,
+  `PreconditionError`, `TreeStaleError`, `WritableFS`) — unchanged.
+- **Ordered write log + serialized applier** — the single write serializer; CAS
+  and post-commit hooks run here, uniformly for fresh writes and approval
+  replays.
+- **Middleware seams** in `buildSessionShell` (so SSH + MCP + HTTP are covered
+  by one factory): admission (pre-commit), post-commit, and read chains.
+- **`WriteMiddlewareProvider`** (and read equivalent) plugin hook; core composes
+  provider middleware in registration order, **after** the fixed scope layer.
+- **Tailable-stream mechanism + `Emit` interface** — named, appendable,
+  `tail -f`/SSE-able virtual files. Content-agnostic. Ephemeral (in-memory).
+- **`shellexec` default plugin** — reproduces the old `openlore.yml` hooks
+  (`pre_read`, `post_write`, plus a new pre-commit slot) as middleware.
+
+### knowledge-backend owns (all policy)
+
+- **Approval middleware** — synchronous, **fail-closed** DB gating
+  (`ClassRequiresApproval` + core-partition rules), owns VFS-path → partition/
+  class mapping; on gated paths persists the `ChangeSet` and returns
+  `PendingChangeError`.
+- **Held-changeset store** — the relocated file-backed `RequestStore` (proposed
+  bytes stay immutable on disk for exact CAS replay + delete review), rooted
+  under the KB DB directory (per-tenant if multi-tenancy on). Separate from the
+  proposals table.
+- **Resolution** — human-triggered via a KB HTTP endpoint → `CommitChangeSet`
+  (append to log). Idempotent + drift-safe (stale on `Precondition`/`TreeStale`).
+- **Event writers + stream routing/filtering** — the KB emits events into named
+  streams (`/feed`, `/partitions/{p}/feed`, …) via the `Emit` interface; all
+  subset/filter logic is KB-side.
+- **`Actor{ID}`** — passed into admission middleware from the session
+  `Identity`; never enters the durable `ChangeSet`.
+
+### Deleted from go-openlore
+
+`eventbus`-as-fanout, shell `hooks` package (→ `shellexec` plugin), `RequestsFS`,
+`approve`/`reject` cmds + `OPENLORE_CAPABILITIES`, docset `RequiresApproval` /
+`ApprovalRule`, `approvalFS`, `KindApprovalPending`, and the `approval.go`
+request/backend types.
+
+---
+
+## 3. Locked decisions
+
+1. Middleware chain installed in `buildSessionShell` (covers SSH/MCP/HTTP via
+   `shellForContext`).
+2. Approve/reject CLI + `/requests` mount **deleted**; resolution is 100% KB
+   (HTTP + proposals UI).
+3. KB DB is the **sole** gating authority; docset `RequiresApproval` deleted;
+   middleware does a synchronous fail-closed DB lookup and owns path→partition
+   mapping.
+4. Held changesets live in a **separate dedicated store**, not folded into the
+   proposals table.
+5. Store = **relocated file-backed** `RequestStore` in the KB (immutable on-disk
+   proposed bytes).
+6. Async write model: writes flow through admission middleware into an **ordered
+   log**; a **serialized applier** does CAS against current state and commits.
+   `CommitChangeSet` == append to the log. There is no separate "ungated writer"
+   — the applier is the sole writer.
+7. Scope (auth/write isolation) is a **fixed, non-bypassable layer before** the
+   plugin middleware chain — not itself middleware. In the KB it is the
+   `WithAgent` DBFS injected via `sessionFSFn`.
+8. `Actor{ID}` flows into admission middleware from session identity; never into
+   `ChangeSet`.
+9. Eventbus-as-fanout **deleted**; the tailable feed **stays** as a filtered,
+   ephemeral projection (distinct from the log). Writers move to the KB behind an
+   `Emit` interface; filtering is entirely KB-side.
+10. Shell hooks survive as an opt-in **`shellexec` plugin**; read + write command
+    execution both maintained. Read-middleware seam **added** (symmetric).
+11. Hook execution: **sync by default** on both seams (`async` opt-in);
+    `fail_on_error` defaults **true**; timeout defaults **on** (30s, timeout =
+    failure). Pre-read / pre-commit failures **abort** the operation;
+    post-commit failures are **surfaced but the log keeps moving** (write already
+    durable; external side-effects may drift — reconciliation is operator's job).
+12. Conflict policy is **per-write** (a field the write carries), not per-file.
+    The applier dispatches per entry; supporting CAS + DMP + last-write-wins
+    needs no architectural change (reuses `WriteConflictPolicy`). No per-file
+    policy registry.
+13. **CAS feedback timing = await.** `Submit` blocks until the serialized applier
+    commits the entry and returns the committed hash or CAS error (per-entry
+    buffered reply channel). Preserves the "re-read and retry" contract.
+14. **Log durability = none (in-memory).** Because await means nothing is
+    "accepted" until applied+durable in the substrate, the log is a plain
+    in-memory ordered channel. Durability = substrate (committed) + KB
+    held-changeset store (pending/approved). No WAL, no replay/offset
+    bookkeeping. A crash loses only in-flight, un-acknowledged writes → caller
+    retries.
+15. **Concurrency = one applier goroutine + per-entry reply channel.** Callers
+    (already their own request goroutines) run admission inline, submit, and
+    block on the reply. The applier is the sole substrate writer. **Graceful
+    shutdown:** `writeLog.Close(ctx)` (called from `Server.Shutdown`, itself
+    driven by the entrypoint's signal handler) stops new submits (→
+    `ErrLogClosed`), drains queued + in-flight entries so every acknowledged
+    write completes, and waits for the applier to exit.
+
+### Explicitly deferred (revisit later)
+
+- Whether strict **submission ordering** is guaranteed under concurrent
+  submitters (currently: FIFO into the channel; apply-time CAS resolves
+  conflicts, commit order = channel arrival order).
+- Durable/replayable event streams (currently ephemeral in-memory).
+- DMP / alternate write semantics (architecture supports it per-write; not built).
+
+---
+
+## 4. Implementation phases
+
+### Phase A — go-openlore primitives (no behavior change to callers yet) — DONE
+
+A1. ✅ Added `vfs.ChangeSet`, `WriteChange`, `DeleteChange`, `PendingChangeError`
+    (`pkg/vfs/changeset.go`).
+A2. ✅ Extracted CAS-replay into `vfs.CommitChangeSet(fs, cs)` (write via
+    IfMatch/IfNoneMatch, delete via snapshot `Expected`). Tested incl. drift.
+A3. ✅ Ordered write log + single applier goroutine (`pkg/openlore/writelog.go`):
+    await via per-entry reply channel, in-memory (no WAL), graceful
+    `Close(ctx)` draining in-flight + queued. Tests pass under `-race`
+    (order/await, error propagation, submit-after-close, drain-on-shutdown).
+
+    NOTE: `CommitChangeSet` in `writelog` currently commits directly; post-commit
+    hooks + feed emit are added at the applier in Phase C. The old
+    `approvalFS`/`RequestStore` still stand (deleted in Phase C).
+
+### Phase B — go-openlore middleware seams
+
+B1. Define `WriteMiddleware`/`WriteHandler`, admission + post-commit + read
+    chains, and `WriteMiddlewareProvider` (+ read provider). `Actor{ID}` type. — DONE
+    (`pkg/openlore/middleware.go`, `pkg/openlore/middleware_test.go`.)
+B2. Wire the chains into `buildSessionShell`: fixed scope layer (existing) →
+    `sessionFSFn` → admission chain → log; post-commit chain at the applier;
+    read chain around `Stat`/`ReadDir`/`ReadFile`. Verify MCP/HTTP via
+    `shellForContext`.
+    - **Write path DONE.** `middlewareFS` (`pkg/openlore/middleware_fs.go`) is
+      the innermost writable wrapper: it turns every write/mkdir/remove into a
+      `ChangeSet`, runs `Server.writeChain()` (admission → terminal submit), and
+      awaits the global `writeLog`. `writeLog` created in `NewServer` over
+      `s.merge` (readonly=false only), closed in `Shutdown`. Covered by SSH +
+      MCP + HTTP because it lives in `buildSessionShell`.
+    - **Decision 1 (global applier):** one `writeLog` over the single substrate;
+      attribution is the `Actor{ID}` carried on each log entry to the
+      post-commit chain, NOT a per-session substrate. (KB's per-agent `DBFS`
+      attribution migrates to `Actor` in Phase D.)
+    - **Decision 2 (mkdir/remove are log ops):** `ChangeSet` now has
+      `write`/`mkdir`/`mkdir_all`/`remove`/`remove_all` actions so directory
+      creation and removal serialize through the log too — a write can never
+      race ahead of, or land on, a removed path.
+    - **Post-commit chain DONE at the applier** (`Server.postCommitChain()` →
+      `writeLog.postCommit`): runs after a durable commit with
+      `CommitInfo{ChangeSet, Hash, Actor}`; failures logged, log keeps moving
+      (decision #11).
+    - **Read chain DONE.** `readChainFS` (`pkg/openlore/read_chain_fs.go`) runs
+      `Server.readChain()` in front of `Stat`/`ReadDir`/`ReadFile`; a middleware
+      may abort a read by returning an error. Installed in `buildSessionShell`
+      as the innermost read wrapper, only when `s.readMW` is non-empty (zero
+      overhead otherwise).
+    - All three chains compose uniformly from provider slices (`s.writeMW`,
+      `s.readMW`, `s.postCommitMW`), currently empty in core.
+    - **Provider registration DONE** (built with C4): `Server.registerPlugin(p any)`
+      type-asserts the three provider interfaces and appends into `s.writeMW` /
+      `s.readMW` / `s.postCommitMW`. Called in `NewServer` before the write log is
+      built (post-commit chain is composed at `newWriteLog`). External-plugin
+      registration timing (KB) is revisited in Phase D.
+B3. Update `pkg/shell/cmds` `write`/`rm` to treat `PendingChangeError` as
+    exit-0 and print `Ref`. — DONE
+    - `write`/`tee`, `rm`, `publish`, `patch` now handle `*vfs.PendingChangeError`
+      (exit 0, prints "<cmd>: <target> change pending as <Ref>") alongside the
+      legacy `*vfs.PendingApprovalError`. Shared `pendingChangeLine` helper in
+      `write.go`. Tests: `pkg/shell/cmds/pending_change_test.go`.
+
+### Phase C — go-openlore deletions + shellexec plugin
+
+C1. Delete `approval.go` (RequestStore/RequestsFS/approvalBackend/
+    ApprovalRequest), approval-specific `approval_fs.go`, `approve.go` cmds +
+    `OPENLORE_CAPABILITIES`, docset `RequiresApproval`/`ApprovalRule`,
+    `KindApprovalPending`. — DONE
+    - Deleted `pkg/openlore/approval.go`, `approval_fs.go`, and their tests
+      (`approval_test.go`, `approval_fs_test.go`, `approval_delete_test.go`,
+      `approval_events_test.go`, `approve_flow_test.go`); deleted
+      `pkg/shell/cmds/approve.go`.
+    - `server.go`: removed `requests *RequestStore` field, the `/requests`
+      control-plane mount + `cmds.Approvals` wiring, the `approvalFS` layer in
+      `buildSessionShell`, the `ActionApprove` grant, and the
+      `OPENLORE_CAPABILITIES` env var. Preserved `hasCapability` (moved here;
+      still used for `spawn` gating).
+    - `cmds`: removed `ActionApprove` + `approve`/`reject` classifications and
+      registrations, the APPROVALS help block, and `DocsetInfo.Approval` (+
+      `lore` table attribute). Removed `vfs.PendingApprovalError` handling from
+      `write.go`/`rm.go`/`publish.go`/`patch.go` and `jobs.go`.
+    - `internal/config`: removed docset `RequiresApproval`/`ApprovalRule`.
+    - `pkg/vfs`: removed `PendingApprovalError`.
+    - `eventbus`: removed `KindApprovalPending`; `hooks`: removed
+      `HookSet.ApprovalPending` field + wiring.
+    - go-openlore `go build ./... && go test ./...` green (incl. `-race`); KB
+      still compiles against updated go-openlore (local replace).
+C2. Delete the `eventbus` fan-out and the shell `hooks` package. Move
+    `kb publish --wait` coordination fully into the KB. — DONE
+    - Deleted `pkg/openlore/hooks/` (relocated `Runner`/`ShellRunner` into
+      `pkg/openlore/runner.go`); `shellexec.go`/`jobs.go`/`server.go` use
+      `Runner`/`ShellRunner`; removed `Hooks` config.
+    - Detached core from the bus: `vfs.go`/`server.go`/`jobs.go` no longer hold
+      a bus, `WithBus`, or publish post_write/post_delete.
+    - Deleted the `pkg/openlore/eventbus` fan-out package entirely (no
+      remaining references in either repo).
+    - `kb publish --wait`: no separate wait/coordination primitive exists; per
+      the design, any publish waiter is a KB-only concern and is NOT built on
+      the stream. Nothing to move.
+C3. Build the tailable-stream mechanism + `Emit` interface (read side:
+    `tail -f`/SSE; append side: interface). — DONE
+    - `pkg/openlore/events.go`: `Event`, `EventKind` (+ `KindOnStartup`,
+      `KindPreRead`, `KindPostWrite`, `KindPostDelete`, `KindTopicRefreshed`),
+      `Emit`/`EmitFunc`, `EventFilter`, `MatchAll`/`MatchPartition`.
+    - `pkg/openlore/stream.go`: in-memory ring + live subscribe + `OpenReader`
+      (`tail -f`) + SSE `HTTPHandler` + `EncodeEvent`. Tested (`stream_test.go`).
+C4. Build the `shellexec` default plugin: config-driven (`pre_read`,
+    `post_write`, `pre_commit`), sync-default, `fail_on_error=true` default,
+    default timeout, same `OPENLORE_*` env protocol. Post-commit failures log +
+    continue; pre-* failures abort. — DONE
+    - `pkg/openlore/shellexec.go` — `shellexecPlugin` implements all three
+      providers. pre_read → read mw (per-path debounce, 2s default; abort on
+      fail), pre_commit → write mw (reject on fail), post_write → post-commit
+      (fire-and-forget, never halts log). Defaults: sync, `fail_on_error=true`,
+      30s timeout. Env: `OPENLORE_{DATA_DIR,EVENT,PATH,AGENT,ACTION,BYTES,HASH,
+      READ_KIND,EXTRA_*}`. `async: true` opt-in (background, cannot abort).
+    - Config: `config.ShellexecConfig`/`ShellexecCmd` (`shellexec:` block,
+      string durations, `fail_on_error *bool` → default true). Wired in
+      `NewServer` via `registerPlugin` before the write log is built.
+    - Reuses `hooks.Runner`/`ShellRunner` for now; the runner moves out of the
+      doomed `hooks` package in C2.
+    - Tests: `pkg/openlore/shellexec_test.go` (env, allow/reject/abort,
+      debounce, post-commit never-halts, async no-abort, config
+      defaults/validation).
+C5. `go build ./... && go test ./...` green in go-openlore. — DONE
+    (verified incl. `-race` on `pkg/openlore` + `pkg/vfs` after the eventbus/
+    hooks deletions).
+
+### Phase D — knowledge-backend plugin
+
+D1. New `internal/openlore/approvals/` package (OSS-staging, mirrors
+    `scorer`/`notifier`/`policy`): approval admission middleware
+    (fail-closed DB gating, path→partition mapping), relocated file-backed held
+    store, resolver (`CommitChangeSet`), `Actor` from identity. — DONE
+    - `store.go` (file-backed held-change store), `policy.go`
+      (`GovernancePolicy`: DB-backed, fail-closed, gates the
+      `governance.config_approval` list of `/config/*.yml` basenames),
+      `middleware.go` (`WriteMiddlewareProvider`; parks gated writes as
+      `*vfs.PendingChangeError`, fail-closed on policy error), `resolver.go`
+      (approve → `CommitChangeSet`; CAS drift → STALE; idempotent; a per-resolver
+      mutex serializes the read-commit-update sequence).
+D2. HTTP endpoint(s) for human resolution (`approve`/`reject` a held changeset).
+    Consider unioning with the proposals UI (read-side only). — DONE
+    - `approvals/http.go`: `GET /approvals`, `GET /approvals/{id}`,
+      `POST /approvals/{id}/approve`, `POST /approvals/{id}/reject`. STALE → 409,
+      missing → 404. Mounted from `cmd/server/main.go` via `Server.Approvals()` /
+      `Server.Resolver()`.
+D3. KB event writers: emit into named streams via the `Emit` interface; move all
+    routing/filtering here. Delete the KB `eventbus` staging shim; re-point the
+    feed to the new mechanism. — PARTIALLY DONE
+    - DONE: feed re-pointed to the go-openlore `Stream` (`api.Feed` wraps
+      `Stream`, implements `Emit`); all KB writers (DBFS post_write, `publish`,
+      worker `topic_refreshed`, teach, gdrive) call `Emit` directly; notifier +
+      worker-queue converted from bus `Subscriber`s to `Emit` sinks/adapters;
+      `main.go` wires the feed as the single `Emit` sink (no bus).
+    - REMAINING: the KB `internal/openlore/eventbus` package is still an alias
+      shim over upstream `openlore` (kept to avoid the package-name collision);
+      decide whether to keep it or import `openlore` directly. Named/multiple
+      streams + KB-side routing/filtering not yet built (single stream today).
+D4. Wire it in `internal/openlore/server.go`: register the approvals middleware +
+    shellexec (if used) as providers; keep `WithAgent` scope via `sessionFSFn`.
+    — DONE
+    - KB `NewServer` now builds the DBFS first and installs it via
+      `openlore.NewServerWithRootFS(dbFS, WithReadonly(cfg.Readonly), …)` so the
+      ordered write log + admission chain exist over the DBFS at construction
+      (a late `SetRootBashFS` would leave the log with no writable backend).
+    - The approvals middleware is registered via `srv.RegisterPlugin(mw)` before
+      serving; the resolver commits approved changes via `srv.CommitChangeSet`.
+    - `sessionFSFn` now WRAPS `base` (the go-openlore `middlewareFS`) instead of
+      replacing it: `session_fs.go` serves agent-scoped reads from
+      `dbFS.WithAgent(id.User)` while routing all writes through `base` (→ log +
+      admission), confined to the supported `/config/*.yml` write surface
+      (scope-before-policy). The KB `write` command was fixed to use `ctx.FS()`
+      (not raw DBFS) and to treat `*vfs.PendingChangeError` as a pending success.
+
+### Phase E — verification
+
+E1. go-openlore unit tests: chain admit/gate, delete gate, CAS drift,
+    `RemoveOpts.Expected`, ordering, post-commit hook sync + failure semantics,
+    read hook debounce. — DONE (incl. `pkg/openlore/server_seams_test.go`:
+    `NewServerWithRootFS` live write log, late `RegisterPlugin`, late post-commit,
+    `CommitChangeSet` bypasses admission but still commits).
+E2. KB tests: approvals middleware (gated vs ungated path, fail-closed on DB
+    error), resolver idempotency + drift → stale, path→partition mapping. — DONE
+    (`approvals/approvals_test.go`, `approvals/http_test.go`).
+E3. **End-to-end gap closed (SSH):** `internal/openlore/approvals_e2e_test.go`
+    starts the real KB SSH server, and over a live SSH session a governance-gated
+    `write /config/agents.yml` defers (reports pending), appears in the held
+    store, and only commits after `Resolver.Approve` (the same resolver the HTTP
+    approve endpoint drives); an ungated `/config/openlore.yml` write commits
+    inline. **MCP still bypasses** the shared write log (KB's `/mcp` handler is a
+    separate custom stack); unifying it onto `buildSessionShell` is a larger,
+    separate effort, deliberately deferred.
+E4. `go test ./...` green in both repos; run the KB e2e suite
+    (`eval/run_eval.sh`), regenerating the base DB if gating changes stored data
+    (`FORCE_REGEN_DB=1`). — go-openlore green; KB `internal/openlore/...` green.
+    (Pre-existing unrelated failures remain in KB `internal/handlers` — nil
+    `gitrepo.Manager` test setup — not touched by this refactor. `eval/` suite
+    not run here.)
+
+---
+
+## 5. Key risks / invariants to hold
+
+- **Cycle:** `PendingChangeError` + `ChangeSet` + `CommitChangeSet` must live in
+  `pkg/vfs` (`cmds` imports `vfs`; `openlore` imports `cmds`).
+- **Scope before policy:** an out-of-scope write must be denied before any
+  plugin middleware sees it. Scope is fixed-first, non-bypassable.
+- **Immutable ChangeSet:** middleware inspect/decide only; never rewrite bytes/
+  snapshot. Guarantees the parked changeset and the eventual commit are
+  byte-identical (sound CAS).
+- **The applier's sole input is the log.** Both fresh admitted writes and
+  approved held changesets append to the **log**, never directly to the applier —
+  a second producer would reintroduce concurrency and break race-free CAS +
+  ordering. `CommitChangeSet` == append to the log; there is no separate commit
+  path.
+- **Approvals skip admission, not the log.** An approved held ChangeSet was
+  already admitted (it passed scope and reached the approval middleware), so it
+  appends **below** the admission chain. Re-running admission would let the
+  approval middleware re-defer it into an infinite loop.
+- **CAS at the applier is authoritative** (serialized, race-free). Resolvers
+  treat "already committed / stale" as terminal, not error.
+- **Fail-closed gating:** a DB error in the approval middleware must reject the
+  write, never silently commit.
+- **Applier liveness:** sync post-commit hooks run inside the serialized applier;
+  the mandatory timeout is what prevents a hung command from wedging all writes.
+```

--- a/docs/mcp-bearer-auth.md
+++ b/docs/mcp-bearer-auth.md
@@ -1,0 +1,567 @@
+# Bearer-token Auth & Identity for MCP + HTTP API
+
+**Status:** Design (decisions locked)
+**Scope:** How OpenLore authenticates callers of the **MCP-over-HTTP** endpoint
+and the **plain JSON HTTP API**, maps each caller to a **named identity**, and
+scopes every operation to that identity — via a **login flow** that mints
+short-lived bearer tokens. Designed to be **forward-compatible** with OIDC
+Workload Identity Federation (WIF); see
+[`teleport-oidc-ssh-integration.md`](./teleport-oidc-ssh-integration.md) for the
+SSH-transport analogue and Anthropic's
+[WIF docs](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation).
+
+---
+
+## 1. Goal & driving use case
+
+A **local Obsidian plugin** must talk to OpenLore's MCP server / HTTP API and act
+**as a specific user**:
+
+- A user **logs in** (passkey) and receives a **bearer token**.
+- The plugin presents `Authorization: Bearer <token>` to **both** `/mcp` and
+  `/api`.
+- Every tool call runs with that identity's **lore** (docset access),
+  **capabilities** (write/publish/approve), and **home** — exactly as an SSH
+  session does today.
+
+**Posture mirrors SSH.** If SSH allows public/anonymous access, so do `/mcp` and
+`/api`; if SSH requires a credential, so do they. There is **no separate enable
+switch** — posture derives from the existing `allow_keyless` /
+`unknown_identity` (§4). A public/anonymous MCP caller behaves like an anonymous
+SSH caller: it lands in the **`default` lore**, read-only, and **cannot see
+docsets outside that lore** because it runs against the same filtered filesystem
+(§6).
+
+**Forward-looking.** Any token we issue fits a WIF-style model where an external
+IdP JWT (GitHub Actions, Kubernetes, Okta, SPIFFE, …) is exchanged for an
+OpenLore token at the same token endpoint. We build the human path now; WIF is
+purely additive later (§8).
+
+---
+
+## 2. What exists today
+
+| Concern | State |
+|---|---|
+| MCP-over-HTTP (`/mcp`) | `mcp.NewStreamableHTTPHandler` in [`server.go`](../pkg/openlore/server.go); **unauthenticated** |
+| JSON HTTP API (`/shell`, `/commands`) | [`mcp_http_api.go`](../pkg/openlore/mcp_http_api.go); **unauthenticated**, single persistent in-memory session |
+| MCP shell tool | Runs against the full `s.fs` — **no per-identity scoping** |
+| Passkey login | [`/passkey/login/*`](../internal/passkeys/passkeys.go) runs WebAuthn and, on success, sets an HMAC **cookie** carrying a lore. A login that sets identity already exists for the browser. |
+| Passkey registration | Invite-based: `passkey register --name X --lore Y` prints a 5-min link ([command.go](../internal/passkeys/command.go), [pending.go](../internal/passkeys/pending.go)) |
+| Identity model | `resolveIdentity` ([server.go](../pkg/openlore/server.go)) maps an SSH key/cert → `Identity{LoreName, PathAccess, PublishDocsets, Capabilities, HomeDir}`; matched **only by `public_key`** ([config.go:177](../internal/config/config.go)) |
+| FS scoping | The SSH `shellHandler` runs the shell against `s.merge.FilteredView(loreDocsets)` — out-of-lore files are absent from the namespace |
+| Libraries | `github.com/golang-jwt/jwt/v5` in the module graph; go-sdk ships an `auth` package (`RequireBearerToken`, `TokenInfo`) |
+| knowledge-backend | Imports go-openlore as a library (`replace … => ../go-openlore`) and uses **SQLite** — so new auth storage must be interface-backed |
+
+Two facts drive the design:
+1. The go-sdk has a first-class bearer hook. `auth.RequireBearerToken(verifier)` stores `*auth.TokenInfo` on the request context, and the Streamable transport already reads `auth.TokenInfoFromContext(req.Context())`. Identity propagates to tool handlers for free — the bespoke `internal/mcpserver` `AuthResolver`/`WithAuthIdentity` scaffolding is **deleted** in favor of this.
+2. The MCP shell tool does **none** of the per-identity scoping the SSH shell does. "Operate as a user" is mostly *that* gap (§6), not the token.
+
+---
+
+## 3. Decisions (summary)
+
+| # | Decision |
+|---|---|
+| Q1 | **Reference tokens** — carry only `sub`/`iss`/`aud`/`exp` (+`scope`); authority resolved **live** per request |
+| Q2 | `sub` = identity `Name`; `public_key` becomes optional; **one identity table** |
+| Q3 | Build an OAuth **token endpoint** now (`authorization_code` via passkey); full OAuth trimmings later |
+| Q4 | **Rule-based** identity resolution from day one (exact-`sub` = a degenerate rule) |
+| Q5 | **Short access token + refresh token** (OAuth/WIF-native) |
+| Q6 | Passkey / SSH key / WIF subject are **authenticators**; authority lives in the identity table |
+| Q7 | **Flat-file refresh store + rotation** (reuse-detection), behind an interface |
+| Q8 | **ES256 + published JWKS** (asymmetric), behind an `Issuer` interface |
+| Q9 | **Coarse `Resolve(claims) → Identity`** `IdentityStore` interface |
+| Q10 | ES256 + `DataDir`-default key (interface-injectable) + `kid` rotation |
+| Q11 | **Invite-based** `passkey register --identity <name>` |
+| Q12 | **One audience per instance**; scopes = explicit **`full`** sentinel, fail-closed, narrow-only |
+
+---
+
+## 4. Posture is derived from SSH (`allow_keyless` / `unknown_identity`)
+
+`s.auth` is loaded once at startup ([server.go:98](../pkg/openlore/server.go)) but
+read **live per request** by the resolver. The middleware in front of `/mcp` and
+`/api` is chosen from the *existing* SSH posture — no new flag:
+
+| `lore.json` | SSH behavior | MCP/HTTP wrapper |
+|---|---|---|
+| no auth config | full access (local `openlore .`) | **no middleware** — open, full FS |
+| `allow_keyless: true` (default) | anyone connects; unknown → `default` lore | **optional-token**: verify a token if present (reject if invalid); if absent → anonymous `default` lore |
+| `allow_keyless: false`, `unknown_identity: allow` | any key accepted; unknown → `default` | **required-token**; valid token, unknown `sub` → `default` |
+| `allow_keyless: false`, `unknown_identity: deny` | only registered keys | **required-token**; valid token, unknown `sub` → **403** |
+
+Invariants in every posture:
+- A **present but invalid** token (bad signature / expired / wrong `aud`) is
+  **always rejected**, even in keyless mode.
+- A **missing** token is OK only where anonymous SSH is OK.
+- Whatever identity results — named or anonymous `default` — is then **scoped**
+  by §6. Anonymous ≠ unrestricted; it is `default`, read-only.
+
+Implemented as a small `optionalBearer(verifier)` wrapper alongside the SDK's
+`RequireBearerToken`, selected by `allow_keyless`.
+
+**OAuth is advertised even in keyless mode (so Claude always has a login path).**
+Optional-token means a *direct* tokenless request (curl, CI, SSH-style clients)
+is still served anonymously — we never force OAuth on those. But OAuth-native MCP
+clients (Claude Desktop, Cowork) decide whether to offer a login flow by
+**discovering protected-resource-metadata**; if we never advertise it, such a
+client just connects anonymously and the user has **no in-client way to log in**
+(they'd have to paste a token by hand). So the server **advertises** OAuth
+metadata in every posture where login is possible. A client that runs the flow
+lands on the authorize screen, which itself offers the **public-vs-login choice**
+(§8.4): "continue with public access" mints a token that resolves to the same
+anonymous `default` identity, so the OAuth flow **completes for everyone** —
+authenticated or not — instead of stranding users who only want public docs.
+
+---
+
+## 5. Token model
+
+### 5.1 Reference tokens (Q1), resolved live (Q4)
+
+Access tokens are standard JWTs carrying **only identity**, not authority:
+
+```json
+{
+  "iss": "https://openlore.example",
+  "sub": "alice",                 // identity Name (Q2)
+  "aud": "https://openlore.example",  // one audience per instance (Q12)
+  "exp": 1735693200,              // short-lived (Q5)
+  "iat": 1735689600,
+  "scope": "full"                 // sentinel; see §5.4
+}
+```
+
+On **every request**, the verifier resolves `token → claims → Identity` via the
+rule engine (§7). Nothing about permissions is frozen into the token, so
+**permission changes take effect on the next request with no re-auth** — editing
+a rule/identity is picked up live (subject to config reload; see §9). The only
+thing bounded by TTL is a *claim the matcher reads that changed upstream* — the
+WIF case, where an IdP attribute change waits for the next short-lived refresh.
+
+### 5.2 Access + refresh (Q5)
+
+- **Access token:** ES256 JWT, short TTL (default ~30 min), stateless, verified
+  on the hot path (signature + rule resolution, no store lookup).
+- **Refresh token:** opaque, **stateful** (§ interfaces), rotated on every use.
+  Presenting an already-used refresh token signals theft → revoke the whole
+  chain for that `sub`. Revocation = expiry + delete the refresh row (no
+  per-request denylist).
+
+### 5.3 Signing: ES256 + JWKS (Q8, Q10)
+
+- **ES256** (compact — matters for MCP header size; universally supported by OIDC
+  libs).
+- Private key generated on first boot into `DataDir` (mirrors host-key handling),
+  **behind the `Issuer` interface** so knowledge-backend can supply a
+  DB-stored, cross-instance keypair.
+- Public keys published at a **JWKS endpoint** (`/.well-known/jwks.json`),
+  `kid`-tagged; sign with newest, verify against any published; dual-publish
+  rotation so in-flight tokens stay valid. Because tokens are asymmetric, any
+  resource server (including knowledge-backend) can verify them without a shared
+  secret.
+
+### 5.4 Scopes: explicit `full` sentinel (Q12)
+
+Scopes exist to *narrow* a token below its identity's authority (WIF's per-rule
+`oauth_scope`), but are not enforced beyond the sentinel today:
+
+- **`scope: "full"`** = full identity authority. Every token today carries it.
+- **Missing / empty / unrecognized scope → deny** (fail-closed) — never full.
+- **Effective authority = `identity_authority ∩ scope_constraints`**, where
+  `full` = ⊤ (no constraint).
+- **`full` is reserved** (no future WIF scope may reuse it) and **exclusive**: if
+  any narrowing scope is present, `full` is ignored (narrowing wins).
+
+Forward-compat: WIF later issues tokens with *narrowing* scopes instead of
+`full`; the verifier's `full → ⊤, unknown → deny, else intersect` logic is stable
+and already in place. Old tokens (all ≤ access-token TTL, re-minted from refresh
+tokens under current logic) keep resolving to full authority. Additive, not
+breaking.
+
+---
+
+## 6. Scoping the MCP shell to the identity (the core work)
+
+**This is "behave the same way as SSH."** The SSH `shellHandler` builds a
+**per-identity filesystem** and runs the shell against it, so files outside the
+caller's lore are physically absent. The MCP shell tool skips all of it and runs
+against the full `s.fs` — the security gap.
+
+The SSH path builds this chain ([server.go](../pkg/openlore/server.go)):
+
+```
+sessionFS := s.merge                                    // full merged FS
+if id.LoreName != "": sessionFS = s.merge.FilteredView(loreDocsets)  // ← the gate
+sessionFS = newApprovalFS(sessionFS, …)                 // Part C approval gating
+sessionFS = newScopedWriteFS(sessionFS, writableRoots)  // Part B write isolation
+sessionFS = sessionFSFn(id, sessionFS)                  // optional decorator
+sessionFS = newReadTrackingFS(sessionFS)                // CAS
+shell := shell.NewShell(sessionFS)
+shell.SetAllowedActions(...)                            // read-only vs write
+shell.SetEnv("OPENLORE_IDENTITY"/"LORE"/"DOCSETS"/"CAPABILITIES"/"HOME"/"USER")
+```
+
+`FilteredView(loreDocsets)` is the enforcement: an anonymous caller resolves to
+`default` and gets a FilteredView of only the default docsets — it literally
+cannot `cat`, `grep`, or `ls` anything else.
+
+**Extract this whole chain into a shared `buildSessionShell(id Identity) *shell.Shell`**
+and call it from (1) the SSH `shellHandler`, (2) the MCP `shell` tool handler,
+(3) the JSON API. The MCP handler reads `auth.TokenInfoFromContext(ctx)` →
+`Identity` (named or anonymous `default`) → `buildSessionShell`. Result: **every**
+MCP/HTTP caller, including anonymous public ones, is read-only unless its identity
+has write capability and sees only its lore's docsets. Identical to SSH.
+
+### 6.1 Per-request in-memory session for the JSON API
+
+The Streamable transport propagates the request ctx (hence `TokenInfo`) to the
+tool handler automatically. The JSON API's current **persistent** in-memory
+session does not: a per-call ctx passed to `session.CallTool` does not cross the
+in-memory pipe (the handler ctx derives from the session's `Connect` ctx).
+
+**Decision: the JSON API creates a per-request in-memory session.** The
+middleware resolves identity, then `server.Connect(ctxWithTokenInfo, …)` is
+called **per request**, so the shared tool handler sees the identity via the same
+`auth.TokenInfoFromContext` path as the Streamable transport. Identity always
+enters via the connection ctx — never via client-supplied tool arguments (a
+direct MCP client could spoof those). The persistent-session field on
+`MCPHTTPAPI` is removed. `NewInMemoryTransports` is an in-process `net.Pipe`, so
+the per-request session is cheap.
+
+---
+
+## 7. Identity resolution (Q2, Q4, Q6, Q9)
+
+All credentials are **authenticators** that establish a `sub`; authority lives in
+**one identity table**:
+
+```diagram
+credentials (authenticate)             authority (one table, matched by rules)
+  ssh public_key ┐
+  passkey cred   ├──► sub / claims ──► IdentityStore.Resolve() ──► Identity
+  WIF sub/claims ┘                       { lore, capabilities, home, publish }
+```
+
+- **`sub` = identity `Name`;** `public_key` becomes optional (an identity may have
+  an SSH key, a passkey, both, or neither).
+- **Rule-based from day one:** resolution is a list of
+  `{ match: {sub|sub_prefix|claims}, lore, capabilities }` rules. The human case
+  is the degenerate exact-`sub` rule `{match: {sub: "alice"}}`; WIF adds
+  `sub_prefix`/`claims` rules with no new resolution path.
+- **`IdentityStore` is a coarse single method** (Q9):
+  `Resolve(claims map[string]any) (Identity, error)`. go-openlore's default
+  implementation reads `lore.json` (identities + their `match` rules) + the passkey store;
+  knowledge-backend supplies a SQLite-backed `Resolve`. Keeps the contract tiny
+  and lets the DB backend express matching in SQL.
+- Passkeys reference an identity by name (Q6): `StoredCredential.Name` = an
+  identity `Name`; login resolves that name → full authority. No authority lives
+  in the passkey store.
+
+---
+
+## 8. Login & token issuance (Q3, Q11)
+
+### 8.1 The token endpoint (the WIF seam)
+
+Build a standard OAuth **token endpoint** with **grant-type dispatch** and a
+shared `Issuer`:
+
+```diagram
+                    ╭─────────────── /oauth/token ───────────────╮
+  human (now) ──code──▶│ grant=authorization_code → passkey identity │──▶ access+refresh (ES256)
+  workload (WIF)──JWT──▶│ grant=jwt-bearer → claims→rule→identity     │──▶ access+refresh
+                    ╰──────────────┬──────────────────────────────╯
+                                   ▼  one Issuer, one IdentityStore.Resolve
+```
+
+- **Now:** the `authorization_code` grant, driven by the existing **passkey
+  login** ceremony. Defer heavyweight OAuth (dynamic client registration, full
+  metadata) until a real MCP client needs it.
+- **WIF (shipped):** the `jwt-bearer` grant (RFC 7523) on the *same* endpoint
+  verifies an external IdP JWT against that issuer's JWKS (pinned to a trusted
+  issuer + our audience), matches a rule → identity, narrows by the rule's
+  `scope`, and mints an OpenLore access token (access-only — no refresh, so no
+  long-lived credential). Same issuer, same identity model. See
+  workload-identity-federation.md.
+- Token lifetime follows the WIF formula when brokering:
+  `min(rule ttl, 2× remaining assertion lifetime)`, floor 60s.
+
+### 8.2 Human login UX (Obsidian)
+
+The deliverable is a standard OAuth **authorization-code + PKCE** flow returning
+the code through an **HTTP callback** (normal OAuth), not manual copy. A native
+client (the Obsidian plugin) opens `GET /authorize` (loopback `redirect_uri`),
+OpenLore runs the passkey ceremony, and on success the login-finish hook calls
+`Server.CompleteAuthorize` to mint a PKCE-bound code and redirect the browser
+back to the client's `redirect_uri?code=&state=`. The client captures the code on
+its loopback port and exchanges it (`code_verifier` + `redirect_uri`) at
+`/oauth/token` for access+refresh tokens.
+
+The passkey ceremony and the `/authorize` OAuth layer are separate concerns wired
+by the `TokenIssuer` seam, so Phase 3's protected-resource-metadata + dynamic
+client registration slot in front of the *same* `/authorize` → `/oauth/token`
+mint step — MCP clients (Claude Desktop, Cowork) then federate automatically via
+`WWW-Authenticate` → protected-resource-metadata → `/authorize` → `/oauth/token`
+with no change to the mint path.
+
+### 8.3 Provisioning (Q11)
+
+Invite-based, retargeted from `--lore` to `--identity`:
+`passkey register --identity alice` (identity must exist in the table) → 5-min
+link → user registers a passkey → thereafter login mints tokens for `alice`. For
+**local single-user Obsidian** the operator *is* the user:
+`passkey register --identity me`, click, done. No self-service — access is
+granted, not claimed; `default` (read-only) is already reachable anonymously.
+
+### 8.4 The authorize screen: public vs login (universal Claude flow)
+
+The OAuth authorize screen presents **two choices**, so the *same* flow serves
+both anonymous and authenticated users:
+
+```diagram
+   Claude runs OAuth ──▶ ╭──────────── /authorize ────────────╮
+                         │  How do you want to connect?         │
+                         │                                      │
+                         │  [ Continue with public access ]     │──▶ token: sub=anonymous,
+                         │  [ Log in with passkey ]             │       resolves to `default`
+                         ╰──────────────┬───────────────────────╯       (read-only)
+                                        │  passkey → identity
+                                        ▼
+                            token: sub=<identity> (full authority)
+```
+
+- **Continue with public access** → `/oauth/token` mints a normal access+refresh
+  token whose `sub` is the reserved **anonymous** subject. It resolves through the
+  identity resolver (§7) to exactly the same `anonymousIdentity()` a tokenless
+  caller gets: `default` lore, read-only, cannot see other docsets. It is **not**
+  more privileged than tokenless anonymous — it simply gives an OAuth-only client
+  a token to hold so its connect flow completes.
+- **Log in with passkey** → the existing WebAuthn ceremony (§8.2) resolves to a
+  named identity; `/oauth/token` mints a token with `sub=<identity>` and that
+  identity's full authority.
+
+**Why this matters:** an OAuth-native client (Claude) that discovers OAuth
+metadata will insist on completing the flow before connecting — it won't fall
+back to a bare anonymous connection. Without the public option, users who only
+want public docs would be **unable to connect through Claude at all**. The public
+button lets them satisfy the OAuth flow *as anonymous*, so **login works for
+everyone**: identity for those who want it, public access for those who don't,
+one screen, one flow. Non-OAuth clients (curl, CI) are unaffected — they still
+hit the endpoints tokenless and are served anonymously (§4).
+
+The reserved anonymous `sub` is a first-class (if unprivileged) identity in the
+token model — the verifier treats a public token like any other, then §7 maps it
+to `default`. Nothing downstream special-cases "public": it is just the anonymous
+identity wearing a token.
+
+---
+
+## 9. Storage interfaces (Q7, Q8, Q9)
+
+knowledge-backend backs these with SQLite; go-openlore ships flat-file defaults.
+Injected via server functional options, defaulting so standalone `openlore` needs
+no config.
+
+```diagram
+                     pkg/openlore (interface + default)     knowledge-backend
+  Issuer            ── mint/verify (ES256), JWKS ──────────  key in DataDir      │ key in DB (shared)
+  RefreshTokenStore ── save / lookup / rotate / revoke ────  flat file (DataDir) │ SQLite table
+  IdentityStore     ── Resolve(claims) → Identity ─────────  lore.json + passkey │ SQLite tables
+```
+
+- **`Issuer`** — signing seam. Default is an **ES256 keypair in `DataDir`**,
+  generated on first boot; knowledge-backend injects a DB-stored keypair (host-
+  key-derived keys are per-host and break multi-instance).
+- **`RefreshTokenStore`** — stateful, revocable; flat-file default, DB impl for
+  knowledge-backend.
+- **`IdentityStore`** — coarse `Resolve` (Q9); default reads lore.json
+  (identities + their `match` rules) + the passkey store, DB impl reads SQL.
+  This is what makes "permissions change live" work against either backend.
+
+**Config reload:** "live" is true within a process, but `s.auth` is a startup
+snapshot — on-disk edits to lore.json need a reload to apply without
+restart (`air` restarts in dev; add an auth reload for production parity; the DB
+already has `Reload()`).
+
+---
+
+## 10. Config schema (summary)
+
+Config splits by responsibility: **token issuance is server infrastructure**
+(`openlore.yml`), **access policy is per-lore** (`lore.json`). Posture (public vs
+token-required) derives from `lore.json`'s `allow_keyless`/`unknown_identity`
+(§4) — it is not a token setting.
+
+`openlore.yml` (server infra — sits alongside `passkeys`):
+
+```yaml
+tokens:
+  issuer: https://openlore.example      # `iss` + JWKS base
+  audience: https://openlore.example    # one audience per instance (Q12)
+  access_ttl: 30m
+  refresh_ttl: 720h
+  # ES256 key auto-generated in DataDir; Issuer interface overrides for DB.
+
+# ── reserved for WIF (Q8 / §8.1) ──────────────────────
+oidc_issuers:
+  - issuer_url: https://token.actions.githubusercontent.com
+    jwks: { mode: discovery }
+```
+
+`lore.json` (access policy). Identity resolution is **rule-based, but the rules
+live on the identity they select** (Q4) — every rule maps to exactly one
+identity, so a separate list with a back-pointer is redundant. The exact-`sub`
+human case needs no entry (a token whose `sub` == an identity `Name` resolves
+there implicitly). WIF adds `sub_prefix`/`aud`/`claims` match entries with
+narrowing `scope`/`ttl`:
+
+```json
+{
+  "identities": [
+    { "name": "alice", "lore": "eng" },
+    {
+      "name": "ci-indexer",
+      "lore": "ci",
+      "match": [
+        { "sub_prefix": "repo:org/repo:", "aud": "https://openlore.example",
+          "scope": "read", "ttl": "15m" }
+      ]
+    }
+  ]
+}
+```
+
+Cross-identity match precedence (when two identities' *patterns* both match) is
+exact-`sub`-beats-pattern, then most-specific; moot in Phase 1 (exact-`sub` only,
+which is unique).
+
+Code touch points:
+- `internal/config/config.go`: `AuthTokensConfig` + `OIDCIssuer` on `Config`
+  (openlore.yml); `IdentityMatch` on `AuthIdentity` (lore.json).
+- `pkg/openlore/`: `issuer.go` (ES256 + JWKS, `Issuer` iface), `refreshstore.go`
+  (`RefreshTokenStore` iface + flat-file impl), `identitystore.go`
+  (`IdentityStore` iface + lore.json/passkey/rule impl), `tokenendpoint.go`
+  (`/oauth/token` + JWKS handler), refactor `resolveIdentity` to funnel through
+  `IdentityStore.Resolve`, extract `buildSessionShell(id)`.
+- `pkg/openlore/server.go`: wrap `/mcp` + `/api` with posture-aware middleware
+  (§4); per-request in-memory session for the JSON API (§6.1); mount
+  `/oauth/token` + JWKS.
+- Consolidate the two MCP server constructors into one; delete
+  `internal/mcpserver` auth scaffolding.
+- `internal/passkeys`: login-success hook that mints via the token endpoint;
+  `register` retargeted to `--identity`.
+- `cmd/openlore/main.go`: `token` subcommand (debug mint/verify).
+
+---
+
+## 11. Implementation phases
+
+1. **Phase 0 — Consolidate + scope (prerequisite, highest value).** Merge the two
+   MCP server constructors; extract `buildSessionShell(id)`; run MCP + JSON API
+   through it; switch the JSON API to a per-request in-memory session (§6.1).
+   **No tokens yet**, but public MCP/HTTP access now behaves like anonymous SSH:
+   `default` lore, read-only, FilteredView FS. Tests: anonymous MCP caller reads
+   `default` docsets but **cannot** read a non-default docset; anonymous is
+   read-only.
+2. **Phase 1 — Issuer + IdentityStore + token endpoint. ✅ Implemented.** ES256
+   `Issuer` + JWKS ([`issuer.go`](../pkg/openlore/issuer.go)); flat-file
+   `RefreshTokenStore` with rotation + reuse-detection
+   ([`refreshstore.go`](../pkg/openlore/refreshstore.go)); coarse
+   `IdentityStore.Resolve` (exact-`sub` rules, direct `sub`→identity, reserved
+   `sub_prefix`/claims) ([`identitystore.go`](../pkg/openlore/identitystore.go));
+   `/oauth/token` with `authorization_code` + `refresh_token` grants and an
+   explicit `jwt-bearer` **501 stub** for the WIF seam
+   ([`tokenendpoint.go`](../pkg/openlore/tokenendpoint.go)); posture-aware
+   middleware on `/mcp` + `/api` ([`auth_middleware.go`](../pkg/openlore/auth_middleware.go));
+   `token mint`/`verify` CLI. `public_key` is optional; `sub`=Name; the reserved
+   `anonymous` sub resolves to `default`. Token auth activates only when
+   `tokens` is configured (openlore.yml) (otherwise Phase 0 anonymous). Tests cover: valid
+   token → identity + scope; expired/forged → 401 even keyless; unknown `sub` +
+   `unknown_identity: deny` → 403; refresh rotation + reuse revokes the chain.
+3. **Phase 2 — Passkey login → token + Obsidian. ✅ Implemented.** A standard
+   OAuth **authorization-code + PKCE** flow (RFC 7636) mints tokens via a passkey
+   login, returning the code to the client through an **HTTP callback** (normal
+   OAuth), not manual copy: `GET /authorize`
+   ([`authorize.go`](../pkg/openlore/authorize.go)) validates the request
+   (loopback/custom-scheme `redirect_uri` only, to block open redirects) and
+   redirects into the existing passkey ceremony; on success the login-finish hook
+   calls `Server.CompleteAuthorize`, which mints a PKCE-bound auth code and
+   redirects back to `redirect_uri?code=&state=`; `/oauth/token` verifies the
+   `code_verifier` + `redirect_uri` and mints access+refresh. `passkey register`
+   is retargeted from `--lore` to `--identity` (`StoredCredential.Identity` =
+   token `sub`); the passkey↔token seam is the `TokenIssuer` interface
+   ([`passkeys.go`](../internal/passkeys/passkeys.go)). Obsidian runbook +
+   bearer/OAuth docs in [`assets/lore/mcp.md`](../assets/lore/mcp.md). Tests
+   cover the full PKCE round trip, wrong/missing verifier, redirect mismatch, and
+   bad `/authorize` params.
+4. **Phase 3 — Full OAuth for MCP clients. ✅ Implemented.** OAuth discovery +
+   Dynamic Client Registration in front of the same `/authorize` → `/oauth/token`
+   mint step, so Claude Desktop/Cowork federate automatically:
+   - **RFC 9728 Protected Resource Metadata** at
+     `/.well-known/oauth-protected-resource` (`resource` == `tokens.audience`,
+     `authorization_servers` == [`tokens.issuer`]) and **RFC 8414 Authorization
+     Server Metadata** at `/.well-known/oauth-authorization-server`
+     ([`oauth_metadata.go`](../pkg/openlore/oauth_metadata.go)). Both are mounted
+     whenever `tokens` is configured — **even in keyless mode** — so OAuth-native
+     clients always discover the flow (§4). The metadata's absolute URLs derive
+     from `tokens.issuer` (must be pathless).
+   - **RFC 7591 Dynamic Client Registration** at `/register`, open, issuing only
+     **public PKCE clients** (`token_endpoint_auth_method=none`, no
+     `client_secret`) ([`registration.go`](../pkg/openlore/registration.go)),
+     persisted behind a **`ClientStore`** interface (flat-file default in
+     `DataDir/auth/clients.json`; DB impl for knowledge-backend)
+     ([`clientstore.go`](../pkg/openlore/clientstore.go)).
+   - **Redirect policy** now DCR-aware: a registered `client_id` must present a
+     redirect that **exactly matches** a registered one (this is what admits a
+     remote HTTPS callback like `https://claude.ai/...`); an absent/unregistered
+     `client_id` falls back to the native rules (loopback / custom scheme only),
+     never a remote origin ([`authorize.go`](../pkg/openlore/authorize.go)). Auth
+     codes are bound to `client_id` + the RFC 8707 `resource` and re-checked at
+     the token endpoint.
+   - **Public-vs-login authorize screen** (§8.4): `GET /authorize` renders a
+     choice page — "continue with public access" POSTs to `/authorize/public`
+     and mints an anonymous `default` (read-only) token so the flow completes for
+     every user; "log in with passkey" runs the Phase 2 ceremony and mints an
+     identity token. PKCE (`code_challenge`) is now **required** on `/authorize`.
+   - **`WWW-Authenticate`** on every 401 carries
+     `resource_metadata="…/.well-known/oauth-protected-resource"` so a challenged
+     client discovers the resource (RFC 9728 §5.1). Non-OAuth clients (curl, CI)
+     still connect tokenless/anonymous.
+
+   Keyless discovery caveat: a keyless server never 401s a tokenless request, so
+   OAuth-native clients must discover via proactive
+   `/.well-known/oauth-protected-resource` probing (the metadata is always
+   advertised). If a client only starts OAuth after a 401, run required-token
+   mode. WIF (`jwt-bearer`) is deliberately **not** advertised until Phase 4.
+5. **Phase 4 — WIF / OIDC.** `jwt-bearer` grant on `/oauth/token`; `OIDCVerifier`
+   (JWKS + claim/`sub_prefix` rules); narrowing `scope` enforcement
+   (`intersect`). Reuses Phases 0–2 unchanged. **Docs deliverable:** operator
+   setup guide in [`workload-identity-federation.md`](./workload-identity-federation.md)
+   (repo reference, cross-links this plan + the Teleport SSH doc) and the served
+   end-user guide `openlore.sh/docs/workload-identity-federation.md` (mirrored to
+   `assets/lore/`, reachable as `cat /workload-identity-federation.md`); both are
+   already written and marked "planned" pending this phase.
+
+Phases 0–2 ship the Obsidian use case. Phases 3–4 are additive and gated behind
+config already reserved here.
+
+---
+
+## 12. Open questions
+
+- **Service identities for WIF:** reuse the identity table, or add a distinct
+  "service account" concept (closer to WIF's `svac_`)?
+- **Instant revocation:** is refresh-token revocation + short access TTL enough,
+  or do writes eventually require a small access-token denylist for
+  *immediate* cutoff (sub-TTL)?
+- **Auth config reload:** add file-watch/`Reload()` for lore.json + openlore.yml now, or
+  rely on process restart until multi-instance/DB deployment?
+- **Unifying passkey cookie + bearer:** should the browser session cookie and the
+  MCP bearer be issued by the same endpoint for one identity?
+
+Resolved (see §3): posture (derived), JSON-API session model (per-request),
+token model (reference), resolution (rule-based), lifetime (short+refresh),
+signing (ES256/JWKS), storage (interfaces), provisioning (invite), scopes
+(`full` sentinel, fail-closed, narrow-only).

--- a/docs/teleport-oidc-ssh-integration.md
+++ b/docs/teleport-oidc-ssh-integration.md
@@ -1,0 +1,379 @@
+# Temporary SSH Logins via OIDC / Workload Identity Federation (Teleport)
+
+**Status:** Draft / design
+**Scope:** How OpenLore grants *short-lived, identity-federated* SSH access to
+humans and workloads (CI, agents) — using Teleport as the certificate issuer,
+plus a path for native OIDC-over-SSH without Teleport.
+
+---
+
+## 1. The problem
+
+OpenLore today authenticates SSH clients with **long-lived material**:
+
+- a raw SSH public key registered in `lore.json` (`identities[].public_key`), or
+- an SSH certificate signed by a CA we trust (`ca_keys_file` →
+  `wish.WithTrustedUserCAKeys`), whose `ValidPrincipals` map to a lore, or
+- keyless (accept-all) mode for fresh containers / CI.
+
+This is the SSH-key-distribution problem that OpenAI's
+[workload identity federation](https://developers.openai.com/api/docs/guides/workload-identity-federation)
+and Teleport both exist to kill. We want:
+
+- **No long-lived keys** handed to agents or CI runners.
+- **Short-lived logins** that expire in minutes/hours, revoked passively by
+  expiry.
+- **Identity from an IdP** (GitHub Actions OIDC, Okta/Keycloak/Entra,
+  Kubernetes/SPIFFE) mapped to a lore + capabilities.
+- Works **over SSH**, which is OpenLore's primary transport. (HTTP/MCP can do
+  `Authorization: Bearer <jwt>` trivially; SSH is the interesting case.)
+
+---
+
+## 2. How Teleport does temporary SSH logins (reference model)
+
+Teleport is the canonical implementation of "temporary SSH login from an IdP".
+The mechanism is **the SSH certificate**, not a custom protocol:
+
+```diagram
+                    ┌──────── humans ────────┐   ┌──── workloads/CI ────┐
+                    │ tsh login --proxy=...   │   │ tbot (Machine ID)    │
+                    │  → OIDC/SAML redirect   │   │  → platform join     │
+                    │  → IdP authenticates    │   │    (github/aws/k8s)  │
+                    └───────────┬─────────────┘   └──────────┬──────────┘
+                                ▼                             ▼
+                    ╭───────────────────────────────────────────────╮
+                    │           Teleport Auth Service (CA)            │
+                    │  claims_to_roles → role.allow.logins            │
+                    │  issues SHORT-LIVED SSH user cert:              │
+                    │    ValidPrincipals = allowed logins            │
+                    │    ValidBefore     = now + max_session_ttl     │
+                    │    Extensions      = teleport-roles, …         │
+                    ╰───────────────────────┬───────────────────────╯
+                                            ▼
+                    client presents cert ───────────────▶ SSH server
+                                            trusts Teleport user CA via
+                                            TrustedUserCAKeys; validates
+                                            signature + time window +
+                                            ValidPrincipals
+```
+
+Key properties (all confirmed from Teleport docs/source):
+
+1. **Auth Service = SSH user CA.** After SSO, it mints a short-lived OpenSSH
+   user certificate. TTL is governed by role `max_session_ttl`; shortest role
+   TTL wins. Teleport's whole model is "certs valid for hours-to-minutes,
+   prefer expiry over revocation lists."
+2. **IdP claims → roles → principals.** OIDC connector `claims_to_roles` maps an
+   IdP group claim to Teleport roles; a role's `allow.logins` become the SSH
+   cert's `ValidPrincipals`.
+3. **Plain OpenSSH servers just trust the CA.** Teleport's own OpenSSH guide
+   tells you to export the CA pubkey and add `TrustedUserCAKeys
+   /etc/ssh/teleport_openssh_ca.pub` to `sshd_config`. Nothing Teleport-specific
+   is required on the node for the basic case.
+4. **Teleport-specific data rides in cert extensions** (`teleport-roles`, custom
+   `cert_extensions`). A node *may* read these but OpenSSH semantics
+   (`ValidPrincipals`, validity window, critical options) are enough.
+5. **Workloads use Machine ID / `tbot`.** `tbot` authenticates to Teleport with
+   a **platform-bound join token** (`join_method: github`/`aws`/`kubernetes`/…)
+   — i.e. the same OIDC/platform-attestation idea as OpenAI WIF — and writes a
+   short-lived `key` + `key-cert.pub` to disk. CI then SSHes with that cert. No
+   long-lived secret in the runner.
+
+**The punchline for OpenLore:** we are the *relying SSH server*. Teleport is the
+issuer. OpenLore already does step 3 + 4 partially. The work is hardening,
+mapping, lifetime handling, and docs.
+
+---
+
+## 3. What OpenLore already supports
+
+| Teleport concept            | OpenLore today                                                                 |
+|-----------------------------|-------------------------------------------------------------------------------|
+| Trust the user CA           | `config.CAKeysFile` → `wish.WithTrustedUserCAKeys` (`server.go` `ListenAndServe`) |
+| Principal → access mapping  | `resolveIdentity` maps `cert.ValidPrincipals` to a `lore` name (`server.go` L344-353) |
+| Cert deny for unknown ident | `PublicKeyAuth` allows certs whose principal is a known lore (`server.go` L686-693) |
+| Host cert                   | `config.HostCertFile` (server presents a CA-signed host key)                   |
+
+So a **minimal Teleport integration already works operationally**: point
+`ca_keys_file` at Teleport's exported user CA, name Teleport role logins to match
+lore names, done. The rest of this doc is what we must *add* to make it correct,
+safe, and ergonomic.
+
+---
+
+## 4. Gaps & risks in the current implementation
+
+These must be fixed before advertising federated SSH access:
+
+1. **`WithTrustedUserCAKeys` overrides our own public-key handler (the real
+   blocker).** `ssh.PublicKeyAuth` is a *setter* (`srv.PublicKeyHandler = fn`),
+   and `wish.WithTrustedUserCAKeys` is implemented as a `PublicKeyAuth` setter.
+   In `ListenAndServe` the `CAKeysFile` option is appended **last**, so enabling
+   `ca_keys_file` silently replaces OpenLore's own handler — the
+   `identities[].public_key` matching and the deny-check in `PublicKeyAuth`
+   become dead code. Consequences:
+   - `allow_keyless: false` + `ca_keys_file`: a raw registered key (non-cert) is
+     rejected (`CertChecker` returns false for non-certs) — **raw-key identities
+     can't log in alongside certs.**
+   - `allow_keyless: true` + `ca_keys_file`: a raw key fails publickey, falls
+     back to the always-true keyboard-interactive handler, and is admitted with
+     **no key recorded → demoted to `default` lore.**
+   **Fix:** compose a single `PublicKeyHandler` ourselves — try CA-cert
+   verification via our own `gossh.CertChecker` first, then fall back to
+   raw-key/identity matching — instead of relying on `WithTrustedUserCAKeys` to
+   layer on top. This is a prerequisite for letting Teleport certs and raw keys
+   coexist.
+2. **Forged-principal isolation bypass in keyless-without-CA (minor).** When
+   `allow_keyless: true` **and no `ca_keys_file`**, the active handler accepts
+   any key, so `resolveIdentity` will trust `cert.ValidPrincipals` from a
+   self-signed cert to pick a lore. This is *not* an escalation when a CA is
+   configured (the CA checker rejects forged certs), and keyless already means
+   "anyone may connect" — but it does defeat per-lore isolation for anonymous
+   users. **Fix:** only honor cert principals when the cert was CA-verified;
+   ignore principals entirely in keyless mode.
+3. **No explicit TTL / validity enforcement visibility.** `wish` +
+   `TrustedUserCAKeys` validates `ValidAfter/ValidBefore` during the handshake,
+   but we never surface it, never enforce a *max acceptable* TTL, and never log
+   expiry. **Fix:** read `cert.ValidBefore`, reject certs whose remaining
+   lifetime exceeds a configurable `max_cert_ttl` (defense against
+   over-long-lived certs), and log expiry on connect.
+4. **No CA rotation story.** `ca_keys_file` is a single file read at startup.
+   Teleport rotates CAs. **Fix:** support multiple CA keys in the file (already
+   possible — multiple lines) and document the dual-publish rotation window;
+   optionally hot-reload the file.
+5. **No claim/role → capability mapping.** OpenLore has `capabilities` (approval
+   gating) on `identities`, but cert-authenticated users get none. **Fix:** map
+   cert principals (and optionally Teleport `teleport-roles` extension) to
+   capabilities.
+6. **No audit trail of *which IdP identity*.** We log principals but not the
+   upstream subject. **Fix:** surface cert `KeyId` (Teleport puts the username
+   there) and selected extensions into the connect log / metrics.
+
+---
+
+## 5. Design — Model A: Teleport as issuer (recommended)
+
+OpenLore stays a dumb, correct relying party. Teleport owns identity, RBAC, TTL.
+
+### 5.1 Trust anchor
+
+```yaml
+# openlore.yml
+auth:
+  ssh_ca:
+    # One or more trusted user-CA public keys (OpenSSH authorized_keys format).
+    # During CA rotation, list both old and new.
+    trusted_user_ca_keys: ./teleport_user_ca.pub
+    max_cert_ttl: 8h          # reject certs valid longer than this
+    require_ca_for_principals: true  # never trust ValidPrincipals from a
+                                     # non-CA-verified cert (closes gap #1)
+```
+
+Operator gets the CA key from Teleport:
+
+```bash
+curl 'https://<proxy>/webapi/auth/export?type=openssh' \
+  | sed 's/cert-authority //' > teleport_user_ca.pub
+```
+
+### 5.2 Principal → lore + capability mapping
+
+Reuse the existing `lore` map; add an explicit federated mapping so principals
+don't have to be named identically to lores and can grant capabilities:
+
+```yaml
+# lore.json (or openlore.yml auth section)
+federated_principals:
+  - principal: "docset:engineering"     # exact, or "agent:*" glob
+    lore: "engineering"
+    capabilities: []
+  - principal: "openlore-approver"
+    lore: "engineering"
+    capabilities: ["approve@oncall"]
+```
+
+Resolution order in `resolveIdentity`:
+1. raw public-key identity match (unchanged), else
+2. **CA-verified** cert → first matching `federated_principals` rule (glob), else
+3. **CA-verified** cert → `ValidPrincipals` that directly names a lore
+   (current behavior, kept for convenience), else
+4. `default` lore.
+
+Steps 2–3 require `ctx` to carry a "cert was CA-verified" flag.
+
+### 5.3 Optional: read Teleport extensions
+
+If present, log `cert.Extensions["teleport-roles"]` and `cert.KeyId` for audit.
+Do **not** require them — keep OpenSSH-native semantics so any CA (not just
+Teleport) works.
+
+### 5.4 Teleport-side config (operator runbook, goes in README/skill)
+
+```yaml
+# Teleport OIDC connector: IdP groups → Teleport roles
+kind: oidc
+spec:
+  claims_to_roles:
+    - {claim: groups, value: /eng,   roles: [openlore-eng]}
+    - {claim: groups, value: /oncall, roles: [openlore-approver]}
+---
+# Teleport role: grants the SSH principal OpenLore maps to a lore
+kind: role
+metadata: {name: openlore-eng}
+spec:
+  options: {max_session_ttl: 1h}
+  allow:
+    logins: ["docset:engineering"]   # becomes cert ValidPrincipals
+    node_labels: {'openlore': 'true'}
+```
+
+Human flow: `tsh login` → `tsh ssh docset:engineering@openlore-host` (or plain
+`ssh` using the cert tbot/tsh wrote).
+
+---
+
+## 6. Workloads & CI — the WIF part (Teleport Machine ID / `tbot`)
+
+This is the direct analogue of OpenAI WIF: a platform-attested join, not a
+stored secret.
+
+```diagram
+GitHub Actions job
+  │  OIDC token (repo-bound)         join_method: github
+  ▼
+tbot ──────────────▶ Teleport Auth ──────────▶ writes ./certs/key, key-cert.pub
+  │                  (verifies repo claim,        (short TTL, principal
+  │                   issues bot cert)             = docset:ci-indexer)
+  ▼
+ssh -i ./certs/key -o CertificateFile=./certs/key-cert.pub \
+    docset:ci-indexer@openlore-host "grep -r foo /openlore"
+        │
+        ▼  OpenLore validates cert vs Teleport CA → lore "ci-indexer"
+```
+
+Teleport bot/token (operator side):
+
+```yaml
+kind: token
+spec:
+  roles: [Bot]
+  join_method: github
+  bot_name: openlore-ci
+  github:
+    allow: [{repository: my-org/my-repo}]
+```
+
+OpenLore side: nothing new beyond Model A — the bot's cert principal flows
+through the same `federated_principals` mapping. CI holds **zero** long-lived
+SSH keys.
+
+---
+
+## 7. Model B: native OIDC-over-SSH (no Teleport dependency)
+
+For users who don't run Teleport, we still want IdP-federated SSH. SSH has no
+native "bearer token" auth, so there are three realistic options:
+
+### Option B1 — Built-in CA broker (recommended native path)
+OpenLore (or a tiny sidecar `openlore-ssh-broker`) exposes an HTTP endpoint that
+**exchanges an OIDC JWT for a short-lived SSH certificate**, mirroring OpenAI's
+token-exchange:
+
+```diagram
+agent ──POST /ssh/cert  Authorization: Bearer <oidc-jwt>──▶ broker
+                          verify iss/aud/sub vs JWKS,
+                          match claim rules → principal+TTL,
+                          sign ephemeral pubkey with OpenLore user CA
+agent ◀── { certificate, ttl } ───────────────────────────┘
+agent ──ssh with cert──▶ OpenLore (trusts its own user CA)  ✓
+```
+
+- Reuses Model A's relying-party code unchanged (OpenLore just trusts a CA —
+  here, its own).
+- Broker is the only new component: JWKS fetch+cache (refresh on `kid` miss),
+  `iss`/`aud`/`sub`-glob matching à la OpenAI service-account mappings, CEL-free
+  exact/glob claim rules, sign with an in-process SSH CA key.
+- Library: `github.com/coreos/go-oidc/v3` for discovery/verify; `x/crypto/ssh`
+  for cert signing.
+
+### Option B2 — JWT via keyboard-interactive
+Carry the JWT in an SSH `keyboard-interactive` response and verify it in the
+auth callback. Works without certs, but: clunky UX, token size limits, no
+standard client support, and we'd reinvent session lifetime. **Not recommended**
+except as a fallback for clients that can't use certs.
+
+### Option B3 — JWT in the SSH username
+e.g. `ssh jwt:<base64url-token>@host`. Hacky, length-limited, leaks token into
+logs. **Rejected.**
+
+**Recommendation:** B1. It keeps SSH-cert semantics identical to Teleport, so
+Model A and Model B share one verification codepath; only the *issuer* differs.
+
+---
+
+## 8. Config schema changes (summary)
+
+```yaml
+auth:
+  ssh_ca:
+    trusted_user_ca_keys: <path>     # multi-key file; rotation = dual list
+    max_cert_ttl: <duration>         # reject over-long certs
+    require_ca_for_principals: true  # security fix for gap #1
+  federated_principals:              # principal-glob → lore + capabilities
+    - {principal: <glob>, lore: <name>, capabilities: [<cap>...]}
+  oidc_broker:                       # Model B only
+    enabled: false
+    issuers:
+      - url: https://token.actions.githubusercontent.com
+        audience: https://openlore/<id>
+        claim_rules:
+          - {match: {sub: "repo:my-org/my-repo:*"}, principal: "docset:ci", ttl: 15m}
+    signing_ca_key: <path>           # the user CA OpenLore also trusts
+```
+
+Code touch points:
+- `internal/config/config.go`: new `SSHCAConfig`, `FederatedPrincipal`,
+  `OIDCBrokerConfig` types + YAML/Option wiring.
+- `pkg/openlore/server.go`: record CA-verification on `ssh.Context`; gate
+  principal mapping (`resolveIdentity`) on it; enforce `max_cert_ttl`; map
+  principals → capabilities; log `KeyId`/extensions.
+- `pkg/openlore/identity.go`: add `Capabilities` from federated mapping (field
+  already exists).
+- (Model B) new `internal/sshbroker/` package + HTTP handler mounted on the
+  existing HTTP server.
+
+---
+
+## 9. Implementation phases
+
+1. **Phase 0 — Auth handler rework (must-ship, prerequisite).** Close gap #1:
+   replace the `WithTrustedUserCAKeys` reliance with a single composed
+   `PublicKeyHandler` that does CA-cert verification *and* raw-key/identity
+   matching, so certs and raw keys coexist. Close gap #2: only honor cert
+   principals when CA-verified; ignore principals in keyless mode. Add
+   `max_cert_ttl` enforcement (gap #3). Tests: raw key + CA cert both work;
+   forged cert rejected; principal honored only when CA-verified.
+2. **Phase 1 — Teleport relying-party hardening (Model A).** `federated_principals`
+   mapping (globs + capabilities), CA multi-key + rotation docs, audit logging
+   of `KeyId`/`teleport-roles`. Operator runbook + a `teach`-style skill.
+3. **Phase 2 — Workload/CI guide.** Document `tbot` + GitHub/AWS/K8s join;
+   example workflow connecting to OpenLore with an ephemeral cert.
+4. **Phase 3 — Native broker (Model B1).** OIDC→SSH-cert exchange endpoint;
+   JWKS verify + claim rules; reuse Phase 1 verification path.
+
+Phases 0–2 are mostly config + small server changes (the primitive exists).
+Phase 3 is the only net-new subsystem.
+
+---
+
+## 10. Open questions
+
+- Should the broker (B1) live **in** OpenLore (one binary, simplest) or as a
+  separate signer so the CA private key isn't in the doc-server process?
+  (Security argues for separate; ergonomics argue for in-process behind a flag.)
+- Do we need active revocation (Teleport-style locks) or is expiry enough? For
+  read-only docs, expiry is likely sufficient; revisit when writes are enabled.
+- Capability mapping source of truth: cert principals only, or also Teleport
+  `teleport-roles` extension (couples us to Teleport)?
+- Per-principal TTL ceilings vs one global `max_cert_ttl`.

--- a/docs/workload-identity-federation.md
+++ b/docs/workload-identity-federation.md
@@ -1,0 +1,169 @@
+# Setting up Workload Identity Federation (WIF)
+
+**Status:** Shipped (Phase 4). The `jwt-bearer` grant verifies external IdP
+assertions against each configured issuer's JWKS and exchanges them for OpenLore
+tokens. Bearer tokens minted without WIF carry the `full` scope and continue to
+verify unchanged — WIF is additive, never a breaking change.
+
+**Audience:** operators configuring an OpenLore instance to accept federated
+workloads on the HTTP/MCP transports.
+
+**See also:**
+- [`mcp-bearer-auth.md`](./mcp-bearer-auth.md) — the full auth design; WIF is
+  §8.1 (token endpoint / `jwt-bearer` grant), §10 (config schema), and Phase 4
+  of §11.
+- [`teleport-oidc-ssh-integration.md`](./teleport-oidc-ssh-integration.md) — the
+  **SSH-transport** analogue (short-lived SSH certificates via Teleport / native
+  OIDC-over-SSH). WIF here covers HTTP/MCP; that doc covers SSH.
+- Anthropic's [Workload Identity Federation docs](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation).
+- The served, end-user version of this guide:
+  [`../openlore.sh/docs/workload-identity-federation.md`](../openlore.sh/docs/workload-identity-federation.md)
+  (embedded and reachable as `cat /workload-identity-federation.md` on a running
+  server).
+
+---
+
+## What WIF gives you
+
+Workloads (CI runners, agents, pods) authenticate to `/mcp` and `/api` **without
+a long-lived secret**. A workload presents a short-lived JWT its platform already
+issues (GitHub Actions OIDC, Kubernetes/SPIFFE, Okta/Entra/Keycloak); OpenLore
+verifies it against the IdP's JWKS, matches its claims to a rule, and exchanges
+it for a short-lived OpenLore bearer token bound to a named identity.
+
+```
+ platform JWT ──POST /oauth/token (grant=jwt-bearer, assertion=<jwt>)──▶ OpenLore token
+      │                                                                       │
+      │  verify vs IdP JWKS → match claims to rule → rule→identity+scope      │
+      ▼                                                                       ▼
+  no OpenLore secret stored on the workload                     Authorization: Bearer …
+                                                                 → /mcp and /api, scoped
+                                                                   to the identity's lore
+```
+
+The exchanged token flows through the **same** `Issuer` and
+`IdentityStore.Resolve` as human passkey logins, and resolves to the **same**
+`Identity` (lore, capabilities, home) used by SSH sessions — so a federated
+caller is scoped by `FilteredView` exactly like an SSH session.
+
+## Prerequisites
+
+- The identities the rules resolve to already exist in `lore.json`
+  (`identities[]` with a `lore`, optional `publish`/`capabilities`/`home`). WIF
+  maps *external claims* onto these existing identities; it does not create them.
+- The HTTP server is enabled (`http_port`), since `/oauth/token`, `/mcp`, and
+  `/api` are mounted there.
+- Posture derives from `allow_keyless` / `unknown_identity` — there is no
+  separate WIF enable switch. If SSH is public, anonymous MCP/HTTP still works
+  (read-only `default` lore); WIF simply lets a workload upgrade to a named
+  identity.
+
+## Configuration
+
+```yaml
+# openlore.yml
+auth:
+  tokens:
+    issuer: https://openlore.example      # `iss` on issued tokens + JWKS base
+    audience: https://openlore.example    # one audience per instance
+    access_ttl: 30m
+    refresh_ttl: 720h
+    # ES256 signing key auto-generated in DataDir; the Issuer interface lets a
+    # DB-backed deployment (knowledge-backend) inject a shared key instead.
+
+  # Identity resolution rules. Exact-`sub` rules serve human/passkey/SSH
+  # identities; WIF rules add claim/prefix matches, a narrowing scope, and a ttl.
+  rules:
+    - match: { sub: "alice" }             # human identity (lore from the table)
+
+    - match:                              # WIF rule
+        sub_prefix: "repo:my-org/my-repo:"
+        aud: "https://openlore.example"
+      identity: ci-indexer                # must exist in lore.json identities[]
+      scope: "read"                       # narrows below the identity's authority
+      ttl: 15m                            # caps this rule's OpenLore token TTL
+
+  # External IdPs whose JWTs may be exchanged.
+  oidc_issuers:
+    - issuer_url: https://token.actions.githubusercontent.com
+      jwks: { mode: discovery }           # discover keys from the issuer
+```
+
+### Rule matching
+
+| Key | Meaning |
+|---|---|
+| `sub` | Exact subject match. |
+| `sub_prefix` | Prefix match on `sub` (e.g. pin a repo without pinning every branch). |
+| `aud` | Required audience; pin it to this instance to stop cross-service token reuse. |
+| `claims` | Require specific claim values (`environment`, `ref`, `iss`, …) to gate privilege. |
+
+All fields in a rule must match (AND). **Exact `sub` matches take precedence**
+over `sub_prefix`/`aud`/`claims` pattern matches, so a specific subject can
+override a broad rule. A single `lore.json` identity can back several rules at
+different privilege levels (e.g. read-only for PR builds, publish for `main`).
+
+**Verification already binds issuer + audience.** Before any rule is consulted,
+the assertion is verified against a *specific* trusted issuer's JWKS (so its
+`iss` is authentic) and its `aud` must equal this instance's `audience` (so a
+token minted for another service can't be replayed here). If you trust **more
+than one** `oidc_issuer` and their `sub` namespaces could overlap, pin the
+issuer explicitly with `claims: { iss: "https://…" }` so a token from issuer B
+can't satisfy a rule you wrote for issuer A.
+
+### Scopes (narrow-only, fail-closed)
+
+Effective authority = `identity_authority ∩ scope`.
+
+- `full` — full identity authority (what SSH keys / passkey logins resolve to).
+  Reserved and exclusive; if any narrowing scope is present, `full` is ignored.
+- A narrowing scope (e.g. `read`) constrains the identity's authority.
+- Missing / empty / unrecognized scope → **denied** (never full).
+
+Forward-compat: today every non-WIF token carries `full`; WIF introduces
+narrowing scopes without changing how existing `full` tokens resolve.
+
+### Token lifetime when brokering
+
+An exchanged token's lifetime is
+`min(rule ttl, 2 × remaining assertion lifetime, access_ttl)`, floored at 60s — a
+federated token never long-outlives the assertion that produced it. The
+`jwt-bearer` exchange issues an **access token only** (no refresh token): a
+workload re-presents a fresh platform assertion each time, so no long-lived
+credential is ever created. `refresh_ttl` applies only to human
+(`authorization_code`) logins.
+
+## Platform quick reference
+
+- **GitHub Actions** — job needs `permissions: id-token: write`; request the
+  OIDC token with `&audience=<your audience>`, then exchange it. `sub` looks like
+  `repo:org/repo:ref:refs/heads/main` (use `sub_prefix: "repo:org/repo:"`).
+- **Kubernetes / SPIFFE** — project a service-account token with `audience:
+  <your audience>` (or use a SPIRE-issued SVID); match on
+  `system:serviceaccount:<ns>:<name>` or the SPIFFE ID; point `issuer_url` /
+  `jwks` at the cluster or SPIRE bundle.
+- **Okta / Entra / Keycloak** — register the issuer under `oidc_issuers`; match
+  on `sub` / group / app claims.
+
+Full runnable exchange snippets for each platform are in the served guide:
+[`../openlore.sh/docs/workload-identity-federation.md`](../openlore.sh/docs/workload-identity-federation.md).
+
+## Verifying the setup
+
+1. From the workload, obtain the platform JWT and exchange it:
+   ```bash
+   curl -sS -X POST https://openlore.example/oauth/token \
+     -d grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer \
+     -d "assertion=$PLATFORM_JWT"
+   # → {"access_token":"…","token_type":"Bearer","expires_in":900,…}
+   ```
+2. Call `/api` with the token and confirm the identity:
+   ```bash
+   curl -sS -X POST https://openlore.example/api/shell \
+     -H "Authorization: Bearer $OL_TOKEN" \
+     -H 'Content-Type: application/json' \
+     -d '{"command":"whoami"}'
+   # → resolves to the rule's identity + lore, not "anonymous (lore: default)"
+   ```
+3. Confirm scoping: a `read`-scoped token can `cat` its docsets but a write
+   (`publish`, `>`) is rejected read-only; docsets outside its lore are absent.

--- a/docs/write-system.md
+++ b/docs/write-system.md
@@ -183,6 +183,7 @@ Because all verbs go through here, the policy resolution, CAS base capture, and
 read-only/precondition error reporting exist in exactly one place. Commands that
 write: [`write`/`tee`/redirects](../pkg/shell/cmds/write.go),
 [`patch`](../pkg/shell/cmds/patch.go), [`sed -i`](../pkg/shell/cmds/sed.go),
+[`mkdir`](../pkg/shell/cmds/mkdir.go), [`rm`](../pkg/shell/cmds/rm.go),
 [`publish`](../pkg/shell/cmds/publish.go), and
 [`spawn`](../pkg/shell/cmds/spawn.go)'s background write-back.
 
@@ -201,10 +202,10 @@ travels:
   scopedWriteFS   ── is the target inside THIS identity's docset roots?  ──no──▶ ErrReadOnly
         │ yes
         ▼
-  approvalFS      ── does the target match a requires_approval rule?     ──yes─▶ record pending request,
+  approvalFS      ── does the target match a requires_approval rule?     ──yes─▶ record changeset (write or delete),
         │ no                                                                     return PendingApprovalError
         ▼
-  DirFS substrate ── precondition check + atomic temp-write + rename(2) ──▶ post_write event
+  DirFS substrate ── precondition check + atomic temp-write/rename-aside ──▶ post_write / post_delete event
 ```
 
 - **`scopedWriteFS`** ([`scoped_write_fs.go`](../pkg/openlore/scoped_write_fs.go))
@@ -215,12 +216,15 @@ travels:
   still prevented from writing each other's private docsets. It also implements
   `vfs.WriteScopeFS.CanWrite` for fail-fast checks (used by `spawn`).
 - **`approvalFS`** ([`approval_fs.go`](../pkg/openlore/approval_fs.go)) sits
-  *inside* the scope gate, so an out-of-scope write is denied before it could
-  ever become an approval request. For a gated path it honors the caller's
-  original precondition first (a stale write fails immediately — no doomed
-  request is parked), captures the proposal-time base, records a **pending
-  request**, fires `approval_pending`, and returns `vfs.PendingApprovalError`
-  (which callers report informationally, not as a failure).
+  *inside* the scope gate, so an out-of-scope mutation is denied before it could
+  ever become a changeset. For a gated **write** it honors the caller's original
+  precondition first (a stale write fails immediately — no doomed request is
+  parked), captures the proposal-time base, and records a write changeset. For a
+  gated **delete** (`rm` / `rm -r`) it captures an exact subtree snapshot and
+  records a delete changeset (the union of every gated descendant's capability).
+  `mkdir` is never gated and applies straight through. In every gated case it
+  fires `approval_pending` and returns `vfs.PendingApprovalError` (which callers
+  report informationally, not as a failure).
 
 ---
 
@@ -232,7 +236,7 @@ Commands are classified by `Action` in
 | Action | Verbs | Granted to |
 |--------|-------|------------|
 | `read` | `ls`, `cat`, `grep`, … (default) | everyone |
-| `write` | `write`, `patch`, `tee`, `>`/`>>`, `sed -i` | recognized identities |
+| `write` | `write`, `patch`, `tee`, `>`/`>>`, `sed -i`, `mkdir`, `rm` | recognized identities |
 | `publish` | `publish` | recognized identities |
 | `approve` | `approve`, `reject` | identities holding any approval capability |
 | `spawn` | `spawn` | identities holding the explicit `spawn` capability |
@@ -246,21 +250,40 @@ unrecognized identities get the read-only set. `sed` is special-cased: only
 
 ---
 
-## 7. Human-in-the-loop approvals (`/requests`)
+## 7. Human-in-the-loop approvals: changesets (`/requests`)
 
 A docset can declare `requires_approval` rules (path glob → required
-capability). When a write hits a gated path, `approvalFS` records an
-`ApprovalRequest` in a `RequestStore` (it stores the proposer, target, base hash,
-proposed bytes, and required capability) instead of committing.
+capability). When a gated file operation hits a matching path, `approvalFS`
+records a **changeset** — an `ApprovalRequest` in a `RequestStore` — instead of
+committing. The changeset is the single approval primitive for every gated
+mutation; its `Action` discriminates the payload:
+
+- **Write changesets** (`write`, `patch`, `tee`, `>`/`>>`, `sed -i`) carry a
+  `WriteApprovalPayload`: the base hash + proposed bytes, stored alongside the
+  metadata for the diff and for CAS replay at approval time. The caller's own
+  precondition is honored first, so a stale write fails immediately rather than
+  parking a doomed request.
+- **Delete changesets** (`rm`, `rm -r`) carry a `DeleteApprovalPayload`: an
+  **exact subtree snapshot** captured at proposal time. The snapshot is both the
+  reviewable manifest and the compare-and-swap base. Delete changesets are
+  manifest-only — no bytes are copied aside — so the target files stay **live**
+  for review until the delete is approved. A recursive delete whose subtree spans
+  several gated rules requires the **union** of their capabilities, and the
+  approver must hold *all* of them.
+
+`mkdir` / `mkdir -p` are never gated: directory creation carries no content to
+review, so it applies directly (still scope- and read-only-checked).
 
 - **`/requests`** is a read-only computed FS (`NewRequestsFS`, mounted via
-  `MountSystem`). `ls /requests` lists pending requests; `cat /requests/<id>`
-  shows the request metadata and a diff of the proposed change.
+  `MountSystem`). `ls /requests` lists pending changesets; `cat /requests/<id>`
+  shows the metadata and either the proposed diff (write) or the delete manifest.
 - **`approve <id>` / `reject <id>`** ([`approve.go`](../pkg/shell/cmds/approve.go))
   are gated by `ActionApprove`. The approval backend re-checks that the approver
-  holds the rule's required capability, then commits the stored bytes through the
-  raw substrate via CAS against the captured base (so a change since the proposal
-  is detected), or discards the request on reject.
+  holds every required capability, then replays the change through the raw
+  substrate against the captured base — a write via CAS on the base hash, a
+  delete via `RemoveAll` with the exact snapshot as the expected precondition
+  (strict staleness: any drift anywhere in the subtree marks the changeset
+  `STALE` and deletes nothing). Reject discards the changeset.
 
 ---
 
@@ -268,7 +291,8 @@ proposed bytes, and required capability) instead of committing.
 
 [`pkg/openlore/eventbus`](../pkg/openlore/eventbus/bus.go) is an in-process bus.
 Event kinds: `on_startup`, `pre_read` (debounced per path), `post_write`,
-`approval_pending`, `topic_refreshed`.
+`post_delete` (after a committed `rm` / `rm -r`), `approval_pending`,
+`topic_refreshed`.
 
 [`pkg/openlore/hooks`](../pkg/openlore/hooks/hooks.go) subscribes external
 commands to these events (configured under `hooks:` in `openlore.yml`). A hook is
@@ -317,9 +341,9 @@ In `openlore.yml` (global) and per docset in `lore.json`:
 |---------|-------|---------|
 | `readonly` | global / per-docset | Global is a hard physical lock (default `true`). A per-docset `readonly: false` cannot loosen a global lock; a per-docset `readonly: true` excludes that docset from writes. |
 | `write_conflict_policy` | global / per-docset | `hash` (CAS, default) or `last_write_wins`. Per-docset overrides global. |
-| `requires_approval` | per-docset | List of `{ path, capability }` rules that gate matching writes behind `approve`. |
+| `requires_approval` | per-docset | List of `{ path, capability }` rules that gate matching writes and deletes behind `approve` (as changesets). |
 | `max_jobs` | global | Max concurrent async `spawn` jobs (default `8`). |
-| `hooks` | global | External commands subscribed to `on_startup`/`pre_read`/`post_write`/`approval_pending`. |
+| `hooks` | global | External commands subscribed to `on_startup`/`pre_read`/`post_write`/`post_delete`/`approval_pending`. |
 
 The substrate is read-only unless `readonly: false` is set globally (or
 `--readonly=false` on the CLI). To enable per-agent writes, give each identity

--- a/internal/config/auth_home_test.go
+++ b/internal/config/auth_home_test.go
@@ -22,9 +22,8 @@ func TestLoadAuthConfigHomeValid(t *testing.T) {
 			"public": {"paths": ["/docs/public"]},
 			"agent-home": {"paths": [{"published/agent": "/home/agent"}]}
 		},
-		"lore": {"agent": ["public", "agent-home"]},
 		"identities": [
-			{"name": "a1", "public_key": "ssh-ed25519 AAAA", "lore": "agent", "home": "agent-home"}
+			{"name": "a1", "public_key": "ssh-ed25519 AAAA", "docsets": {"public": "ro", "agent-home": "rw"}, "home": "agent-home"}
 		]
 	}`)
 
@@ -37,19 +36,46 @@ func TestLoadAuthConfigHomeValid(t *testing.T) {
 	}
 }
 
-func TestLoadAuthConfigHomeNotInLore(t *testing.T) {
+func TestLoadAuthConfigHomeNotInGrants(t *testing.T) {
 	p := writeAuth(t, `{
 		"docsets": {
 			"public": {"paths": ["/docs/public"]},
 			"other": {"paths": ["/docs/other"]}
 		},
-		"lore": {"agent": ["public"]},
 		"identities": [
-			{"name": "a1", "public_key": "ssh-ed25519 AAAA", "lore": "agent", "home": "other"}
+			{"name": "a1", "public_key": "ssh-ed25519 AAAA", "docsets": {"public": "ro"}, "home": "other"}
 		]
 	}`)
 
 	if _, err := LoadAuthConfig(p); err == nil {
-		t.Fatal("expected error for home docset not in lore, got nil")
+		t.Fatal("expected error for home docset not in grants, got nil")
+	}
+}
+
+func TestLoadAuthConfigUnknownDocset(t *testing.T) {
+	p := writeAuth(t, `{
+		"docsets": {"public": {"paths": ["/docs/public"]}},
+		"identities": [
+			{"name": "a1", "docsets": {"missing": "ro"}}
+		]
+	}`)
+
+	if _, err := LoadAuthConfig(p); err == nil {
+		t.Fatal("expected error for grant on unknown docset, got nil")
+	}
+}
+
+func TestLoadAuthConfigDefault(t *testing.T) {
+	p := writeAuth(t, `{
+		"docsets": {"public": {"paths": ["/docs/public"]}},
+		"default": {"public": "ro"}
+	}`)
+
+	auth, err := LoadAuthConfig(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth.Default["public"] != "ro" {
+		t.Errorf("default grant: got %q, want %q", auth.Default["public"], "ro")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,8 +149,10 @@ type AuthConfig struct {
 	UnknownIdentity string                `json:"unknown_identity,omitempty"`
 	DefaultCwd      string                `json:"default_cwd,omitempty"`
 	Docsets         map[string]DocsetSpec `json:"docsets"`
-	Lore            map[string][]string   `json:"lore"`
-	Identities      []AuthIdentity        `json:"identities"`
+	// Default is the docset→grant map applied to keyless / unrecognized callers
+	// (the former `lore.default`). Empty = no access for anonymous sessions.
+	Default    map[string]string `json:"default,omitempty"`
+	Identities []AuthIdentity    `json:"identities"`
 }
 
 // AuthTokensConfig controls the bearer-token issuer for the MCP + HTTP API.
@@ -178,9 +180,13 @@ type JWKSSpec struct {
 
 // DocsetSpec defines a named set of path mappings.
 type DocsetSpec struct {
-	Paths          []PathMapping `json:"paths"`
-	PublishDir     string        `json:"publish_dir,omitempty"`
-	MaxPublishSize int64         `json:"max_publish_size,omitempty"` // bytes; 0 = use default (2.5MB)
+	Paths []PathMapping `json:"paths"`
+	// Inbox names a subfolder (VFS path, relative to a docset root or absolute)
+	// that the `publish` grant confines create/edit to. Empty = the docset has
+	// no inbox, so a `publish` grant on it can write nothing.
+	Inbox string `json:"inbox,omitempty"`
+	// MaxWriteSize caps a single write's bytes for this docset; 0 = default (2.5MB).
+	MaxWriteSize int64 `json:"max_write_size,omitempty"`
 
 	// Readonly is the per-docset policy check (enforced in the write pipeline,
 	// not on the substrate). nil means "inherit" (writable when the global lock
@@ -227,16 +233,20 @@ func (p *PathMapping) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// AuthIdentity defines a user identity with access to a lore spec.
+// AuthIdentity defines a user identity and its per-docset grants.
 type AuthIdentity struct {
-	Name      string   `json:"name"`
-	Comment   string   `json:"comment,omitempty"`
-	PublicKey string   `json:"public_key"`
-	Lore      string   `json:"lore"`
-	Publish   []string `json:"publish,omitempty"` // writable docsets; empty = all in lore
+	Name    string `json:"name"`
+	Comment string `json:"comment,omitempty"`
+	// PublicKey is optional: an identity may exist purely as a passkey/token
+	// login target (no SSH key). Empty = no SSH public-key auth for this identity.
+	PublicKey string `json:"public_key,omitempty"`
+	// Docsets maps a docset name to the grant this identity holds on it
+	// (e.g. "ro", "rw", "publish"). Grant names must be registered grant types
+	// at server startup, else the server refuses to boot (fail-closed).
+	Docsets map[string]string `json:"docsets"`
 	// Home names the docset that serves as this identity's home directory. Its
 	// display path becomes $HOME and the session's initial working directory.
-	// Must be one of the docsets in the identity's lore. Empty = no home.
+	// Must be one of the docsets in the identity's grants. Empty = no home.
 	Home string `json:"home,omitempty"`
 	// Capabilities are the extra capabilities this identity holds, e.g.
 	// "spawn" to authorize the async external-work command.
@@ -872,29 +882,31 @@ func LoadAuthConfig(path string) (*AuthConfig, error) {
 		return nil, err
 	}
 
-	for _, ident := range auth.Identities {
-		docsetNames, ok := auth.Lore[ident.Lore]
-		if !ok {
-			return nil, fmt.Errorf("identity %q references unknown lore %q", ident.Name, ident.Lore)
+	// Every docset referenced by an identity's grants or by the anonymous
+	// default must exist; home must be one of the identity's granted docsets.
+	// Grant *names* are validated against the registered grant types at server
+	// startup (fail-closed), not here — config parsing does not know the plugin
+	// set.
+	for name, grant := range auth.Default {
+		if grant == "" {
+			return nil, fmt.Errorf("default grant for docset %q is empty", name)
 		}
-		if ident.Home != "" {
-			inLore := false
-			for _, ds := range docsetNames {
-				if ds == ident.Home {
-					inLore = true
-					break
-				}
-			}
-			if !inLore {
-				return nil, fmt.Errorf("identity %q home docset %q is not in its lore %q", ident.Name, ident.Home, ident.Lore)
-			}
+		if _, ok := auth.Docsets[name]; !ok {
+			return nil, fmt.Errorf("default references unknown docset %q", name)
 		}
 	}
-
-	for loreName, docsetNames := range auth.Lore {
-		for _, ds := range docsetNames {
-			if _, ok := auth.Docsets[ds]; !ok {
-				return nil, fmt.Errorf("lore %q references unknown docset %q", loreName, ds)
+	for _, ident := range auth.Identities {
+		for name, grant := range ident.Docsets {
+			if grant == "" {
+				return nil, fmt.Errorf("identity %q grant for docset %q is empty", ident.Name, name)
+			}
+			if _, ok := auth.Docsets[name]; !ok {
+				return nil, fmt.Errorf("identity %q references unknown docset %q", ident.Name, name)
+			}
+		}
+		if ident.Home != "" {
+			if _, ok := ident.Docsets[ident.Home]; !ok {
+				return nil, fmt.Errorf("identity %q home docset %q is not in its grants", ident.Name, ident.Home)
 			}
 		}
 	}

--- a/internal/passkeys/browser.go
+++ b/internal/passkeys/browser.go
@@ -31,7 +31,7 @@ func (p *Passkeys) LoreBrowserHandler(fsys vfs.FileSystem) http.Handler {
 			return
 		}
 
-		allowed := p.allowedPrefixes(session.Lore)
+		allowed := p.allowedPrefixes(session.Identity)
 
 		// Map the request path under lorePath onto a filesystem path.
 		rel := strings.TrimPrefix(r.URL.Path, lorePath)
@@ -71,18 +71,25 @@ func (p *Passkeys) LoreBrowserHandler(fsys vfs.FileSystem) http.Handler {
 	})
 }
 
-// allowedPrefixes returns the display path prefixes a lore spec may browse.
-func (p *Passkeys) allowedPrefixes(lore string) []string {
+// allowedPrefixes returns the display path prefixes an identity may browse,
+// resolved from the docsets it holds any grant on.
+func (p *Passkeys) allowedPrefixes(identity string) []string {
 	if p.auth == nil {
 		return []string{"/"}
 	}
-	docsetNames, ok := p.auth.Lore[lore]
-	if !ok {
+	var grants map[string]string
+	for _, ident := range p.auth.Identities {
+		if ident.Name == identity {
+			grants = ident.Docsets
+			break
+		}
+	}
+	if grants == nil {
 		return nil
 	}
 	var prefixes []string
-	for _, ds := range docsetNames {
-		spec, ok := p.auth.Docsets[ds]
+	for name := range grants {
+		spec, ok := p.auth.Docsets[name]
 		if !ok {
 			continue
 		}

--- a/internal/passkeys/passkeys.go
+++ b/internal/passkeys/passkeys.go
@@ -28,9 +28,6 @@ type TokenIssuer interface {
 	// table. Registration references an identity by name (Q6/§8.3), so this
 	// validates the target at register time.
 	IdentityExists(name string) bool
-	// LoreForIdentity returns the lore spec name granted to an identity, used to
-	// set the browser session cookie for the /lore browser.
-	LoreForIdentity(name string) (lore string, ok bool)
 	// IssueAuthCode mints a single-use OAuth authorization code for sub, to be
 	// exchanged at /oauth/token. ok is false when token auth is disabled, in
 	// which case login still sets the browser cookie but issues no bearer token.
@@ -333,15 +330,9 @@ func (p *Passkeys) handleLoginFinish(w http.ResponseWriter, r *http.Request) {
 	_ = p.store.UpdateSignCount(cred.ID, cred.Authenticator.SignCount)
 
 	// Set the browser session cookie for the /lore docs browser. The cookie
-	// carries the lore spec the identity is granted, resolved live from the
+	// carries the identity name; the browser resolves its grants live from the
 	// identity table.
-	lore := ""
-	if p.tokens != nil {
-		if l, ok := p.tokens.LoreForIdentity(matched.Identity); ok {
-			lore = l
-		}
-	}
-	p.sessions.SetCookie(w, lore)
+	p.sessions.SetCookie(w, matched.Identity)
 
 	// OAuth authorization-code flow: if this login was reached via /authorize
 	// (?authz=<id>), finalize it and hand the browser a redirect back to the

--- a/internal/passkeys/session.go
+++ b/internal/passkeys/session.go
@@ -28,14 +28,14 @@ func NewSessionManager(key []byte, ttl time.Duration) *SessionManager {
 
 // SessionInfo holds the decoded session values.
 type SessionInfo struct {
-	Lore      string
+	Identity  string
 	ExpiresAt time.Time
 }
 
 // SetCookie creates and sets a signed session cookie on the response.
-func (sm *SessionManager) SetCookie(w http.ResponseWriter, lore string) {
+func (sm *SessionManager) SetCookie(w http.ResponseWriter, identity string) {
 	expiry := time.Now().Add(sm.ttl)
-	payload := fmt.Sprintf("%s:%d", lore, expiry.Unix())
+	payload := fmt.Sprintf("%s:%d", identity, expiry.Unix())
 	sig := sm.sign(payload)
 	value := base64.RawURLEncoding.EncodeToString([]byte(payload)) + "." + base64.RawURLEncoding.EncodeToString(sig)
 
@@ -80,7 +80,7 @@ func (sm *SessionManager) ValidateRequest(r *http.Request) (*SessionInfo, bool) 
 		return nil, false
 	}
 
-	lore := payload[:sepIdx]
+	identity := payload[:sepIdx]
 	expiryUnix, err := strconv.ParseInt(payload[sepIdx+1:], 10, 64)
 	if err != nil {
 		return nil, false
@@ -91,7 +91,7 @@ func (sm *SessionManager) ValidateRequest(r *http.Request) (*SessionInfo, bool) 
 		return nil, false
 	}
 
-	return &SessionInfo{Lore: lore, ExpiresAt: expiry}, true
+	return &SessionInfo{Identity: identity, ExpiresAt: expiry}, true
 }
 
 // ClearCookie removes the session cookie.

--- a/lore.json.example
+++ b/lore.json.example
@@ -5,6 +5,8 @@
 
   "//tokens": "Bearer-token auth for the MCP + HTTP API is SERVER config: set the `tokens:` block in openlore.yml, not here. lore.json is access policy (who can see what); token issuance is infrastructure.",
 
+  "//grants": "An identity holds a named GRANT on each docset it can access. Core grants: `ro` (read the whole docset) and `rw` (read + write anywhere in the docset). The inbox plugin adds `publish` (read the whole docset, no deletes, create/edit only within the docset's `inbox` folder). A grant name with no registered handler makes the server refuse to start.",
+
   "docsets": {
     "public": {
       "paths": [
@@ -26,14 +28,14 @@
         {"internal/db-schema": "/docs/database"},
         "/docs/shared"
       ],
-      "publish_dir": "./published/backend",
-      "max_publish_size": 5000000
+      "inbox": "inbox",
+      "max_write_size": 5000000
     },
     "backend-home": {
       "paths": [
         {"published/backend-home": "/home/backend"}
       ],
-      "publish_dir": "./published/backend-home"
+      "inbox": "inbox"
     },
     "ops": {
       "paths": [
@@ -43,38 +45,60 @@
       ]
     }
   },
-  "lore": {
-    "default": ["public"],
-    "frontend": ["public", "frontend"],
-    "backend": ["public", "backend", "backend-home"],
-    "ops": ["public", "ops"],
-    "full-access": ["public", "frontend", "backend", "ops"]
+
+  "//default": "The docset→grant map applied to keyless / unrecognized callers. Omit for no anonymous access.",
+  "default": {
+    "public": "ro"
   },
+
   "identities": [
     {
       "name": "frontend-agent",
       "comment": "Claude agent for frontend team",
       "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleFrontendKeyHere frontend-agent",
-      "lore": "frontend"
+      "docsets": {
+        "public": "ro",
+        "frontend": "rw"
+      }
     },
     {
       "name": "backend-agent",
       "comment": "GPT agent for backend services",
       "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleBackendKeyHere backend-agent",
-      "lore": "backend",
+      "docsets": {
+        "public": "ro",
+        "backend": "rw",
+        "backend-home": "rw"
+      },
       "home": "backend-home"
+    },
+    {
+      "name": "contributor",
+      "comment": "Outside collaborator: can read backend docs and drop files into its inbox, but cannot edit the rest or delete anything",
+      "docsets": {
+        "public": "ro",
+        "backend": "publish"
+      }
     },
     {
       "name": "ops-agent",
       "comment": "Infrastructure and deployment docs",
       "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleOpsKeyHere ops-agent",
-      "lore": "ops"
+      "docsets": {
+        "public": "ro",
+        "ops": "rw"
+      }
     },
     {
       "name": "read-all",
       "comment": "Full read access to all documentation",
       "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleReadAllKeyHere admin",
-      "lore": "full-access",
+      "docsets": {
+        "public": "ro",
+        "frontend": "ro",
+        "backend": "ro",
+        "ops": "ro"
+      },
       "//match": "Optional: extra token-claim predicates that resolve TO this identity. A token whose `sub` == the identity Name resolves here automatically; add `match` only to map additional subjects (aliases) or WIF assertions via `sub_prefix`/`aud`/`claims`. `scope` narrows (e.g. \"read\") and `ttl` caps matched WIF tokens. Exact `sub` beats pattern matches.",
       "match": [
         { "sub": "alice" },

--- a/openlore.sh/openlore.yml
+++ b/openlore.sh/openlore.yml
@@ -9,6 +9,12 @@ default_cwd: /
 auth_file: ./lore.json
 data_dir: ./data
 
+# Global write lock. The substrate boots read-only by default; set false to
+# enable the experimental writable substrate so authenticated identities can
+# create/overwrite files within their writable docsets (per-identity/per-docset
+# scoping still applies on top of this).
+readonly: false
+
 # How whole-file overwrites (>, tee, sed -i, publish) defend against concurrent
 # writers. "hash" (the default) makes them compare-and-swap: a write that would
 # clobber a change made since the file was read is rejected. "last_write_wins"
@@ -69,3 +75,5 @@ folders:
     path: ./published/zeb
   - name: adil
     path: ./published/adil
+  - name: alfie
+    path: ./published/alfie

--- a/pkg/openlore/auth_middleware_test.go
+++ b/pkg/openlore/auth_middleware_test.go
@@ -3,6 +3,7 @@ package openlore
 import (
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -25,6 +26,7 @@ func newTokenTestServer(t *testing.T, allowKeyless bool, unknownIdentity string)
 	s := &Server{
 		merge:        merge,
 		authEnforced: true,
+		grants:       newGrantRegistry(),
 		auth: &config.AuthConfig{
 			AllowKeyless:    &keyless,
 			UnknownIdentity: unknownIdentity,
@@ -32,12 +34,9 @@ func newTokenTestServer(t *testing.T, allowKeyless bool, unknownIdentity string)
 				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}},
 				"secret": {Paths: []config.PathMapping{{Source: "/secret", Display: "/secret"}}},
 			},
-			Lore: map[string][]string{
-				"default": {"public"},
-				"eng":     {"public", "secret"},
-			},
+			Default: map[string]string{"public": "ro"},
 			Identities: []config.AuthIdentity{
-				{Name: "alice", Lore: "eng"},
+				{Name: "alice", Docsets: map[string]string{"public": "ro", "secret": "rw"}},
 			},
 		},
 		config: config.Config{
@@ -65,8 +64,22 @@ func (s *Server) identityEcho() http.Handler {
 		if name == "" {
 			name = "anonymous"
 		}
-		w.Write([]byte(name + " " + id.LoreName))
+		w.Write([]byte(name + " " + grantsString(id.Grants)))
 	})
+}
+
+// grantsString renders a grant map as a stable "docset:grant,…" string.
+func grantsString(grants map[string]string) string {
+	keys := make([]string, 0, len(grants))
+	for k := range grants {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+":"+grants[k])
+	}
+	return strings.Join(parts, ",")
 }
 
 func mint(t *testing.T, s *Server, sub, scope string) string {
@@ -88,8 +101,8 @@ func TestAuthMiddleware_KeylessNoTokenIsAnonymous(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if got := rec.Body.String(); got != "anonymous default" {
-		t.Fatalf("body = %q, want %q", got, "anonymous default")
+	if got := rec.Body.String(); got != "anonymous public:ro" {
+		t.Fatalf("body = %q, want %q", got, "anonymous public:ro")
 	}
 }
 
@@ -105,8 +118,8 @@ func TestAuthMiddleware_ValidTokenResolvesIdentity(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	if got := rec.Body.String(); got != "alice eng" {
-		t.Fatalf("body = %q, want %q", got, "alice eng")
+	if got := rec.Body.String(); got != "alice public:ro,secret:rw" {
+		t.Fatalf("body = %q, want %q", got, "alice public:ro,secret:rw")
 	}
 }
 
@@ -168,7 +181,7 @@ func TestAuthMiddleware_AnonymousTokenResolvesToDefault(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
-	if got := rec.Body.String(); got != "anonymous default" {
-		t.Fatalf("public token body = %q, want %q", got, "anonymous default")
+	if got := rec.Body.String(); got != "anonymous public:ro" {
+		t.Fatalf("public token body = %q, want %q", got, "anonymous public:ro")
 	}
 }

--- a/pkg/openlore/authorize.go
+++ b/pkg/openlore/authorize.go
@@ -254,13 +254,3 @@ func (s *Server) IdentityExists(name string) bool {
 	_, ok := s.findAuthIdentity(name)
 	return ok
 }
-
-// LoreForIdentity returns the lore spec name granted to an identity, for the
-// browser session cookie. It backs passkeys.TokenIssuer.
-func (s *Server) LoreForIdentity(name string) (string, bool) {
-	ident, ok := s.findAuthIdentity(name)
-	if !ok {
-		return "", false
-	}
-	return ident.Lore, true
-}

--- a/pkg/openlore/authorize_test.go
+++ b/pkg/openlore/authorize_test.go
@@ -122,8 +122,8 @@ func TestAuthorize_PublicChoiceMintsAnonymousToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClaims: %v", err)
 	}
-	if id.IdentityName != "" || id.LoreName != "default" {
-		t.Errorf("public token resolved to %q/%q, want anonymous/default", id.IdentityName, id.LoreName)
+	if id.IdentityName != "" || id.Grants["public"] != "ro" {
+		t.Errorf("public token resolved to %q/%v, want anonymous with default grants", id.IdentityName, id.Grants)
 	}
 }
 
@@ -338,20 +338,17 @@ func TestMatchResolvesToIdentity(t *testing.T) {
 	if id.IdentityName != "alice" {
 		t.Fatalf("IdentityName = %q, want alice (via Match alias)", id.IdentityName)
 	}
-	if id.LoreName != "eng" {
-		t.Errorf("LoreName = %q, want eng", id.LoreName)
+	if id.Grants["secret"] != "rw" {
+		t.Errorf("Grants = %v, want secret:rw", id.Grants)
 	}
 }
 
-func TestIdentityExistsAndLoreForIdentity(t *testing.T) {
+func TestIdentityExists(t *testing.T) {
 	s := newTokenTestServer(t, true, "allow")
 	if !s.IdentityExists("alice") {
 		t.Error("IdentityExists(alice) = false, want true")
 	}
 	if s.IdentityExists("nobody") {
 		t.Error("IdentityExists(nobody) = true, want false")
-	}
-	if lore, ok := s.LoreForIdentity("alice"); !ok || lore != "eng" {
-		t.Errorf("LoreForIdentity(alice) = (%q, %v), want (eng, true)", lore, ok)
 	}
 }

--- a/pkg/openlore/authz.go
+++ b/pkg/openlore/authz.go
@@ -1,0 +1,224 @@
+package openlore
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+// validateGrants verifies that every grant name referenced by the auth config
+// (the anonymous default and each identity's docset grants) is a registered
+// grant type. It runs at startup, after plugins have registered their grant
+// types, so a config referencing an unregistered grant (e.g. `publish` without
+// the inbox plugin) fails closed rather than silently denying all access.
+func (s *Server) validateGrants() error {
+	if !s.authEnforced {
+		return nil
+	}
+	check := func(where, grant string) error {
+		if _, ok := s.grants.get(grant); !ok {
+			return fmt.Errorf("auth config: %s references unregistered grant %q (no plugin provides it)", where, grant)
+		}
+		return nil
+	}
+	for docset, grant := range s.auth.Default {
+		if err := check(fmt.Sprintf("default grant for docset %q", docset), grant); err != nil {
+			return err
+		}
+	}
+	for _, ident := range s.auth.Identities {
+		for docset, grant := range ident.Docsets {
+			if err := check(fmt.Sprintf("identity %q grant for docset %q", ident.Name, docset), grant); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// displayPath returns a path mapping's cleaned display (virtual) path, falling
+// back to its source when no display override is set.
+func displayPath(pm config.PathMapping) string {
+	d := pm.Display
+	if d == "" {
+		d = pm.Source
+	}
+	return vfs.CleanPath(d)
+}
+
+// grantForPath resolves the most-specific docset the identity holds a grant on
+// that contains display path p, returning the docset spec and its grant type. A
+// path may sit inside several granted docsets (nesting); the longest matching
+// display root wins so a nested docset overrides its parent.
+func (s *Server) grantForPath(id Identity, p string) (config.DocsetSpec, GrantType, bool) {
+	clean := vfs.CleanPath(p)
+	bestLen := -1
+	var bestDS config.DocsetSpec
+	var bestGrant GrantType
+	for name, grantName := range id.Grants {
+		ds, ok := s.auth.Docsets[name]
+		if !ok {
+			continue
+		}
+		grant, ok := s.grants.get(grantName)
+		if !ok {
+			continue
+		}
+		for _, pm := range ds.Paths {
+			root := displayPath(pm)
+			if pathWithinRoot(root, clean) && len(root) > bestLen {
+				bestLen = len(root)
+				bestDS = ds
+				bestGrant = grant
+			}
+		}
+	}
+	if bestLen < 0 {
+		return config.DocsetSpec{}, nil, false
+	}
+	return bestDS, bestGrant, true
+}
+
+// identityCanWrite is the per-operation write authorizer. A mutation to display
+// path p is permitted only when the global lock is open, the token scope grants
+// write, the identity holds a grant on the docset containing p, that docset is
+// not per-docset readonly, and the grant permits the action on that path.
+func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string) bool {
+	if s.config.Readonly {
+		return false // global write lock closed
+	}
+	if !scopeGrantsWrite(id.Scopes) {
+		return false // token scope ceiling: only full authority may write
+	}
+	ds, grant, ok := s.grantForPath(id, p)
+	if !ok {
+		return false
+	}
+	if ds.Readonly != nil && *ds.Readonly {
+		return false // per-docset lock can only further restrict
+	}
+	return grant.CanWrite(ds, action, p)
+}
+
+// readableRoots returns the display roots the identity may read: the display
+// paths of every docset it holds a readable grant on, plus every system mount
+// (control-plane mounts like /jobs and /requests are always visible). Used to
+// build the session's read-scoping filesystem.
+func (s *Server) readableRoots(id Identity) []string {
+	var roots []string
+	for name, grantName := range id.Grants {
+		ds, ok := s.auth.Docsets[name]
+		if !ok {
+			continue
+		}
+		grant, ok := s.grants.get(grantName)
+		if !ok {
+			continue
+		}
+		for _, pm := range ds.Paths {
+			root := displayPath(pm)
+			if grant.CanRead(ds, root) {
+				roots = append(roots, root)
+			}
+		}
+	}
+	roots = append(roots, s.merge.SystemMountPaths()...)
+	return roots
+}
+
+// scopedReadFS confines a session's reads (Stat / ReadDir / ReadFile) to a fixed
+// set of display roots, plus the ancestor directories that lead down to them so
+// the tree stays navigable. A ReadDir at an ancestor lists only entries that are
+// themselves readable (a granted root, or an ancestor of one), so an identity
+// only ever sees the docsets it was granted — never the sibling docsets sharing
+// the same backing root filesystem.
+type scopedReadFS struct {
+	vfs.FileSystem
+	roots []string // cleaned readable display roots
+}
+
+func newScopedReadFS(base vfs.FileSystem, roots []string) *scopedReadFS {
+	cleaned := make([]string, 0, len(roots))
+	for _, r := range roots {
+		cleaned = append(cleaned, vfs.CleanPath(r))
+	}
+	return &scopedReadFS{FileSystem: base, roots: cleaned}
+}
+
+// within reports whether p sits at or under one of the readable roots.
+func (s *scopedReadFS) within(p string) bool {
+	clean := vfs.CleanPath(p)
+	for _, root := range s.roots {
+		if pathWithinRoot(root, clean) {
+			return true
+		}
+	}
+	return false
+}
+
+// ancestor reports whether p is a proper ancestor directory of some readable
+// root (so it may be listed/stat'd to navigate down toward that root).
+func (s *scopedReadFS) ancestor(p string) bool {
+	clean := vfs.CleanPath(p)
+	if clean == "/" {
+		return true
+	}
+	for _, root := range s.roots {
+		if strings.HasPrefix(root, clean+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// readable reports whether p may be stat'd or listed: it is within a root or is
+// an ancestor of one.
+func (s *scopedReadFS) readable(p string) bool {
+	return s.within(p) || s.ancestor(p)
+}
+
+func (s *scopedReadFS) Stat(p string) (*vfs.FileInfo, error) {
+	if !s.readable(p) {
+		return nil, fs.ErrNotExist
+	}
+	return s.FileSystem.Stat(p)
+}
+
+func (s *scopedReadFS) ReadFile(p string) ([]byte, error) {
+	if !s.within(p) {
+		return nil, fs.ErrNotExist
+	}
+	return s.FileSystem.ReadFile(p)
+}
+
+func (s *scopedReadFS) ReadDir(p string) ([]vfs.FileInfo, error) {
+	if !s.readable(p) {
+		return nil, fs.ErrNotExist
+	}
+	entries, err := s.FileSystem.ReadDir(p)
+	if err != nil {
+		return nil, err
+	}
+	clean := vfs.CleanPath(p)
+	// Fully inside a readable root: every entry is readable.
+	if s.within(clean) {
+		return entries, nil
+	}
+	// At an ancestor: keep only children that are themselves readable.
+	out := entries[:0]
+	for _, e := range entries {
+		child := clean
+		if child == "/" {
+			child = "/" + e.FileName
+		} else {
+			child = clean + "/" + e.FileName
+		}
+		if s.readable(child) {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}

--- a/pkg/openlore/authz_test.go
+++ b/pkg/openlore/authz_test.go
@@ -1,0 +1,169 @@
+package openlore
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+// grantTestServer builds an auth-enforced, writable server with two path-based
+// docsets sharing one root filesystem (alfie, miles), each with an /inbox, plus
+// the inbox plugin registered so the `publish` grant resolves.
+func grantTestServer() *Server {
+	s := &Server{
+		merge:        NewMergeFS(),
+		authEnforced: true,
+		grants:       newGrantRegistry(),
+		config:       config.Config{Readonly: false},
+		auth: &config.AuthConfig{
+			Docsets: map[string]config.DocsetSpec{
+				"alfie": {Paths: []config.PathMapping{{Source: "/alfie", Display: "/alfie"}}, Inbox: "inbox"},
+				"miles": {Paths: []config.PathMapping{{Source: "/miles", Display: "/miles"}}, Inbox: "inbox"},
+			},
+		},
+	}
+	s.registerPlugin(NewInboxPlugin())
+	return s
+}
+
+func TestIdentityCanWrite_RW(t *testing.T) {
+	s := grantTestServer()
+	id := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeFull}}
+
+	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/notes.md") {
+		t.Fatal("rw should write anywhere in its docset")
+	}
+	if !s.identityCanWrite(id, vfs.ChangeActionRemove, "/alfie/notes.md") {
+		t.Fatal("rw should delete in its docset")
+	}
+	// No grant on miles → denied.
+	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/miles/notes.md") {
+		t.Fatal("no grant on miles → write must be denied")
+	}
+}
+
+func TestIdentityCanWrite_RO(t *testing.T) {
+	s := grantTestServer()
+	id := Identity{IdentityName: "bob", Grants: map[string]string{"alfie": "ro"}, Scopes: []string{ScopeFull}}
+	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/notes.md") {
+		t.Fatal("ro must never write")
+	}
+}
+
+func TestIdentityCanWrite_Publish(t *testing.T) {
+	s := grantTestServer()
+	// miles holds publish on alfie: create/edit only within /alfie/inbox, no deletes.
+	id := Identity{IdentityName: "miles", Grants: map[string]string{"alfie": "publish"}, Scopes: []string{ScopeFull}}
+
+	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/inbox/from-miles.md") {
+		t.Fatal("publish should write inside the inbox")
+	}
+	if !s.identityCanWrite(id, vfs.ChangeActionMkdir, "/alfie/inbox/sub") {
+		t.Fatal("publish should mkdir inside the inbox")
+	}
+	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/notes.md") {
+		t.Fatal("publish must NOT write outside the inbox")
+	}
+	if s.identityCanWrite(id, vfs.ChangeActionRemove, "/alfie/inbox/from-miles.md") {
+		t.Fatal("publish must NOT delete even inside the inbox")
+	}
+	if s.identityCanWrite(id, vfs.ChangeActionRemoveAll, "/alfie/inbox") {
+		t.Fatal("publish must NOT remove_all")
+	}
+}
+
+func TestIdentityCanWrite_ScopeAndLockCeilings(t *testing.T) {
+	s := grantTestServer()
+	id := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeRead}}
+	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/notes.md") {
+		t.Fatal("a read-scoped token must not write even with an rw grant")
+	}
+
+	full := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeFull}}
+	s.config.Readonly = true
+	if s.identityCanWrite(full, vfs.ChangeActionWrite, "/alfie/notes.md") {
+		t.Fatal("the global write lock must block all writes")
+	}
+}
+
+func TestValidateGrants(t *testing.T) {
+	// publish referenced but inbox plugin NOT registered → fail-closed.
+	s := &Server{
+		authEnforced: true,
+		grants:       newGrantRegistry(), // only ro/rw
+		auth: &config.AuthConfig{
+			Docsets:    map[string]config.DocsetSpec{"alfie": {}},
+			Identities: []config.AuthIdentity{{Name: "miles", Docsets: map[string]string{"alfie": "publish"}}},
+		},
+	}
+	if err := s.validateGrants(); err == nil {
+		t.Fatal("expected validateGrants to reject unregistered 'publish' grant")
+	}
+
+	// Register the inbox plugin → publish becomes valid.
+	s.registerPlugin(NewInboxPlugin())
+	if err := s.validateGrants(); err != nil {
+		t.Fatalf("publish should validate once the inbox plugin is registered: %v", err)
+	}
+}
+
+// TestSessionPublishTargets_ResolvesInboxPath pins that a publish target
+// carries the docset's resolved inbox path (not just its name), so `publish`
+// routes into /docset/inbox/... where the publish grant actually permits writes.
+func TestSessionPublishTargets_ResolvesInboxPath(t *testing.T) {
+	s := grantTestServer()
+	id := Identity{
+		IdentityName: "miles",
+		Grants:       map[string]string{"alfie": "publish"},
+		Scopes:       []string{ScopeFull},
+	}
+	targets := s.sessionPublishTargets(id)
+	if len(targets) != 1 {
+		t.Fatalf("want 1 publish target, got %d: %+v", len(targets), targets)
+	}
+	if targets[0].Name != "alfie" {
+		t.Fatalf("target name = %q, want alfie", targets[0].Name)
+	}
+	if targets[0].InboxPath != "/alfie/inbox" {
+		t.Fatalf("target inbox path = %q, want /alfie/inbox", targets[0].InboxPath)
+	}
+}
+
+func TestScopedReadFS_HidesSiblingDocsets(t *testing.T) {
+	merge := NewMergeFS()
+	merge.SetRoot(NewFSAdapter(fstest.MapFS{
+		"alfie/secret.md": {Data: []byte("alfie")},
+		"miles/secret.md": {Data: []byte("miles")},
+	}))
+	// Session may read only /alfie.
+	fs := newScopedReadFS(merge, []string{"/alfie"})
+
+	if _, err := fs.ReadFile("/alfie/secret.md"); err != nil {
+		t.Fatalf("should read granted docset: %v", err)
+	}
+	if _, err := fs.ReadFile("/miles/secret.md"); err == nil {
+		t.Fatal("must not read ungranted sibling docset")
+	}
+
+	// Root listing shows only /alfie, never /miles.
+	entries, err := fs.ReadDir("/")
+	if err != nil {
+		t.Fatalf("ReadDir(/): %v", err)
+	}
+	for _, e := range entries {
+		if e.FileName == "miles" {
+			t.Fatalf("root listing must hide ungranted docset: %+v", entries)
+		}
+	}
+	var sawAlfie bool
+	for _, e := range entries {
+		if e.FileName == "alfie" {
+			sawAlfie = true
+		}
+	}
+	if !sawAlfie {
+		t.Fatalf("root listing should show the granted docset: %+v", entries)
+	}
+}

--- a/pkg/openlore/docsets_test.go
+++ b/pkg/openlore/docsets_test.go
@@ -10,33 +10,44 @@ import (
 func boolPtr(b bool) *bool { return &b }
 
 // enforcedDocsetServer builds a writable, auth-enforced server with a mix of
-// docset shapes for exercising the per-session builders.
+// docset shapes for exercising the per-session builders. The inbox plugin's
+// `publish` grant is registered so inbox docsets can be exercised.
 func enforcedDocsetServer() *Server {
-	return &Server{
+	s := &Server{
 		merge:        NewMergeFS(),
 		authEnforced: true,
+		grants:       newGrantRegistry(),
 		config:       config.Config{Readonly: false}, // global write lock open
 		auth: &config.AuthConfig{
 			Docsets: map[string]config.DocsetSpec{
 				"public": {Paths: []config.PathMapping{{Source: "/docs/public", Display: "/docs/public"}}},
 				"backend": {
-					Paths:          []config.PathMapping{{Source: "/docs/backend", Display: "/docs/backend"}},
-					PublishDir:     "./published/backend",
-					MaxPublishSize: 5000,
+					Paths:        []config.PathMapping{{Source: "/docs/backend", Display: "/docs/backend"}},
+					Inbox:        "inbox",
+					MaxWriteSize: 5000,
 				},
 				"archive": {
 					Paths:    []config.PathMapping{{Source: "/docs/archive", Display: "/docs/archive"}},
 					Readonly: boolPtr(true),
 				},
 				"home": {
-					Paths:      []config.PathMapping{{Source: "/home/agent", Display: "/home/agent"}},
-					PublishDir: "./published/home",
+					Paths: []config.PathMapping{{Source: "/home/agent", Display: "/home/agent"}},
+					Inbox: "inbox",
 				},
 			},
-			Lore: map[string][]string{
-				"agent": {"public", "backend", "archive", "home"},
-			},
 		},
+	}
+	s.registerPlugin(NewInboxPlugin())
+	return s
+}
+
+// agentIdentity is the full-authority identity used across the docset tests.
+func agentIdentity() Identity {
+	return Identity{
+		IdentityName: "agent",
+		Grants:       map[string]string{"public": "rw", "backend": "rw", "archive": "rw", "home": "rw"},
+		HomeDocset:   "home",
+		Scopes:       []string{ScopeFull},
 	}
 }
 
@@ -51,42 +62,36 @@ func docsetByName(ds []cmds.DocsetInfo, name string) (cmds.DocsetInfo, bool) {
 
 func TestSessionDocsets_Enforced(t *testing.T) {
 	s := enforcedDocsetServer()
-	id := Identity{
-		IdentityName: "agent",
-		LoreName:     "agent",
-		HomeDocset:   "home",
-		Scopes:       []string{ScopeFull},
-	}
+	got := s.sessionDocsets(agentIdentity())
 
-	got := s.sessionDocsets(id)
-
-	// Order follows the lore spec.
-	wantOrder := []string{"public", "backend", "archive", "home"}
+	// Sorted by name.
+	wantOrder := []string{"archive", "backend", "home", "public"}
 	if len(got) != len(wantOrder) {
 		t.Fatalf("got %d docsets, want %d: %+v", len(got), len(wantOrder), got)
 	}
 	for i, name := range wantOrder {
 		if got[i].Name != name {
-			t.Fatalf("docset[%d] = %q, want %q (order should follow lore spec)", i, got[i].Name, name)
+			t.Fatalf("docset[%d] = %q, want %q (sorted by name)", i, got[i].Name, name)
 		}
 	}
 
 	public, _ := docsetByName(got, "public")
-	// public is in the lore and not per-docset readonly, so a full-scope agent
-	// can write to it directly (direct writability is independent of publish_dir).
 	if !public.Writable {
 		t.Fatalf("public should be directly writable for a full-scope agent: %+v", public)
 	}
-	if public.Home || public.HasPublish {
+	if public.Home || public.Inbox {
 		t.Fatalf("public should carry no attributes: %+v", public)
+	}
+	if public.Grant != "rw" {
+		t.Fatalf("public grant = %q, want rw", public.Grant)
 	}
 
 	backend, _ := docsetByName(got, "backend")
 	if !backend.Writable {
 		t.Fatalf("backend should be writable")
 	}
-	if !backend.HasPublish {
-		t.Fatalf("backend has publish_dir → HasPublish")
+	if !backend.Inbox {
+		t.Fatalf("backend has an inbox → Inbox")
 	}
 
 	archive, _ := docsetByName(got, "archive")
@@ -106,63 +111,61 @@ func TestSessionDocsets_Enforced(t *testing.T) {
 func TestSessionDocsets_GlobalReadonlyMakesAllRead(t *testing.T) {
 	s := enforcedDocsetServer()
 	s.config.Readonly = true // close the global lock
-	id := Identity{IdentityName: "agent", LoreName: "agent", Scopes: []string{ScopeFull}}
 
-	for _, d := range s.sessionDocsets(id) {
+	for _, d := range s.sessionDocsets(agentIdentity()) {
 		if d.Writable {
 			t.Fatalf("global lock closed: %q must not be writable", d.Name)
 		}
 	}
 }
 
-func TestSessionDocsets_AnonymousIsReadOnly(t *testing.T) {
+func TestSessionDocsets_ReadOnlyGrantIsReadOnly(t *testing.T) {
 	s := enforcedDocsetServer()
-	// Anonymous: default lore, no identity name, no write scope.
-	s.auth.Lore["default"] = []string{"public", "backend"}
-	id := Identity{LoreName: "default"}
+	// An identity with only ro grants (no identity name / not a writer).
+	id := Identity{Grants: map[string]string{"public": "ro", "backend": "ro"}}
 
 	for _, d := range s.sessionDocsets(id) {
 		if d.Writable {
-			t.Fatalf("anonymous session: %q must be read-only", d.Name)
+			t.Fatalf("ro-grant session: %q must be read-only", d.Name)
 		}
 	}
 }
 
-func TestSessionPublishTargets_OnlyDocsetsWithPublishDir(t *testing.T) {
+func TestSessionPublishTargets_OnlyWritableInboxDocsets(t *testing.T) {
 	s := enforcedDocsetServer()
-	id := Identity{IdentityName: "agent", LoreName: "agent", Scopes: []string{ScopeFull}}
-
-	targets := s.sessionPublishTargets(id)
+	targets := s.sessionPublishTargets(agentIdentity())
 	names := map[string]int64{}
 	for _, tgt := range targets {
 		names[tgt.Name] = tgt.MaxFileSize
 	}
 	if _, ok := names["public"]; ok {
-		t.Fatalf("public has no publish_dir → not a publish target")
+		t.Fatalf("public has no inbox → not a publish target")
+	}
+	if _, ok := names["archive"]; ok {
+		t.Fatalf("archive has no inbox → not a publish target")
 	}
 	if _, ok := names["backend"]; !ok {
-		t.Fatalf("backend has publish_dir → should be a publish target")
+		t.Fatalf("backend has an inbox → should be a publish target")
 	}
 	if names["backend"] != 5000 {
 		t.Fatalf("backend max size = %d, want 5000", names["backend"])
 	}
 	if _, ok := names["home"]; !ok {
-		t.Fatalf("home has publish_dir → should be a publish target")
+		t.Fatalf("home has an inbox → should be a publish target")
 	}
 }
 
-func TestSessionPublishTargets_RespectsExplicitPublishScope(t *testing.T) {
+func TestSessionPublishTargets_PublishGrant(t *testing.T) {
 	s := enforcedDocsetServer()
+	// A publish grant on backend (which has an inbox) is a publish target.
 	id := Identity{
-		IdentityName:   "agent",
-		LoreName:       "agent",
-		PublishDocsets: []string{"backend"}, // explicit publish scope
-		Scopes:         []string{ScopeFull},
+		IdentityName: "miles",
+		Grants:       map[string]string{"backend": "publish"},
+		Scopes:       []string{ScopeFull},
 	}
-
 	targets := s.sessionPublishTargets(id)
 	if len(targets) != 1 || targets[0].Name != "backend" {
-		t.Fatalf("explicit publish scope should limit targets to backend, got %+v", targets)
+		t.Fatalf("publish grant should yield backend as a target, got %+v", targets)
 	}
 }
 
@@ -170,15 +173,15 @@ func TestSessionPublishTargets_UnenforcedHasNone(t *testing.T) {
 	s := &Server{
 		merge:        NewMergeFS(),
 		authEnforced: false,
+		grants:       newGrantRegistry(),
 		config:       config.Config{Readonly: false},
 		auth: &config.AuthConfig{
 			Docsets: map[string]config.DocsetSpec{
 				"public": {Paths: []config.PathMapping{{Source: "/", Display: "/"}}},
 			},
-			Lore: map[string][]string{"default": {"public"}},
 		},
 	}
-	id := Identity{LoreName: "default", Scopes: []string{ScopeFull}}
+	id := Identity{Grants: map[string]string{"public": "rw"}, Scopes: []string{ScopeFull}}
 	if targets := s.sessionPublishTargets(id); targets != nil {
 		t.Fatalf("unenforced mode has no publish inboxes, got %+v", targets)
 	}
@@ -188,15 +191,15 @@ func TestSessionDocsets_UnenforcedPublicIsWritable(t *testing.T) {
 	s := &Server{
 		merge:        NewMergeFS(),
 		authEnforced: false,
+		grants:       newGrantRegistry(),
 		config:       config.Config{Readonly: false}, // writes unrestricted
 		auth: &config.AuthConfig{
 			Docsets: map[string]config.DocsetSpec{
 				"public": {Paths: []config.PathMapping{{Source: "/", Display: "/"}}},
 			},
-			Lore: map[string][]string{"default": {"public"}},
 		},
 	}
-	id := Identity{LoreName: "default", Scopes: []string{ScopeFull}}
+	id := Identity{Grants: map[string]string{"public": "rw"}, Scopes: []string{ScopeFull}}
 	got := s.sessionDocsets(id)
 	if len(got) != 1 || got[0].Name != "public" {
 		t.Fatalf("want single public docset, got %+v", got)

--- a/pkg/openlore/grants.go
+++ b/pkg/openlore/grants.go
@@ -1,0 +1,79 @@
+package openlore
+
+import (
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+// GrantType decides what a named grant permits within a single docset. Core
+// registers the "ro" and "rw" grants; plugins contribute others (e.g. the
+// inbox plugin's "publish") via GrantTypeProvider.
+//
+// A grant only ever narrows. The authorizer consults it for reads and for each
+// write action; its decision is then further capped by the token scope and the
+// global / per-docset readonly locks (enforced by the server, not here). A
+// grant name referenced by lore.json but not registered as a GrantType makes
+// the server refuse to boot — fail-closed.
+type GrantType interface {
+	// Name is the grant identifier used in lore.json (e.g. "ro", "rw").
+	Name() string
+	// CanRead reports whether the grant permits reading display path p within
+	// docset ds. p is a cleaned VFS display path already known to sit within the
+	// docset.
+	CanRead(ds config.DocsetSpec, p string) bool
+	// AllowsWrite reports whether the grant ever permits writes at all. It drives
+	// coarse shell action gating (whether write verbs are offered); per-op
+	// authorization still runs through CanWrite.
+	AllowsWrite() bool
+	// CanWrite reports whether the grant permits mutation action on display path
+	// p within docset ds.
+	CanWrite(ds config.DocsetSpec, action vfs.ChangeAction, p string) bool
+}
+
+// GrantTypeProvider is implemented by a plugin that contributes named grant
+// types. The server registers them at plugin registration so lore.json may
+// reference the grant names.
+type GrantTypeProvider interface {
+	GrantTypes() []GrantType
+}
+
+// grantRegistry maps grant names to their behavior. Core types are registered at
+// server construction; plugins add more via GrantTypeProvider.
+type grantRegistry struct {
+	types map[string]GrantType
+}
+
+func newGrantRegistry() *grantRegistry {
+	r := &grantRegistry{types: map[string]GrantType{}}
+	r.register(roGrant{})
+	r.register(rwGrant{})
+	return r
+}
+
+func (r *grantRegistry) register(g GrantType) { r.types[g.Name()] = g }
+
+func (r *grantRegistry) get(name string) (GrantType, bool) {
+	g, ok := r.types[name]
+	return g, ok
+}
+
+// roGrant grants reading the whole docset and no writes.
+type roGrant struct{}
+
+func (roGrant) Name() string                           { return "ro" }
+func (roGrant) CanRead(config.DocsetSpec, string) bool { return true }
+func (roGrant) AllowsWrite() bool                      { return false }
+func (roGrant) CanWrite(config.DocsetSpec, vfs.ChangeAction, string) bool {
+	return false
+}
+
+// rwGrant grants reading and writing anywhere in the docset (subject to the
+// per-docset readonly flag and the global write lock, enforced by the server).
+type rwGrant struct{}
+
+func (rwGrant) Name() string                           { return "rw" }
+func (rwGrant) CanRead(config.DocsetSpec, string) bool { return true }
+func (rwGrant) AllowsWrite() bool                      { return true }
+func (rwGrant) CanWrite(config.DocsetSpec, vfs.ChangeAction, string) bool {
+	return true
+}

--- a/pkg/openlore/identity.go
+++ b/pkg/openlore/identity.go
@@ -3,7 +3,6 @@ package openlore
 import (
 	"time"
 
-	"github.com/aakarim/go-openlore/internal/config"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -39,19 +38,17 @@ func recognizedScope(s string) bool {
 
 // Identity represents a connected caller (SSH session or MCP/HTTP request).
 type Identity struct {
-	RemoteAddr     string
-	User           string
-	PublicKey      ssh.PublicKey
-	SessionID      string
-	ConnectedAt    time.Time
-	IdentityName   string               // matched identity name from auth config
-	LoreName       string               // name of the lore spec this identity uses
-	PathAccess     []config.PathMapping // resolved path mappings
-	PublishDocsets []string             // writable docsets (nil = all in lore)
-	Capabilities   []string             // extra capabilities held (e.g. "spawn")
-	HomeDir        string               // display path of the identity's home docset ($HOME); empty = none
-	HomeDocset     string               // name of the identity's home docset; empty = none
-	Scopes         []string             // token scopes narrowing authority; {ScopeFull} = full authority
+	RemoteAddr   string
+	User         string
+	PublicKey    ssh.PublicKey
+	SessionID    string
+	ConnectedAt  time.Time
+	IdentityName string            // matched identity name from auth config
+	Grants       map[string]string // docset name → grant name (ro/rw/publish); nil = no access
+	Capabilities []string          // extra capabilities held (e.g. "spawn")
+	HomeDir      string            // display path of the identity's home docset ($HOME); empty = none
+	HomeDocset   string            // name of the identity's home docset; empty = none
+	Scopes       []string          // token scopes narrowing authority; {ScopeFull} = full authority
 }
 
 // OnConnectFunc is called when a new SSH session is established.

--- a/pkg/openlore/identity_context_test.go
+++ b/pkg/openlore/identity_context_test.go
@@ -13,11 +13,11 @@ import (
 func TestIdentityFromContext_RoundTrip(t *testing.T) {
 	s := &Server{merge: NewMergeFS()}
 
-	want := Identity{IdentityName: "frontend", LoreName: "frontend", Scopes: []string{ScopeFull}}
+	want := Identity{IdentityName: "frontend", Grants: map[string]string{"frontend": "rw"}, Scopes: []string{ScopeFull}}
 	ctx := contextWithIdentity(context.Background(), want)
 
 	got := s.identityFromContext(ctx)
-	if got.IdentityName != "frontend" || got.LoreName != "frontend" {
+	if got.IdentityName != "frontend" || got.Grants["frontend"] != "rw" {
 		t.Fatalf("identity did not round-trip: %+v", got)
 	}
 	if len(got.Scopes) != 1 || got.Scopes[0] != ScopeFull {
@@ -32,13 +32,16 @@ func TestIdentityFromContext_AnonymousIsNotFull(t *testing.T) {
 		merge:        NewMergeFS(),
 		authEnforced: true,
 		auth: &config.AuthConfig{
-			Lore: map[string][]string{"default": {"public"}},
+			Docsets: map[string]config.DocsetSpec{
+				"public": {Paths: []config.PathMapping{{Source: "/", Display: "/"}}},
+			},
+			Default: map[string]string{"public": "ro"},
 		},
 	}
 
 	got := s.identityFromContext(context.Background())
-	if got.LoreName != "default" {
-		t.Fatalf("anonymous caller should resolve to default lore, got %q", got.LoreName)
+	if got.Grants["public"] != "ro" {
+		t.Fatalf("anonymous caller should resolve to default grants, got %v", got.Grants)
 	}
 	if len(got.Scopes) != 0 {
 		t.Fatalf("anonymous caller must not carry any scope (fail-closed), got %v", got.Scopes)
@@ -58,7 +61,6 @@ func TestIdentityFromContext_NoAuthIsFull(t *testing.T) {
 			Docsets: map[string]config.DocsetSpec{
 				"public": {Paths: []config.PathMapping{{Source: "/", Display: "/"}}},
 			},
-			Lore: map[string][]string{"default": {"public"}},
 		},
 	}
 

--- a/pkg/openlore/identitystore.go
+++ b/pkg/openlore/identitystore.go
@@ -348,15 +348,13 @@ func (s *Server) identityForName(name string) (Identity, bool) {
 // authority (ScopeFull). Callers may override Scopes from a token.
 func (s *Server) identityFromAuth(ident config.AuthIdentity) Identity {
 	return Identity{
-		IdentityName:   ident.Name,
-		LoreName:       ident.Lore,
-		PathAccess:     s.resolveLorePathAccess(ident.Lore),
-		PublishDocsets: ident.Publish,
-		Capabilities:   ident.Capabilities,
-		HomeDir:        s.resolveHomeDir(ident.Home),
-		HomeDocset:     ident.Home,
-		Scopes:         []string{ScopeFull},
-		SessionID:      generateSessionID(),
-		ConnectedAt:    time.Now(),
+		IdentityName: ident.Name,
+		Grants:       ident.Docsets,
+		Capabilities: ident.Capabilities,
+		HomeDir:      s.resolveHomeDir(ident.Home),
+		HomeDocset:   ident.Home,
+		Scopes:       []string{ScopeFull},
+		SessionID:    generateSessionID(),
+		ConnectedAt:  time.Now(),
 	}
 }

--- a/pkg/openlore/inbox.go
+++ b/pkg/openlore/inbox.go
@@ -1,0 +1,71 @@
+package openlore
+
+import (
+	"strings"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+// InboxPlugin contributes the "publish" grant: an identity holding it may read
+// the whole docset, may never delete anything, and may only create or edit files
+// within the docset's configured inbox folder. It is registered like any other
+// plugin (Server.RegisterPlugin) and exposes its grant via GrantTypeProvider.
+//
+// The inbox model lets an outside collaborator drop material into a docset (an
+// "inbox") without granting them write access to the rest of the docset and
+// without any ability to delete.
+type InboxPlugin struct{}
+
+// NewInboxPlugin returns the inbox plugin.
+func NewInboxPlugin() *InboxPlugin { return &InboxPlugin{} }
+
+// GrantTypes implements GrantTypeProvider.
+func (*InboxPlugin) GrantTypes() []GrantType { return []GrantType{publishGrant{}} }
+
+// publishGrant is the "publish" grant type: read anywhere in the docset, no
+// deletes, create/edit only within the docset's inbox.
+type publishGrant struct{}
+
+func (publishGrant) Name() string { return "publish" }
+
+// CanRead permits reading the whole docset.
+func (publishGrant) CanRead(config.DocsetSpec, string) bool { return true }
+
+// AllowsWrite is true: publish grants write inside the inbox.
+func (publishGrant) AllowsWrite() bool { return true }
+
+// CanWrite permits create/edit (write, mkdir) only within the docset's inbox,
+// and denies every removal everywhere.
+func (publishGrant) CanWrite(ds config.DocsetSpec, action vfs.ChangeAction, p string) bool {
+	switch action {
+	case vfs.ChangeActionRemove, vfs.ChangeActionRemoveAll:
+		return false // publish can never delete
+	}
+	inbox := inboxPath(ds)
+	if inbox == "" {
+		return false // no inbox configured: publish can write nothing
+	}
+	clean := vfs.CleanPath(p)
+	return clean == inbox || strings.HasPrefix(clean, inbox+"/")
+}
+
+// inboxPath resolves a docset's inbox to a cleaned VFS display path. An absolute
+// Inbox is used verbatim; a relative Inbox is joined onto the docset's first
+// display root. Returns "" when the docset has no inbox or no paths.
+func inboxPath(ds config.DocsetSpec) string {
+	if ds.Inbox == "" {
+		return ""
+	}
+	if strings.HasPrefix(ds.Inbox, "/") {
+		return vfs.CleanPath(ds.Inbox)
+	}
+	if len(ds.Paths) == 0 {
+		return ""
+	}
+	root := ds.Paths[0].Display
+	if root == "" {
+		root = ds.Paths[0].Source
+	}
+	return vfs.CleanPath(root + "/" + ds.Inbox)
+}

--- a/pkg/openlore/jobs_test.go
+++ b/pkg/openlore/jobs_test.go
@@ -42,7 +42,7 @@ func spawnFixture(t *testing.T, runner fakeRunner) (*shell.Shell, *JobManager, *
 	cmds.Jobs = mgr
 	t.Cleanup(func() { cmds.Jobs = saved })
 
-	scoped := newScopedWriteFS(base, []string{"/ops"})
+	scoped := newScopedWriteFS(base, rootsAuthz("/ops"))
 	sh := shell.NewShell(scoped)
 	sh.SetAllowedActions([]cmds.Action{cmds.ActionWrite, cmds.ActionSpawn})
 	sh.SetEnv("OPENLORE_IDENTITY", "jared")

--- a/pkg/openlore/mcp_scoping_test.go
+++ b/pkg/openlore/mcp_scoping_test.go
@@ -32,14 +32,13 @@ func newScopedTestAPI(t *testing.T) http.Handler {
 	s := &Server{
 		merge:        merge,
 		authEnforced: true,
+		grants:       newGrantRegistry(),
 		auth: &config.AuthConfig{
 			Docsets: map[string]config.DocsetSpec{
 				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}},
 				"secret": {Paths: []config.PathMapping{{Source: "/secret", Display: "/secret"}}},
 			},
-			Lore: map[string][]string{
-				"default": {"public"}, // secret deliberately excluded
-			},
+			Default: map[string]string{"public": "ro"}, // secret deliberately excluded
 		},
 		config: config.Config{Readonly: true},
 	}

--- a/pkg/openlore/publish_vfs_test.go
+++ b/pkg/openlore/publish_vfs_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
+	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
 // Step 1 of Part C: `publish` no longer writes straight to disk — it commits
@@ -28,9 +29,16 @@ func TestPublish_GoesThroughScopedVFS(t *testing.T) {
 	}
 
 	// Session can see both docsets but may only write /jared.
-	fs := newScopedWriteFS(base, []string{"/jared"})
+	authz := func(_ vfs.ChangeAction, p string) bool {
+		clean := vfs.CleanPath(p)
+		return clean == "/jared" || strings.HasPrefix(clean, "/jared/")
+	}
+	fs := newScopedWriteFS(base, authz)
 	sh := shell.NewShell(fs)
-	sh.SetPublishTargets([]cmds.PublishTarget{{Name: "jared"}, {Name: "claw"}})
+	sh.SetPublishTargets([]cmds.PublishTarget{
+		{Name: "jared", InboxPath: "/jared"},
+		{Name: "claw", InboxPath: "/claw"},
+	})
 
 	// In-scope publish commits and reads back through the VFS.
 	if out, errs, code := run(sh, "echo hello | publish /jared/topic.md"); code != 0 {
@@ -50,5 +58,51 @@ func TestPublish_GoesThroughScopedVFS(t *testing.T) {
 	}
 	if _, _, c := run(sh, "cat /claw/topic.md"); c == 0 {
 		t.Fatalf("out-of-scope publish must not write /claw/topic.md")
+	}
+}
+
+// TestPublish_RoutesIntoInbox pins that `publish /<docset>/<rest>` writes into
+// the docset's configured inbox (InboxPath/<rest>), not the docset root — the
+// only place a publish grant may create files.
+func TestPublish_RoutesIntoInbox(t *testing.T) {
+	dir := t.TempDir()
+	base := NewDirFS(dir, config.FilesConfig{})
+	if err := base.SetWriteable(); err != nil {
+		t.Fatalf("SetWriteable: %v", err)
+	}
+	if err := base.Mkdir("/alfie"); err != nil {
+		t.Fatalf("seed mkdir /alfie: %v", err)
+	}
+	if err := base.Mkdir("/alfie/inbox"); err != nil {
+		t.Fatalf("seed mkdir /alfie/inbox: %v", err)
+	}
+
+	// Publish grant semantics: create/edit only inside /alfie/inbox, no deletes.
+	authz := func(_ vfs.ChangeAction, p string) bool {
+		clean := vfs.CleanPath(p)
+		return clean == "/alfie/inbox" || strings.HasPrefix(clean, "/alfie/inbox/")
+	}
+	fs := newScopedWriteFS(base, authz)
+	sh := shell.NewShell(fs)
+	sh.SetPublishTargets([]cmds.PublishTarget{{Name: "alfie", InboxPath: "/alfie/inbox"}})
+
+	// publish /alfie/from-miles.md lands in /alfie/inbox/from-miles.md.
+	if out, errs, code := run(sh, "echo hi | publish /alfie/from-miles.md"); code != 0 {
+		t.Fatalf("publish into inbox failed: code=%d out=%q err=%q", code, out, errs)
+	}
+	if out, _, _ := run(sh, "cat /alfie/inbox/from-miles.md"); out != "hi\n" {
+		t.Fatalf("published content = %q, want %q", out, "hi\n")
+	}
+	// It must NOT have written the docset root path.
+	if _, _, c := run(sh, "cat /alfie/from-miles.md"); c == 0 {
+		t.Fatalf("publish must not write to the docset root")
+	}
+
+	// Nested path is preserved under the inbox.
+	if _, errs, code := run(sh, "echo x | publish /alfie/sub/deep.md"); code != 0 {
+		t.Fatalf("nested publish failed: err=%q", errs)
+	}
+	if out, _, _ := run(sh, "cat /alfie/inbox/sub/deep.md"); out != "x\n" {
+		t.Fatalf("nested published content = %q, want %q", out, "x\n")
 	}
 }

--- a/pkg/openlore/scoped_write_fs.go
+++ b/pkg/openlore/scoped_write_fs.go
@@ -1,91 +1,74 @@
 package openlore
 
 import (
-	"strings"
-
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
-// scopedWriteFS narrows a session's write surface to a fixed set of docset
-// roots (Part B per-identity isolation). Reads pass straight through to the
-// wrapped filesystem; a write (WriteFileAtomic / Mkdir) only reaches the
-// backing substrate when its target sits strictly inside one of the writable
-// roots, otherwise it is rejected with vfs.ErrReadOnly.
-//
-// This is how two agents that can both *see* the same docsets (same lore) are
-// still prevented from writing each other's docsets: each session is scoped to
-// the roots of the docsets it may publish to.
+// writeAuthorizer decides whether a session may perform a mutation action on a
+// display path. It is the per-operation authority: the server binds it to the
+// session identity's grants (Server.identityCanWrite), so two agents that can
+// both see the same docsets are still authorized independently per write, and a
+// grant like `publish` can permit create/edit only within an inbox while
+// denying deletes.
+type writeAuthorizer func(action vfs.ChangeAction, p string) bool
+
+// scopedWriteFS gates a session's writes through a writeAuthorizer. Reads pass
+// straight through to the wrapped filesystem; a mutation only reaches the
+// backing substrate when the authorizer allows the specific (action, path),
+// otherwise it fails closed with vfs.ErrReadOnly.
 type scopedWriteFS struct {
 	vfs.FileSystem                // read delegation (Stat / ReadDir / ReadFile)
 	inner          vfs.WritableFS // the writable substrate, nil if base is read-only
-	writableRoots  []string       // cleaned docset roots this session may write
+	authorize      writeAuthorizer
 }
 
-// newScopedWriteFS wraps base so writes are confined to writableRoots. If base
-// is not itself writable, every write fails closed with vfs.ErrReadOnly.
-func newScopedWriteFS(base vfs.FileSystem, writableRoots []string) *scopedWriteFS {
+// newScopedWriteFS wraps base so every mutation is authorized by authz. If base
+// is not itself writable, every write fails closed with vfs.ErrReadOnly. A nil
+// authz denies all writes.
+func newScopedWriteFS(base vfs.FileSystem, authz writeAuthorizer) *scopedWriteFS {
 	w, _ := base.(vfs.WritableFS)
-	cleaned := make([]string, 0, len(writableRoots))
-	for _, r := range writableRoots {
-		cleaned = append(cleaned, vfs.CleanPath(r))
+	if authz == nil {
+		authz = func(vfs.ChangeAction, string) bool { return false }
 	}
-	return &scopedWriteFS{FileSystem: base, inner: w, writableRoots: cleaned}
-}
-
-// inScope reports whether p sits strictly inside one of the writable roots. A
-// root of "/" means the whole tree (any non-root path) is in scope.
-func (s *scopedWriteFS) inScope(p string) bool {
-	clean := vfs.CleanPath(p)
-	for _, root := range s.writableRoots {
-		if root == "/" {
-			if clean != "/" {
-				return true
-			}
-			continue
-		}
-		if strings.HasPrefix(clean, root+"/") {
-			return true
-		}
-	}
-	return false
+	return &scopedWriteFS{FileSystem: base, inner: w, authorize: authz}
 }
 
 func (s *scopedWriteFS) WriteFileAtomic(p string, data []byte, opts vfs.WriteOpts) (string, error) {
-	if s.inner == nil || !s.inScope(p) {
+	if s.inner == nil || !s.authorize(vfs.ChangeActionWrite, p) {
 		return "", vfs.ErrReadOnly
 	}
 	return s.inner.WriteFileAtomic(p, data, opts)
 }
 
-// CanWrite reports whether p is writable in this session's scope (vfs.WriteScopeFS).
-// It enables fail-fast checks (e.g. `spawn`) without performing a write.
+// CanWrite reports whether a whole-file write to p is authorized in this session
+// (vfs.WriteScopeFS). It enables fail-fast checks (e.g. `spawn`) without writing.
 func (s *scopedWriteFS) CanWrite(p string) bool {
-	return s.inner != nil && s.inScope(p)
+	return s.inner != nil && s.authorize(vfs.ChangeActionWrite, p)
 }
 
 func (s *scopedWriteFS) Mkdir(p string) error {
-	if s.inner == nil || !s.inScope(p) {
+	if s.inner == nil || !s.authorize(vfs.ChangeActionMkdir, p) {
 		return vfs.ErrReadOnly
 	}
 	return s.inner.Mkdir(p)
 }
 
 func (s *scopedWriteFS) MkdirAll(p string) error {
-	if s.inner == nil || !s.inScope(p) {
+	if s.inner == nil || !s.authorize(vfs.ChangeActionMkdirAll, p) {
 		return vfs.ErrReadOnly
 	}
 	return s.inner.MkdirAll(p)
 }
 
 func (s *scopedWriteFS) Remove(p string) error {
-	if s.inner == nil || !s.inScope(p) {
+	if s.inner == nil || !s.authorize(vfs.ChangeActionRemove, p) {
 		return vfs.ErrReadOnly
 	}
 	return s.inner.Remove(p)
 }
 
 func (s *scopedWriteFS) RemoveAll(p string, opts vfs.RemoveOpts) error {
-	if s.inner == nil || !s.inScope(p) {
+	if s.inner == nil || !s.authorize(vfs.ChangeActionRemoveAll, p) {
 		return vfs.ErrReadOnly
 	}
 	return s.inner.RemoveAll(p, opts)

--- a/pkg/openlore/scoped_write_fs_test.go
+++ b/pkg/openlore/scoped_write_fs_test.go
@@ -2,11 +2,33 @@ package openlore
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
+
+// rootsAuthz builds a writeAuthorizer that permits writes strictly inside any of
+// the given display roots — the classic per-identity write-isolation behavior.
+func rootsAuthz(roots ...string) writeAuthorizer {
+	return func(_ vfs.ChangeAction, p string) bool {
+		clean := vfs.CleanPath(p)
+		for _, r := range roots {
+			r = vfs.CleanPath(r)
+			if r == "/" {
+				if clean != "/" {
+					return true
+				}
+				continue
+			}
+			if strings.HasPrefix(clean, r+"/") {
+				return true
+			}
+		}
+		return false
+	}
+}
 
 // Part B per-identity write isolation. Two agents share a lore (so they can see
 // the same docsets), but each session is scoped to the docset roots it may
@@ -26,7 +48,7 @@ func TestScopedWriteFS_ConfinesWritesToRoots(t *testing.T) {
 	}
 
 	// This session may only write /jared.
-	fs := newScopedWriteFS(base, []string{"/jared"})
+	fs := newScopedWriteFS(base, rootsAuthz("/jared"))
 
 	if _, err := fs.WriteFileAtomic("/jared/notes.md", []byte("ok"), vfs.WriteOpts{}); err != nil {
 		t.Fatalf("write inside own docset should succeed: %v", err)
@@ -79,7 +101,7 @@ func TestScopedWriteFS_ReadsPassThrough(t *testing.T) {
 	}
 
 	// Session scoped to /jared can still read /claw.
-	fs := newScopedWriteFS(base, []string{"/jared"})
+	fs := newScopedWriteFS(base, rootsAuthz("/jared"))
 	data, err := fs.ReadFile("/claw/readme.md")
 	if err != nil {
 		t.Fatalf("read should pass through scope: %v", err)

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -45,14 +46,17 @@ type Server struct {
 	// enforced (docsets filtered, anonymous is read-only).
 	auth         *config.AuthConfig
 	authEnforced bool
-	fs           vfs.FileSystem
-	merge        *MergeFS
-	metrics      *metrics.Metrics
-	srv          *ssh.Server
-	httpSrv      *httpserver.Server
-	passkeys     *passkeys.Passkeys
-	logger       *slog.Logger
-	motd         string
+	// grants is the registry of grant types (ro/rw + plugin-contributed like
+	// publish). A grant name in lore.json with no registered type fails startup.
+	grants   *grantRegistry
+	fs       vfs.FileSystem
+	merge    *MergeFS
+	metrics  *metrics.Metrics
+	srv      *ssh.Server
+	httpSrv  *httpserver.Server
+	passkeys *passkeys.Passkeys
+	logger   *slog.Logger
+	motd     string
 
 	onConnect    OnConnectFunc
 	onDisconnect OnDisconnectFunc
@@ -134,6 +138,7 @@ func newServerWithRoot(rootDir string, rootFS vfs.FileSystem, opts ...config.Opt
 		// Default to an empty (unenforced) policy; a loaded auth file replaces
 		// it and sets authEnforced below.
 		auth:    &config.AuthConfig{},
+		grants:  newGrantRegistry(),
 		merge:   NewMergeFS(),
 		metrics: &metrics.Metrics{},
 		logger:  logger,
@@ -173,15 +178,14 @@ func newServerWithRoot(rootDir string, rootFS vfs.FileSystem, opts ...config.Opt
 		}
 	} else {
 		// No auth file: run in trusted/unenforced mode as a single `public`
-		// docset rooted at "/", with any folder mounts folded in. Every
-		// consumer (resolveLorePathAccess, sessionDocsets) then reuses the
-		// normal docset machinery instead of special-casing unenforced mode.
+		// docset rooted at "/", with any folder mounts folded in. The anonymous
+		// identity holds an `rw` grant on it (see anonymousIdentity), so every
+		// consumer reuses the normal docset machinery.
 		paths := []config.PathMapping{{Source: "/", Display: "/"}}
 		for _, f := range cfg.Folders {
 			paths = append(paths, config.PathMapping{Source: "/" + f.Name, Display: "/" + f.Name})
 		}
 		s.auth.Docsets = map[string]config.DocsetSpec{"public": {Paths: paths}}
-		s.auth.Lore = map[string][]string{"default": {"public"}}
 	}
 
 	// Collect docset root display paths so DirFS.Mkdir can enforce the
@@ -370,7 +374,7 @@ func generateSessionID() string {
 }
 
 func (s *Server) resolveIdentity(sess ssh.Session) Identity {
-	id := Identity{
+	conn := Identity{
 		RemoteAddr:  sess.RemoteAddr().String(),
 		User:        sess.User(),
 		PublicKey:   sess.PublicKey(),
@@ -378,97 +382,59 @@ func (s *Server) resolveIdentity(sess ssh.Session) Identity {
 		ConnectedAt: time.Now(),
 	}
 
-	// Resolve path access from auth config
-	if s.authEnforced && id.PublicKey != nil {
-		// Extract the underlying public key for matching.
-		// If the client presented a certificate, sess.PublicKey() returns
-		// the certificate itself — we need the inner key to match against
-		// raw public keys stored in lore.json identities.
-		matchKey := id.PublicKey
+	if !s.authEnforced {
+		// Auth not enforced: full access to the synthetic `public` docset.
+		return withConn(conn, s.anonymousIdentity())
+	}
+
+	if conn.PublicKey != nil {
+		// Extract the underlying public key for matching. If the client
+		// presented a certificate, sess.PublicKey() returns the certificate
+		// itself — we need the inner key to match against raw public keys stored
+		// in lore.json identities.
+		matchKey := conn.PublicKey
 		var cert *gossh.Certificate
-		if c, ok := id.PublicKey.(*gossh.Certificate); ok {
+		if c, ok := conn.PublicKey.(*gossh.Certificate); ok {
 			cert = c
 			matchKey = c.Key
 		}
+		// MarshalAuthorizedKey appends a trailing newline; stored keys are
+		// TrimSpace'd (e.g. by `identity add`). Compare trimmed so the newline
+		// mismatch doesn't silently drop every pubkey match.
+		keyStr := strings.TrimSpace(string(gossh.MarshalAuthorizedKey(matchKey)))
 
-		keyStr := string(gossh.MarshalAuthorizedKey(matchKey))
-		matched := false
-
-		// First: try matching by public key.
+		// First: match by public key. An authenticated key holds the identity's
+		// full authority (shared with token resolution).
 		for _, ident := range s.auth.Identities {
-			if ident.PublicKey == keyStr {
-				// Shared with token resolution: an authenticated key holds this
-				// identity's full authority.
-				src := s.identityFromAuth(ident)
-				id.IdentityName = src.IdentityName
-				id.LoreName = src.LoreName
-				id.PathAccess = src.PathAccess
-				id.PublishDocsets = src.PublishDocsets
-				id.Capabilities = src.Capabilities
-				id.HomeDir = src.HomeDir
-				id.HomeDocset = src.HomeDocset
-				id.Scopes = src.Scopes
-				matched = true
-				break
+			if ident.PublicKey != "" && strings.TrimSpace(ident.PublicKey) == keyStr {
+				return withConn(conn, s.identityFromAuth(ident))
 			}
 		}
 
-		// Second: if the client used a certificate and no key matched,
-		// map certificate principals to lore names. This lets you
-		// sign certs with `-n frontend` and have them automatically get
-		// the "frontend" lore without registering individual keys.
-		if !matched && cert != nil {
+		// Second: a certificate's principals name identities directly. This lets
+		// you sign certs with `-n alfie` and have them get alfie's grants without
+		// registering individual keys.
+		if cert != nil {
 			for _, principal := range cert.ValidPrincipals {
-				if _, ok := s.auth.Lore[principal]; ok {
-					id.LoreName = principal
-					id.PathAccess = s.resolveLorePathAccess(principal)
-					// A valid cert holds this lore's full authority.
-					id.Scopes = []string{ScopeFull}
-					matched = true
-					break
+				if src, ok := s.identityForName(principal); ok {
+					return withConn(conn, src)
 				}
 			}
 		}
-
-		// Unrecognized key/cert: fall back to "default" lore
-		if !matched {
-			if _, ok := s.auth.Lore["default"]; ok {
-				id.LoreName = "default"
-				id.PathAccess = s.resolveLorePathAccess("default")
-			}
-		}
-	} else if s.authEnforced {
-		// Keyless connection with auth config: use "default" lore
-		if _, ok := s.auth.Lore["default"]; ok {
-			id.LoreName = "default"
-			id.PathAccess = s.resolveLorePathAccess("default")
-		}
-	} else {
-		// Auth not enforced: full access to the synthetic `public` docset.
-		id.LoreName = "default"
-		id.PathAccess = s.resolveLorePathAccess("default")
-		id.Scopes = []string{ScopeFull}
 	}
 
-	return id
+	// Unrecognized key / keyless: the anonymous default identity.
+	return withConn(conn, s.anonymousIdentity())
 }
 
-// resolveLorePathAccess resolves a lore name to path mappings by looking up
-// its docset list and collecting all paths from each referenced docset.
-func (s *Server) resolveLorePathAccess(loreName string) []config.PathMapping {
-	docsetNames, ok := s.auth.Lore[loreName]
-	if !ok {
-		return nil
-	}
-	var mappings []config.PathMapping
-	for _, dsName := range docsetNames {
-		if ds, ok := s.auth.Docsets[dsName]; ok {
-			for _, pm := range ds.Paths {
-				mappings = append(mappings, pm)
-			}
-		}
-	}
-	return mappings
+// withConn copies the per-connection fields (remote addr, user, public key)
+// from a freshly built connection identity onto a resolved identity, so the
+// resolved authority keeps its live connection context.
+func withConn(conn, resolved Identity) Identity {
+	resolved.RemoteAddr = conn.RemoteAddr
+	resolved.User = conn.User
+	resolved.PublicKey = conn.PublicKey
+	return resolved
 }
 
 // resolveHomeDir returns the display path of the named home docset, used as
@@ -491,38 +457,20 @@ func (s *Server) resolveHomeDir(homeDocset string) string {
 	return vfs.CleanPath(display)
 }
 
-// writableDocsetRoots resolves the docset roots an identity may write to
-// (Part B). It uses the identity's explicit publish list, falling back to every
-// docset in its lore when no explicit publish scope is set (the admin /
-// no-publish case). Docsets flagged readonly are excluded — a per-docset lock
-// can only further restrict. Returns nil for an unrecognized identity, so
-// anonymous sessions are read-only.
-func (s *Server) writableDocsetRoots(id Identity) []string {
-	if id.IdentityName == "" {
-		return nil
-	}
-	names := id.PublishDocsets
-	if len(names) == 0 {
-		names = s.auth.Lore[id.LoreName]
-	}
-	var roots []string
-	for _, name := range names {
-		ds, ok := s.auth.Docsets[name]
-		if !ok {
+// hasWritableGrant reports whether the identity holds any grant that ever
+// permits writes (rw, publish, …). It drives coarse shell action gating: a
+// read-only identity (only `ro` grants) is offered no write verbs. Per-op
+// authorization still runs through identityCanWrite.
+func (s *Server) hasWritableGrant(id Identity) bool {
+	for name, grantName := range id.Grants {
+		if _, ok := s.auth.Docsets[name]; !ok {
 			continue
 		}
-		if ds.Readonly != nil && *ds.Readonly {
-			continue // per-docset lock excludes it from the writable scope
-		}
-		for _, pm := range ds.Paths {
-			display := pm.Display
-			if display == "" {
-				display = pm.Source
-			}
-			roots = append(roots, display)
+		if grant, ok := s.grants.get(grantName); ok && grant.AllowsWrite() {
+			return true
 		}
 	}
-	return roots
+	return false
 }
 
 // writeConflictPolicy resolves the policy governing whole-file overwrites to
@@ -565,7 +513,13 @@ func pathWithinRoot(root, p string) bool {
 }
 
 func (s *Server) sftpSubsystem(sess ssh.Session) {
-	handler := NewSFTPHandler(s.fs)
+	// SFTP must enforce the same read scoping and write authorization as the
+	// interactive shell. Resolve the session identity and build the identical
+	// layered session FS (scoped reads + per-op write authz) rather than the raw
+	// merge FS, so an accepted SSH user cannot read, list, stat, or write
+	// outside their grants over SFTP.
+	id := s.resolveIdentity(sess)
+	handler := NewSFTPHandler(s.buildSessionFS(id))
 	server := sftp.NewRequestServer(sess, sftp.Handlers{
 		FileGet:  handler,
 		FilePut:  handler,
@@ -683,6 +637,11 @@ func (s *Server) registerPlugin(p any) {
 	if pc, ok := p.(PostCommitProvider); ok {
 		s.postCommitMW = append(s.postCommitMW, pc.PostCommitMiddleware()...)
 	}
+	if gp, ok := p.(GrantTypeProvider); ok {
+		for _, g := range gp.GrantTypes() {
+			s.grants.register(g)
+		}
+	}
 }
 
 // writeChain composes the admission (pre-commit) middleware around a terminal
@@ -726,25 +685,26 @@ func hasCapability(have []string, want string) bool {
 }
 
 // buildSessionShell constructs a fully-configured shell scoped to the given
-// identity: a per-identity filesystem (lore FilteredView, write isolation,
+// identity: a per-identity filesystem (read scoping, write authorization,
 // read-tracking CAS), capability-gated allowed actions, and
 // OPENLORE_* environment variables. This is the single source of truth for
 // per-identity scoping, shared by the SSH shell handler and the MCP/HTTP tool
 // handlers so all transports enforce the same access rules.
-func (s *Server) buildSessionShell(id Identity) *shell.Shell {
-	// Build per-session filesystem filtered by lore (the identity's docsets).
-	// Only when auth is enforced: in unenforced/trusted mode the session sees
-	// the whole merge FS (all mounts), so we must not run FilteredView (which
-	// would drop folder mounts not named after the synthetic `public` docset).
+// buildSessionFS constructs the per-session filesystem for an identity: read
+// scoping to the identity's readable roots, the read/write middleware chains,
+// per-op write authorization by grant, and session CAS tracking. It is the
+// single source of the layered VFS shared by both the interactive shell and the
+// SFTP subsystem so both enforce identical read scoping and write authorization.
+func (s *Server) buildSessionFS(id Identity) vfs.FileSystem {
+	// Build per-session filesystem scoped to the identity's readable roots.
+	// Docsets are display-path subtrees of a shared backing filesystem, so read
+	// scoping is by path (not mount name): a session only sees the docsets it
+	// holds a grant on, plus the ancestor directories leading to them and the
+	// always-visible system mounts. Only when auth is enforced; in
+	// unenforced/trusted mode the session sees the whole merge FS (all mounts).
 	sessionFS := vfs.FileSystem(s.merge)
-	if s.authEnforced && id.LoreName != "" {
-		if docsetNames, ok := s.auth.Lore[id.LoreName]; ok {
-			allowed := make(map[string]bool)
-			for _, ds := range docsetNames {
-				allowed[ds] = true
-			}
-			sessionFS = s.merge.FilteredView(allowed)
-		}
+	if s.authEnforced {
+		sessionFS = newScopedReadFS(sessionFS, s.readableRoots(id))
 	}
 	// Read (before-read) gate: run the read middleware chain in front of every
 	// Stat/ReadDir/ReadFile so a plugin can (e.g.) refresh the substrate or
@@ -761,23 +721,28 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 	if s.writeLog != nil {
 		sessionFS = newMiddlewareFS(sessionFS, Actor{ID: id.User}, s.writeChain())
 	}
-	// canWrite is the single authority gate shared by the FS layer and the
+	// canWrite is the coarse authority gate shared by the FS layer and the
 	// action layer: an identity may write only when auth is enforced, it is a
-	// named identity (not anonymous), and its token scope grants write. A WIF
-	// token narrowed to `read` (or any non-`full` scope) is read-only here even
-	// if the underlying identity is write-capable — narrowing wins, fail-closed.
-	canWrite := s.authEnforced && id.IdentityName != "" && scopeGrantsWrite(id.Scopes)
-	// Part B per-identity write isolation: confine this session's writes to
-	// the docset roots it may publish to, so two agents sharing a lore can't
-	// write each other's docsets. Anonymous/unrecognized/read-scoped identities
-	// get no writable roots (fully read-only at the FS layer). No-op when auth
-	// is not enforced.
+	// named identity (not anonymous), its token scope grants write, and it holds
+	// at least one write-capable grant. A WIF token narrowed to `read` (or any
+	// non-`full` scope) is read-only here even if the underlying identity is
+	// write-capable — narrowing wins, fail-closed.
+	canWrite := s.authEnforced && id.IdentityName != "" && scopeGrantsWrite(id.Scopes) && s.hasWritableGrant(id)
+	// Per-op write authorization: every mutation is checked against the
+	// identity's grants (grant ∩ token scope ∩ readonly locks). This confines a
+	// session to exactly what its grants permit — an `rw` grant writes anywhere
+	// in its docset, a `publish` grant only creates/edits within the inbox and
+	// never deletes, and two identities sharing a docset are authorized
+	// independently per write. Anonymous/read-only identities get a nil
+	// authorizer (fully read-only). No-op when auth is not enforced.
 	if s.authEnforced {
-		roots := s.writableDocsetRoots(id)
-		if !canWrite {
-			roots = nil
+		var authz writeAuthorizer
+		if canWrite {
+			authz = func(action vfs.ChangeAction, p string) bool {
+				return s.identityCanWrite(id, action, p)
+			}
 		}
-		sessionFS = newScopedWriteFS(sessionFS, roots)
+		sessionFS = newScopedWriteFS(sessionFS, authz)
 	}
 	if s.sessionFSFn != nil {
 		sessionFS = s.sessionFSFn(id, sessionFS)
@@ -792,6 +757,18 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 			sessionFS = newReadTrackingFS(w)
 		}
 	}
+	return sessionFS
+}
+
+func (s *Server) buildSessionShell(id Identity) *shell.Shell {
+	sessionFS := s.buildSessionFS(id)
+	// canWrite is the coarse authority gate shared by the FS layer and the
+	// action layer: an identity may write only when auth is enforced, it is a
+	// named identity (not anonymous), its token scope grants write, and it holds
+	// at least one write-capable grant. A WIF token narrowed to `read` (or any
+	// non-`full` scope) is read-only here even if the underlying identity is
+	// write-capable — narrowing wins, fail-closed.
+	canWrite := s.authEnforced && id.IdentityName != "" && scopeGrantsWrite(id.Scopes) && s.hasWritableGrant(id)
 
 	sh := shell.NewShell(sessionFS)
 	if s.config.DefaultCwd != "" {
@@ -840,79 +817,73 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 		sh.SetEnv("OPENLORE_USER", id.User)
 		sh.SetEnv("OPENLORE_AGENT_ID", id.User)
 	}
-	if id.LoreName != "" {
-		sh.SetEnv("OPENLORE_LORE", id.LoreName)
-	}
 
 	return sh
 }
 
 // sessionDocsets resolves the docsets this session can access, with their
-// display paths, direct writability, and attributes — the per-session view
-// surfaced by `lore docsets`. Docsets are returned in the order they appear in
-// the identity's lore spec.
+// display paths, grant, and attributes — the per-session view surfaced by
+// `lore docsets`.
 func (s *Server) sessionDocsets(id Identity) []cmds.DocsetInfo {
-	if id.LoreName == "" {
-		return nil
-	}
-	docsetNames, ok := s.auth.Lore[id.LoreName]
-	if !ok {
+	if len(id.Grants) == 0 {
 		return nil
 	}
 	writable := s.writableDocsetNames(id)
 	var out []cmds.DocsetInfo
-	for _, name := range docsetNames {
+	for name, grantName := range id.Grants {
 		ds, ok := s.auth.Docsets[name]
 		if !ok {
 			continue
 		}
 		var paths []string
 		for _, pm := range ds.Paths {
-			display := pm.Display
-			if display == "" {
-				display = pm.Source
-			}
-			paths = append(paths, vfs.CleanPath(display))
+			paths = append(paths, displayPath(pm))
 		}
 		out = append(out, cmds.DocsetInfo{
-			Name:       name,
-			Paths:      paths,
-			Writable:   writable[name],
-			Home:       name == id.HomeDocset,
-			HasPublish: ds.PublishDir != "",
+			Name:     name,
+			Paths:    paths,
+			Grant:    grantName,
+			Writable: writable[name],
+			Home:     name == id.HomeDocset,
+			Inbox:    inboxPath(ds) != "",
 		})
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 
-// sessionPublishTargets resolves the publish inboxes this session may publish
-// to: docsets in the identity's publish scope (its explicit publish list, else
-// all docsets in its lore) that declare a publish_dir. Publish inboxes only
-// exist when auth is enforced.
+// sessionPublishTargets resolves the write inboxes this session may publish to:
+// docsets whose grant allows writes and that declare an inbox. Only exist when
+// auth is enforced.
 func (s *Server) sessionPublishTargets(id Identity) []cmds.PublishTarget {
-	if !s.authEnforced || id.LoreName == "" {
+	if !s.authEnforced {
 		return nil
 	}
-	names := id.PublishDocsets
-	if len(names) == 0 {
-		names = s.auth.Lore[id.LoreName]
-	}
 	var out []cmds.PublishTarget
-	for _, name := range names {
+	for name, grantName := range id.Grants {
 		ds, ok := s.auth.Docsets[name]
-		if !ok || ds.PublishDir == "" {
+		if !ok {
 			continue
 		}
-		out = append(out, cmds.PublishTarget{Name: name, MaxFileSize: ds.MaxPublishSize})
+		grant, ok := s.grants.get(grantName)
+		if !ok || !grant.AllowsWrite() {
+			continue
+		}
+		inbox := inboxPath(ds)
+		if inbox == "" {
+			continue
+		}
+		out = append(out, cmds.PublishTarget{Name: name, InboxPath: inbox, MaxFileSize: ds.MaxWriteSize})
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 
 // writableDocsetNames reports, by docset name, which docsets this session may
-// write to directly. It mirrors the FS-authoritative writable scope: the global
-// write lock must be open; in unenforced mode every docset is writable; when
-// enforced, the identity must be named and hold write scope, and per-docset
-// readonly excludes a docset.
+// write to directly with the normal write verbs. The global lock must be open;
+// in unenforced mode every docset is writable; when enforced, the identity must
+// be named, hold write scope, and hold a grant whose AllowsWrite is true and
+// that is not per-docset readonly.
 func (s *Server) writableDocsetNames(id Identity) map[string]bool {
 	out := map[string]bool{}
 	if s.config.Readonly {
@@ -927,11 +898,7 @@ func (s *Server) writableDocsetNames(id Identity) map[string]bool {
 	if id.IdentityName == "" || !scopeGrantsWrite(id.Scopes) {
 		return out
 	}
-	names := id.PublishDocsets
-	if len(names) == 0 {
-		names = s.auth.Lore[id.LoreName]
-	}
-	for _, name := range names {
+	for name, grantName := range id.Grants {
 		ds, ok := s.auth.Docsets[name]
 		if !ok {
 			continue
@@ -939,29 +906,27 @@ func (s *Server) writableDocsetNames(id Identity) map[string]bool {
 		if ds.Readonly != nil && *ds.Readonly {
 			continue
 		}
-		out[name] = true
+		if grant, ok := s.grants.get(grantName); ok && grant.AllowsWrite() {
+			out[name] = true
+		}
 	}
 	return out
 }
 
 // anonymousIdentity returns the identity used for callers that present no
-// credential (keyless SSH, or an unauthenticated MCP/HTTP request). It mirrors
-// the keyless branches of resolveIdentity: the "default" lore when auth is
-// enforced, or full access when it is not.
+// credential (keyless SSH, or an unauthenticated MCP/HTTP request): the auth
+// config's `default` docset→grant map when auth is enforced, or full access to
+// the synthetic `public` docset when it is not.
 func (s *Server) anonymousIdentity() Identity {
 	id := Identity{
 		SessionID:   generateSessionID(),
 		ConnectedAt: time.Now(),
 	}
 	if s.authEnforced {
-		if _, ok := s.auth.Lore["default"]; ok {
-			id.LoreName = "default"
-			id.PathAccess = s.resolveLorePathAccess("default")
-		}
+		id.Grants = s.auth.Default // nil ⇒ no access for anonymous sessions
 	} else {
 		// Auth not enforced: full access to the synthetic `public` docset.
-		id.LoreName = "default"
-		id.PathAccess = s.resolveLorePathAccess("default")
+		id.Grants = map[string]string{"public": "rw"}
 		id.Scopes = []string{ScopeFull}
 	}
 	return id
@@ -1016,6 +981,9 @@ func joinCommand(parts []string) string {
 
 // ListenAndServe starts the SSH server (blocks).
 func (s *Server) ListenAndServe() error {
+	if err := s.validateGrants(); err != nil {
+		return err
+	}
 	opts := []ssh.Option{
 		wish.WithAddress(fmt.Sprintf(":%d", s.config.Port)),
 		wish.WithHostKeyPath(s.config.HostKeyPath),
@@ -1054,17 +1022,20 @@ func (s *Server) ListenAndServe() error {
 					matchKey = c.Key
 				}
 
-				keyStr := string(gossh.MarshalAuthorizedKey(matchKey))
+				// MarshalAuthorizedKey appends a trailing newline; stored keys
+				// are TrimSpace'd. Compare trimmed so a valid key isn't denied
+				// admission before resolveIdentity ever runs.
+				keyStr := strings.TrimSpace(string(gossh.MarshalAuthorizedKey(matchKey)))
 				for _, ident := range s.auth.Identities {
-					if ident.PublicKey == keyStr {
+					if ident.PublicKey != "" && strings.TrimSpace(ident.PublicKey) == keyStr {
 						return true
 					}
 				}
 
-				// Allow cert-authenticated users whose principal matches a lore name
+				// Allow cert-authenticated users whose principal names an identity.
 				if cert != nil {
 					for _, principal := range cert.ValidPrincipals {
-						if _, ok := s.auth.Lore[principal]; ok {
+						if _, ok := s.findAuthIdentity(principal); ok {
 							return true
 						}
 					}

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -605,8 +605,8 @@ type MergeFS struct {
 	root   vfs.FileSystem
 	mounts map[string]vfs.FileSystem
 	// system marks mount names that are control-plane (e.g. "requests") rather
-	// than lore docsets. System mounts are always preserved across
-	// FilteredView, so every session can see them regardless of its lore.
+	// than lore docsets. System mounts are always readable regardless of an
+	// identity's grants (see Server.readableRoots / SystemMountPaths).
 	system map[string]bool
 }
 
@@ -635,24 +635,15 @@ func (m *MergeFS) MountSystem(name string, fs vfs.FileSystem) {
 	m.system[name] = true
 }
 
-// FilteredView returns a new MergeFS that only includes the specified mount
-// names plus all system mounts. The root filesystem is always included. If
-// allowedMounts is nil, returns the original.
-func (m *MergeFS) FilteredView(allowedMounts map[string]bool) *MergeFS {
-	if allowedMounts == nil {
-		return m
+// SystemMountPaths returns the display paths ("/name") of every control-plane
+// (system) mount. These are always readable regardless of an identity's grants,
+// so the read-scoping layer includes them.
+func (m *MergeFS) SystemMountPaths() []string {
+	var out []string
+	for name := range m.system {
+		out = append(out, "/"+name)
 	}
-	filtered := &MergeFS{
-		root:   m.root,
-		mounts: make(map[string]vfs.FileSystem),
-		system: m.system,
-	}
-	for name, fs := range m.mounts {
-		if allowedMounts[name] || m.system[name] {
-			filtered.mounts[name] = fs
-		}
-	}
-	return filtered
+	return out
 }
 
 // SetWriteable fans out to every writable-capable backend (root + mounts).

--- a/pkg/openlore/wif_test.go
+++ b/pkg/openlore/wif_test.go
@@ -39,6 +39,7 @@ func newWIFTestServer(t *testing.T, verifier OIDCVerifier) *Server {
 	s := &Server{
 		merge:        merge,
 		authEnforced: true,
+		grants:       newGrantRegistry(),
 		oidc:         verifier,
 		auth: &config.AuthConfig{
 			AllowKeyless:    &keyless,
@@ -47,15 +48,12 @@ func newWIFTestServer(t *testing.T, verifier OIDCVerifier) *Server {
 				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}},
 				"secret": {Paths: []config.PathMapping{{Source: "/secret", Display: "/secret"}}},
 			},
-			Lore: map[string][]string{
-				"default": {"public"},
-				"eng":     {"public", "secret"},
-			},
+			Default: map[string]string{"public": "ro"},
 			Identities: []config.AuthIdentity{
-				{Name: "alice", Lore: "eng"},
+				{Name: "alice", Docsets: map[string]string{"public": "ro", "secret": "rw"}},
 				{
-					Name: "ci-indexer",
-					Lore: "eng",
+					Name:    "ci-indexer",
+					Docsets: map[string]string{"public": "ro", "secret": "rw"},
 					Match: []config.IdentityMatch{{
 						SubPrefix: "repo:my-org/my-repo:",
 						Aud:       "https://openlore.test",

--- a/pkg/openlore/writelog_test.go
+++ b/pkg/openlore/writelog_test.go
@@ -19,14 +19,14 @@ type wlRecordingFS struct {
 	errFor  map[string]error
 }
 
-func (f *wlRecordingFS) Stat(string) (*vfs.FileInfo, error)   { return nil, errors.New("no") }
+func (f *wlRecordingFS) Stat(string) (*vfs.FileInfo, error)     { return nil, errors.New("no") }
 func (f *wlRecordingFS) ReadDir(string) ([]vfs.FileInfo, error) { return nil, errors.New("no") }
-func (f *wlRecordingFS) ReadFile(string) ([]byte, error)      { return nil, errors.New("no") }
-func (f *wlRecordingFS) SetWriteable() error                  { return nil }
-func (f *wlRecordingFS) SetReadonly() error                   { return nil }
-func (f *wlRecordingFS) Mkdir(string) error                   { return nil }
-func (f *wlRecordingFS) MkdirAll(string) error                { return nil }
-func (f *wlRecordingFS) Remove(string) error                  { return nil }
+func (f *wlRecordingFS) ReadFile(string) ([]byte, error)        { return nil, errors.New("no") }
+func (f *wlRecordingFS) SetWriteable() error                    { return nil }
+func (f *wlRecordingFS) SetReadonly() error                     { return nil }
+func (f *wlRecordingFS) Mkdir(string) error                     { return nil }
+func (f *wlRecordingFS) MkdirAll(string) error                  { return nil }
+func (f *wlRecordingFS) Remove(string) error                    { return nil }
 func (f *wlRecordingFS) RemoveAll(string, vfs.RemoveOpts) error { return nil }
 
 func (f *wlRecordingFS) WriteFileAtomic(name string, _ []byte, _ vfs.WriteOpts) (string, error) {

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -40,26 +40,32 @@ type CmdContext interface {
 
 // DocsetInfo describes one docset a session can access. It is the per-session
 // view surfaced by `lore docsets` — the host resolves it from the identity's
-// lore at session creation.
+// grants at session creation.
 type DocsetInfo struct {
 	// Name is the docset's logical name (its key in the auth config).
 	Name string
 	// Paths are the docset's display (virtual) paths in the filesystem.
 	Paths []string
+	// Grant is the grant name the session holds on this docset (ro/rw/publish).
+	Grant string
 	// Writable reports whether this session may write to the docset directly
-	// with the normal write verbs (r vs rw). This is the FS-authoritative
-	// answer, independent of any publish inbox.
+	// with the normal write verbs. This is the FS-authoritative answer.
 	Writable bool
 	// Home reports whether this docset is the session's home docset ($HOME).
 	Home bool
-	// HasPublish reports whether the docset has a publish inbox (publish_dir).
-	// It says nothing about the inbox path or size — that lives in PublishTarget.
-	HasPublish bool
+	// Inbox reports whether the docset declares an inbox folder (used by the
+	// publish grant). It says nothing about the inbox path or size — that lives
+	// in PublishTarget.
+	Inbox bool
 }
 
-// PublishTarget is a writable publish inbox: its logical docset name (the first
-// path segment used in `publish /<name>/<file>`) and the per-docset size cap.
+// PublishTarget is a writable inbox: its logical docset name (the first path
+// segment used in `publish /<name>/<file>`), the resolved virtual filesystem
+// path of the docset's inbox that a publish is routed into, and the per-docset
+// size cap. A `publish /<name>/<rest>` writes to InboxPath/<rest>, not to the
+// docset root — the inbox is the only place the publish grant may create files.
 type PublishTarget struct {
 	Name        string
+	InboxPath   string
 	MaxFileSize int64
 }

--- a/pkg/shell/cmds/lore.go
+++ b/pkg/shell/cmds/lore.go
@@ -39,24 +39,24 @@ func printLoreUsage(w io.Writer) {
 func cmdLoreDocsets(ctx CmdContext, args []string, w io.Writer, errW io.Writer) int {
 	docsets := ctx.Docsets()
 
-	rows := [][4]string{{"DOCSET", "ACCESS", "ATTRIBUTES", "PATHS"}}
+	rows := [][4]string{{"DOCSET", "GRANT", "ATTRIBUTES", "PATHS"}}
 	for _, d := range docsets {
-		access := "r"
-		if d.Writable {
-			access = "rw"
+		grant := d.Grant
+		if grant == "" {
+			grant = "ro"
 		}
 		var attrs []string
 		if d.Home {
 			attrs = append(attrs, "home")
 		}
-		if d.HasPublish {
-			attrs = append(attrs, "publish")
+		if d.Inbox {
+			attrs = append(attrs, "inbox")
 		}
 		attrStr := "-"
 		if len(attrs) > 0 {
 			attrStr = strings.Join(attrs, ",")
 		}
-		rows = append(rows, [4]string{d.Name, access, attrStr, strings.Join(d.Paths, ",")})
+		rows = append(rows, [4]string{d.Name, grant, attrStr, strings.Join(d.Paths, ",")})
 	}
 
 	// Column widths from every cell except the last column (which is ragged).

--- a/pkg/shell/cmds/lore_test.go
+++ b/pkg/shell/cmds/lore_test.go
@@ -44,9 +44,9 @@ func TestLore_UnknownSubcommandExitsOne(t *testing.T) {
 
 func TestLoreDocsets_Table(t *testing.T) {
 	docsets := []cmds.DocsetInfo{
-		{Name: "public", Paths: []string{"/docs/public", "/docs/getting-started.md"}},
-		{Name: "backend", Paths: []string{"/docs/backend", "/docs/api"}, Writable: true},
-		{Name: "home", Paths: []string{"/home/backend"}, Writable: true, Home: true, HasPublish: true},
+		{Name: "public", Paths: []string{"/docs/public", "/docs/getting-started.md"}, Grant: "ro"},
+		{Name: "backend", Paths: []string{"/docs/backend", "/docs/api"}, Grant: "rw", Writable: true},
+		{Name: "home", Paths: []string{"/home/backend"}, Grant: "rw", Writable: true, Home: true, Inbox: true},
 	}
 	out, _, code := runLore(t, docsets, "lore docsets")
 	if code != 0 {
@@ -70,9 +70,9 @@ func TestLoreDocsets_Table(t *testing.T) {
 			t.Fatalf("row %q: paths should end with %q", line, paths)
 		}
 	}
-	assertRow(lines[1], "public", "r", "-", "/docs/public,/docs/getting-started.md")
+	assertRow(lines[1], "public", "ro", "-", "/docs/public,/docs/getting-started.md")
 	assertRow(lines[2], "backend", "rw", "-", "/docs/backend,/docs/api")
-	assertRow(lines[3], "home", "rw", "home,publish", "/home/backend")
+	assertRow(lines[3], "home", "rw", "home,inbox", "/home/backend")
 }
 
 func TestLoreDocsets_EmptyShowsHeaderOnly(t *testing.T) {
@@ -80,21 +80,21 @@ func TestLoreDocsets_EmptyShowsHeaderOnly(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if strings.TrimRight(out, "\n") != "DOCSET  ACCESS  ATTRIBUTES  PATHS" {
+	if strings.TrimRight(out, "\n") != "DOCSET  GRANT  ATTRIBUTES  PATHS" {
 		t.Fatalf("empty docsets should print header only, got:\n%q", out)
 	}
 }
 
 func TestLoreDocsets_GrepByAttribute(t *testing.T) {
 	docsets := []cmds.DocsetInfo{
-		{Name: "public", Paths: []string{"/docs"}},
-		{Name: "backend", Paths: []string{"/docs/backend"}, Writable: true, HasPublish: true},
+		{Name: "public", Paths: []string{"/docs"}, Grant: "ro"},
+		{Name: "backend", Paths: []string{"/docs/backend"}, Grant: "rw", Writable: true, Inbox: true},
 	}
-	out, _, code := runLore(t, docsets, "lore docsets | grep publish")
+	out, _, code := runLore(t, docsets, "lore docsets | grep inbox")
 	if code != 0 {
 		t.Fatalf("piped grep exit = %d, want 0", code)
 	}
 	if !strings.Contains(out, "backend") || strings.Contains(out, "public ") {
-		t.Fatalf("grep publish should return only the backend row, got:\n%s", out)
+		t.Fatalf("grep inbox should return only the backend row, got:\n%s", out)
 	}
 }

--- a/pkg/shell/cmds/publish.go
+++ b/pkg/shell/cmds/publish.go
@@ -70,6 +70,12 @@ func CmdPublish(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdi
 		return 1
 	}
 
+	// Route the publish into the docset's inbox: `publish /<docset>/<rest>`
+	// writes to <inbox>/<rest>, never to the docset root. The inbox is the only
+	// place the publish grant may create files, so the destination must be
+	// resolved here rather than writing the raw /<docset>/<rest> path.
+	dest := path.Join(target.InboxPath, segs[1])
+
 	maxSize := target.MaxFileSize
 	if maxSize <= 0 {
 		maxSize = defaultMaxPublishSize
@@ -86,29 +92,29 @@ func CmdPublish(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdi
 		return 1
 	}
 
-	if _, err := WriteFile(ctx, p, data, false); err != nil {
+	if _, err := WriteFile(ctx, dest, data, false); err != nil {
 		var pchg *vfs.PendingChangeError
 		if errors.As(err, &pchg) {
 			// Not a failure: a middleware parked the publish as a pending change.
-			fmt.Fprintln(w, pendingChangeLine("publish", p, pchg))
+			fmt.Fprintln(w, pendingChangeLine("publish", dest, pchg))
 			return 0
 		}
 		var pce *vfs.PreconditionError
 		if errors.As(err, &pce) {
-			fmt.Fprintf(errW, "publish: %s changed concurrently — re-read and retry\n", p)
+			fmt.Fprintf(errW, "publish: %s changed concurrently — re-read and retry\n", dest)
 			return 1
 		}
 		if errors.Is(err, vfs.ErrReadOnly) {
-			fmt.Fprintf(errW, "publish: no access to %s\n", p)
+			fmt.Fprintf(errW, "publish: no access to %s\n", dest)
 		} else {
 			fmt.Fprintf(errW, "publish: %s\n", err)
 		}
 		return 1
 	}
 
-	fmt.Fprintf(w, "Published %s (%d bytes)\n", p, len(data))
+	fmt.Fprintf(w, "Published %s (%d bytes)\n", dest, len(data))
 	if PublishBaseURL != "" {
-		fmt.Fprintf(w, "%s%s\n", PublishBaseURL, p)
+		fmt.Fprintf(w, "%s%s\n", PublishBaseURL, dest)
 	}
 	return 0
 }

--- a/pkg/shell/cmds/whoami.go
+++ b/pkg/shell/cmds/whoami.go
@@ -8,21 +8,14 @@ import (
 func CmdWhoami(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	env := ctx.AllEnv()
 	identity := env["OPENLORE_IDENTITY"]
-	lore := env["OPENLORE_LORE"]
 
-	if identity == "" && lore == "" {
+	if identity == "" {
+		// No resolved identity: report the generic shell principal.
 		fmt.Fprintln(w, "lore")
 		return 0
 	}
 
-	if identity == "" {
-		identity = "anonymous"
-	}
-	if lore == "" {
-		lore = "default"
-	}
-
-	fmt.Fprintf(w, "%s (lore: %s)\n", identity, lore)
+	fmt.Fprintln(w, identity)
 	return 0
 }
 


### PR DESCRIPTION
Replace the lore/tier + publish_dir model with a per-docset grant map. Each identity holds a named grant (ro/rw) on each docset it can access; the inbox plugin contributes a 'publish' grant (read whole docset, no deletes, create/edit only within the docset's configured inbox).

- config: drop AuthConfig.Lore and DocsetSpec.PublishDir/MaxPublishSize; add flat AuthIdentity.Docsets grant map, AuthConfig.Default, and DocsetSpec.Inbox/MaxWriteSize. public_key now optional.
- grants: GrantType/GrantTypeProvider plugin seam, core ro/rw registry, startup validateGrants() fails closed on unknown grant names.
- reads: path-subtree scoping (hides sibling docsets) replaces mount-name FilteredView.
- writes: per-op writeAuthorizer replaces roots-list scoping.
- SFTP now uses the same identity-scoped session FS (no read bypass).
- publish routes into the docset's resolved inbox path.
- trim public keys when matching (MarshalAuthorizedKey newline).
- CLI: identity add --docset/--grant, --key optional; inbox plugin registered by default.