### PR TITLE
refactor(meta): relocate meta package to pkg/openlore/meta

### DIFF
--- a/pkg/openlore/commands.go
+++ b/pkg/openlore/commands.go
@@ -1,7 +1,7 @@
 package openlore
 
 import (
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 )
 

--- a/pkg/openlore/meta/meta.go
+++ b/pkg/openlore/meta/meta.go
@@ -1,11 +1,11 @@
 // Package meta holds the business logic behind `lore meta`: walking a document
 // tree, extracting each document's YAML frontmatter, and letting plugins enrich
-// the result. It is a dedicated business-logic package rather than living in
-// pkg/shell/cmds (which owns only the generic `lore` dispatcher and the thin
-// command adapter) or pkg/openlore (which imports cmds, so cmds cannot import it
-// back without an import cycle). It depends only on pkg/vfs and pkg/okf, so both
-// the shell command and the openlore host can reuse the exact same scanning
-// logic that `lore meta` exposes (as pkg/okf backs write-side validation).
+// the result. It lives under the openlore namespace but is a separate package
+// from pkg/openlore (which imports cmds): keeping meta cmds-free lets the shell
+// command (pkg/shell/cmds) call it without an import cycle, while the parent
+// openlore host reuses it too. It depends only on pkg/vfs and pkg/okf, so the
+// same scanning logic backs `lore meta` on every path (as pkg/okf backs
+// write-side validation).
 package meta
 
 import (

--- a/pkg/openlore/meta/meta_test.go
+++ b/pkg/openlore/meta/meta_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 

--- a/pkg/openlore/okf_plugin.go
+++ b/pkg/openlore/okf_plugin.go
@@ -7,7 +7,7 @@ import (
 	"path"
 
 	"github.com/aakarim/go-openlore/internal/config"
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/okf"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aakarim/go-openlore/internal/metrics"
 	"github.com/aakarim/go-openlore/internal/passkeys"
 	"github.com/aakarim/go-openlore/internal/skills"
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -3,7 +3,7 @@ package cmds
 import (
 	"io"
 
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 

--- a/pkg/shell/cmds/lore_meta.go
+++ b/pkg/shell/cmds/lore_meta.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 )
 
 // cmdLoreMeta is the `lore meta` command adapter. It is shell plumbing only: it

--- a/pkg/shell/cmds/lore_meta_test.go
+++ b/pkg/shell/cmds/lore_meta_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 )

--- a/pkg/shell/cmds/spawn.go
+++ b/pkg/shell/cmds/spawn.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aakarim/go-openlore/pkg/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/shell/parser"
 	"github.com/aakarim/go-openlore/pkg/vfs"


### PR DESCRIPTION
Moves the frontmatter-scanning package from `pkg/meta` to `pkg/openlore/meta`, homing it under the openlore namespace.

It stays a **separate, cmds-free package** (deps: `pkg/vfs`, `pkg/okf` only), so `pkg/shell/cmds` can still import it without an import cycle, while the parent `pkg/openlore` host reuses it too. Pure move + import-path/doc update; no behavior change.

- `go build ./...`, `go vet ./...`, `go test ./pkg/...` all pass.