### PR TITLE
feat: add docset path aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,17 +210,20 @@ OpenLore is built on [Wish](https://github.com/charmbracelet/wish) from Charmbra
 
 ```
 $ lore docsets
-DOCSET    GRANT    ATTRIBUTES   PATHS
-public    ro       -            /docs/public,/docs/getting-started.md
-backend   rw       -            /docs/backend,/docs/api
-home      rw       home,inbox   /home/backend
+DOCSET    GRANT    ATTRIBUTES   PATH             TARGET
+public    ro       -            /docs/public     -
+backend   rw       -            /docs/backend    -
+home      rw       home,inbox   /home/backend    -
+home      rw       alias        /backend         /home/backend
 ```
 
 - `GRANT` is the named grant you hold on the docset: `ro` (read the whole docset),
   `rw` (read + write anywhere in it), or `publish` (read the whole docset, create/edit
   only within its inbox, never delete).
 - `ATTRIBUTES` is a comma-joined set of tokens (`-` if none): `home` (your `$HOME`
-  docset), `inbox` (the docset declares an inbox folder).
+  docset), `inbox` (the docset declares an inbox folder), or `alias` (this mount
+  resolves to the canonical path in `TARGET`). Canonical rows always precede
+  aliases for the same docset.
 
 **Publishing**
 
@@ -740,7 +743,8 @@ Create a `lore.json` to control access per public key:
   "docsets": {
     "public": { "paths": ["/docs/public"] },
     "backend": {
-      "paths": ["/docs/api", {"internal/specs": "/docs/specs"}]
+      "paths": ["/docs/api", {"internal/specs": "/docs/specs"}],
+      "aliases": ["/api"]
     }
   },
   "default": { "public": "ro" },
@@ -759,6 +763,27 @@ Each identity holds a named **grant** on each docset it can access — `ro`
 (read), `rw` (read + write), or `publish` (read all, create/edit only in the
 docset's inbox, no deletes). The `default` map is the grant set for keyless /
 unrecognized callers.
+
+### Path Aliases
+
+A docset can expose alternate virtual roots for its first canonical path:
+
+```json
+{
+  "docsets": {
+    "jared": {
+      "paths": ["/agent/jared"],
+      "aliases": ["/jared"]
+    }
+  }
+}
+```
+
+Both `/agent/jared/notes.md` and `/jared/notes.md` access the same file. Shell
+navigation preserves the path the caller used, but authorization, approvals,
+changesets, hooks, events, inboxes, and `$HOME` use `/agent/jared` as the
+canonical identity. Aliases must be absolute, normalized, and must not overlap
+another canonical path or alias.
 
 ### Home Directory
 

--- a/docs/docsets-command.md
+++ b/docs/docsets-command.md
@@ -28,27 +28,26 @@ it (`lore whoami`, etc.) without reshaping a command's contract later.
 
 ## `lore docsets` output
 
-Space-aligned table, header row, values within a multi-valued cell joined by `,`,
-named attribute tokens (grep-friendly), `-` for empty:
+Space-aligned table with one row per mount, named attribute tokens
+(grep-friendly), and `-` for empty:
 
 ```
-DOCSET    ACCESS  ATTRIBUTES     PATHS
-public    r       -              /docs/public,/docs/getting-started.md
-frontend  r       -              /docs/frontend,/docs/shared
-backend   rw      approval       /docs/backend,/docs/api,/docs/database
-home      rw      home,publish   /home/backend
+DOCSET    GRANT  ATTRIBUTES  PATH             TARGET
+public    ro     -           /docs/public     -
+backend   rw     -           /docs/backend    -
+home      rw     home,inbox  /home/backend    -
+home      rw     alias       /backend         /home/backend
 ```
 
-- **`ACCESS`** — `r` or `rw`. `rw` = the docset is *directly* writable by this session
-  (see writability below). Binary; never mangled.
+- **`GRANT`** — the named grant held on the docset (`ro`, `rw`, `publish`, or a
+  plugin-contributed grant).
 - **`ATTRIBUTES`** — named tokens, any of:
   - `home` — this docset is the session's home docset (`$HOME`).
-  - `publish` — this docset has a publish inbox (`publish_dir`) the user may publish to.
-  - `approval` — some or all writes here are approval-gated (`requires_approval`).
-    Gating can be path-scoped within a docset, so the token means "may be gated," not
-    "always gated" — documented as a caveat.
-- **`PATHS`** — display (virtual) paths, comma-joined. Never on-disk source paths.
-- **Order** — the order docsets appear in the identity's lore spec.
+  - `inbox` — the docset declares an inbox.
+  - `alias` — this row is an alternate mount whose canonical path is `TARGET`.
+- **`PATH`** — the display (virtual) path for this mount. Never an on-disk source path.
+- **`TARGET`** — the canonical display path for aliases; `-` for canonical rows.
+- **Order** — docset name, with canonical rows before aliases of that docset.
 - **Header** — kept; agents can `tail -n +2` / `grep -v '^DOCSET'` for machine parsing.
 
 ## Two concerns, kept separate

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,10 @@ type JWKSSpec struct {
 // DocsetSpec defines a named set of path mappings.
 type DocsetSpec struct {
 	Paths []PathMapping `json:"paths"`
+	// Aliases are alternate display roots for the first path. They expose the
+	// same content while the first path remains canonical for home, inbox,
+	// policy, hooks, and changesets.
+	Aliases []string `json:"aliases,omitempty"`
 	// Inbox names a subfolder (VFS path, relative to a docset root or absolute)
 	// that the `publish` grant confines create/edit to. Empty = the docset has
 	// no inbox, so a `publish` grant on it can write nothing.

--- a/lore.json.example
+++ b/lore.json.example
@@ -37,6 +37,7 @@
       "paths": [
         {"published/backend-home": "/home/backend"}
       ],
+      "aliases": ["/backend"],
       "inbox": "inbox"
     },
     "ops": {

--- a/pkg/openlore/alias_fs.go
+++ b/pkg/openlore/alias_fs.go
@@ -1,0 +1,271 @@
+package openlore
+
+import (
+	"errors"
+	"io/fs"
+	"path"
+	"sort"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+// pathAlias maps an alternate display root to its canonical docset root.
+type pathAlias struct {
+	Alias  string
+	Target string
+}
+
+// aliasFS exposes alternate paths while delegating every operation through the
+// canonical path. It is installed outside scope and middleware wrappers so
+// authorization, hooks, changesets, and storage observe one path identity.
+type aliasFS struct {
+	vfs.FileSystem
+	aliases []pathAlias
+}
+
+func newAliasFS(base vfs.FileSystem, aliases []pathAlias) vfs.FileSystem {
+	clean := make([]pathAlias, 0, len(aliases))
+	for _, a := range aliases {
+		clean = append(clean, pathAlias{Alias: vfs.CleanPath(a.Alias), Target: vfs.CleanPath(a.Target)})
+	}
+	sort.Slice(clean, func(i, j int) bool { return len(clean[i].Alias) > len(clean[j].Alias) })
+	a := &aliasFS{FileSystem: base, aliases: clean}
+	if writable, ok := base.(vfs.WritableFS); ok {
+		return &writableAliasFS{aliasFS: a, inner: writable}
+	}
+	return a
+}
+
+// canonical maps p through the most-specific alias root.
+func (a *aliasFS) canonical(p string) (string, *pathAlias) {
+	clean := vfs.CleanPath(p)
+	for i := range a.aliases {
+		alias := &a.aliases[i]
+		if pathWithinRoot(alias.Alias, clean) {
+			return replacePathRoot(clean, alias.Alias, alias.Target), alias
+		}
+	}
+	return clean, nil
+}
+
+func (a *aliasFS) CanonicalPath(p string) string {
+	canonical, _ := a.canonical(p)
+	return canonical
+}
+
+func replacePathRoot(p, from, to string) string {
+	if p == from {
+		return to
+	}
+	return vfs.CleanPath(to + p[len(from):])
+}
+
+func (a *aliasFS) Stat(p string) (*vfs.FileInfo, error) {
+	requested := vfs.CleanPath(p)
+	canonical, alias := a.canonical(p)
+	if alias != nil {
+		info, err := a.FileSystem.Stat(canonical)
+		if err != nil {
+			return nil, err
+		}
+		copy := *info
+		copy.FileName = path.Base(requested)
+		copy.FilePath = requested
+		return &copy, nil
+	}
+
+	info, err := a.FileSystem.Stat(canonical)
+	if err == nil {
+		return info, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) && a.hasAliasDescendant(canonical) {
+		return &vfs.FileInfo{FileName: path.Base(canonical), FilePath: canonical, Dir: true}, nil
+	}
+	return nil, err
+}
+
+func (a *aliasFS) ReadDir(p string) ([]vfs.FileInfo, error) {
+	clean := vfs.CleanPath(p)
+	canonical, alias := a.canonical(clean)
+	if alias != nil {
+		entries, err := a.FileSystem.ReadDir(canonical)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]vfs.FileInfo, 0, len(entries))
+		for i := range entries {
+			copy := entries[i]
+			copy.FilePath = path.Join(clean, copy.FileName)
+			out = append(out, copy)
+		}
+		return out, nil
+	}
+
+	entries, err := a.FileSystem.ReadDir(clean)
+	children := a.aliasChildren(clean)
+	if err != nil && len(children) == 0 {
+		return nil, err
+	}
+	if err != nil && (!errors.Is(err, fs.ErrNotExist) || !a.hasAliasDescendant(clean)) {
+		return nil, err
+	}
+
+	seen := make(map[string]bool, len(entries)+len(children))
+	for _, entry := range entries {
+		seen[entry.FileName] = true
+	}
+	for _, child := range children {
+		if seen[child] {
+			continue
+		}
+		childPath := path.Join(clean, child)
+		entry := vfs.FileInfo{FileName: child, FilePath: childPath, Dir: true}
+		if target, ok := a.exactAliasTarget(childPath); ok {
+			info, statErr := a.FileSystem.Stat(target)
+			if statErr != nil {
+				if errors.Is(statErr, fs.ErrNotExist) {
+					continue
+				}
+				return nil, statErr
+			}
+			entry = *info
+			entry.FileName = child
+			entry.FilePath = childPath
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func (a *aliasFS) ReadFile(p string) ([]byte, error) {
+	canonical, _ := a.canonical(p)
+	return a.FileSystem.ReadFile(canonical)
+}
+
+func (a *aliasFS) hasAliasDescendant(parent string) bool {
+	parent = vfs.CleanPath(parent)
+	for _, alias := range a.aliases {
+		if parent == "/" || pathWithinRoot(parent, alias.Alias) && parent != alias.Alias {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *aliasFS) aliasChildren(parent string) []string {
+	parent = vfs.CleanPath(parent)
+	children := map[string]bool{}
+	for _, alias := range a.aliases {
+		if parent != "/" && !pathWithinRoot(parent, alias.Alias) {
+			continue
+		}
+		rel := alias.Alias[1:]
+		if parent != "/" {
+			rel = alias.Alias[len(parent)+1:]
+		}
+		if rel == "" {
+			continue
+		}
+		children[path.Base("/"+firstPathSegment(rel))] = true
+	}
+	out := make([]string, 0, len(children))
+	for child := range children {
+		out = append(out, child)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (a *aliasFS) exactAliasTarget(p string) (string, bool) {
+	clean := vfs.CleanPath(p)
+	for _, alias := range a.aliases {
+		if alias.Alias == clean {
+			return alias.Target, true
+		}
+	}
+	return "", false
+}
+
+func firstPathSegment(p string) string {
+	for i, r := range p {
+		if r == '/' {
+			return p[:i]
+		}
+	}
+	return p
+}
+
+// writableAliasFS adds canonicalized mutations when the wrapped session view
+// is writable. Read-only alias views do not advertise vfs.WritableFS.
+type writableAliasFS struct {
+	*aliasFS
+	inner vfs.WritableFS
+}
+
+func (a *writableAliasFS) WriteFileAtomic(p string, data []byte, opts vfs.WriteOpts) (string, error) {
+	canonical, _ := a.canonical(p)
+	return a.inner.WriteFileAtomic(canonical, data, opts)
+}
+
+func (a *writableAliasFS) Mkdir(p string) error {
+	canonical, _ := a.canonical(p)
+	return a.inner.Mkdir(canonical)
+}
+
+func (a *writableAliasFS) MkdirAll(p string) error {
+	canonical, _ := a.canonical(p)
+	return a.inner.MkdirAll(canonical)
+}
+
+func (a *writableAliasFS) Remove(p string) error {
+	canonical, _ := a.canonical(p)
+	return a.inner.Remove(canonical)
+}
+
+func (a *writableAliasFS) RemoveAll(p string, opts vfs.RemoveOpts) error {
+	canonical, _ := a.canonical(p)
+	opts = a.canonicalRemoveOpts(opts)
+	return a.inner.RemoveAll(canonical, opts)
+}
+
+func (a *aliasFS) canonicalRemoveOpts(opts vfs.RemoveOpts) vfs.RemoveOpts {
+	if opts.Expected == nil {
+		return opts
+	}
+	opts.Expected = copyCanonicalSnapshot(opts.Expected, a.CanonicalPath)
+	return opts
+}
+
+func copyCanonicalSnapshot(source *vfs.TreeSnapshot, canonical func(string) string) *vfs.TreeSnapshot {
+	copy := *source
+	copy.Root = canonical(copy.Root)
+	copy.Ops = append([]vfs.TreeOp(nil), source.Ops...)
+	return &copy
+}
+
+func (a *writableAliasFS) SetWriteable() error { return a.inner.SetWriteable() }
+func (a *writableAliasFS) SetReadonly() error  { return a.inner.SetReadonly() }
+
+func (a *writableAliasFS) CanWrite(p string) bool {
+	canonical, _ := a.canonical(p)
+	if scoped, ok := a.inner.(vfs.WriteScopeFS); ok {
+		return scoped.CanWrite(canonical)
+	}
+	return true
+}
+
+func (a *writableAliasFS) LastReadHash(p string) (string, bool) {
+	canonical, _ := a.canonical(p)
+	if tracker, ok := a.inner.(vfs.ReadTracker); ok {
+		return tracker.LastReadHash(canonical)
+	}
+	return "", false
+}
+
+var (
+	_ vfs.FileSystem        = (*aliasFS)(nil)
+	_ vfs.PathCanonicalizer = (*aliasFS)(nil)
+	_ vfs.WritableFS        = (*writableAliasFS)(nil)
+	_ vfs.WriteScopeFS      = (*writableAliasFS)(nil)
+	_ vfs.ReadTracker       = (*writableAliasFS)(nil)
+)

--- a/pkg/openlore/alias_fs_test.go
+++ b/pkg/openlore/alias_fs_test.go
@@ -1,0 +1,255 @@
+package openlore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/shell"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+func TestAliasFS_ReadsListsAndWritesCanonicalStorage(t *testing.T) {
+	root := t.TempDir()
+	canonicalDir := filepath.Join(root, "agent", "jared")
+	if err := os.MkdirAll(canonicalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonicalDir, "note.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := NewDirFS(root, config.FilesConfig{})
+	if err := dir.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	fsys := newAliasFS(dir, []pathAlias{{Alias: "/jared", Target: "/agent/jared"}})
+
+	data, err := fsys.ReadFile("/jared/note.md")
+	if err != nil || string(data) != "hello" {
+		t.Fatalf("alias read = %q, %v", data, err)
+	}
+	entries, err := fsys.ReadDir("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		seen[entry.FileName] = true
+	}
+	if !seen["agent"] || !seen["jared"] {
+		t.Fatalf("root listing should expose canonical parent and alias: %+v", entries)
+	}
+	info, err := fsys.Stat("/jared")
+	if err != nil || info.FileName != "jared" || info.FilePath != "/jared" {
+		t.Fatalf("alias stat = %+v, %v", info, err)
+	}
+
+	writable := fsys.(vfs.WritableFS)
+	if _, err := writable.WriteFileAtomic("/jared/new.md", []byte("new"), vfs.WriteOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(canonicalDir, "new.md"))
+	if err != nil || string(got) != "new" {
+		t.Fatalf("canonical file after alias write = %q, %v", got, err)
+	}
+}
+
+func TestAliasFS_SynthesizesNestedAliasAncestors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "channel", "general"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fsys := newAliasFS(NewDirFS(root, config.FilesConfig{}), []pathAlias{
+		{Alias: "/legacy/shared/knowledge", Target: "/channel/general"},
+	})
+
+	for _, p := range []string{"/legacy", "/legacy/shared", "/legacy/shared/knowledge"} {
+		info, err := fsys.Stat(p)
+		if err != nil || !info.Dir {
+			t.Fatalf("Stat(%q) = %+v, %v", p, info, err)
+		}
+	}
+	entries, err := fsys.ReadDir("/legacy")
+	if err != nil || len(entries) != 1 || entries[0].FileName != "shared" {
+		t.Fatalf("ReadDir(/legacy) = %+v, %v", entries, err)
+	}
+}
+
+func TestServerAliasCanonicalizesAuthorizationAndChangesets(t *testing.T) {
+	s := grantTestServer()
+	ds := s.auth.Docsets["alfie"]
+	ds.Paths = []config.PathMapping{{Source: "/user/alfie", Display: "/user/alfie"}}
+	ds.Aliases = []string{"/alfie"}
+	s.auth.Docsets["alfie"] = ds
+
+	id := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeFull}}
+	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/note.md") {
+		t.Fatal("alias path should authorize through its canonical docset")
+	}
+	if got := s.canonicalPath("/alfie/note.md"); got != "/user/alfie/note.md" {
+		t.Fatalf("canonicalPath = %q", got)
+	}
+}
+
+func TestAliasFS_CanonicalizesMiddlewarePaths(t *testing.T) {
+	root := t.TempDir()
+	canonicalDir := filepath.Join(root, "channel", "general")
+	if err := os.MkdirAll(canonicalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonicalDir, "note.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := NewDirFS(root, config.FilesConfig{})
+
+	var readPath string
+	readView := newReadChainFS(base, Actor{}, func(_ context.Context, op ReadOp) error {
+		readPath = op.Path
+		return nil
+	})
+	readAlias := newAliasFS(readView, []pathAlias{{Alias: "/knowledge", Target: "/channel/general"}})
+	if _, err := readAlias.ReadFile("/knowledge/note.md"); err != nil {
+		t.Fatal(err)
+	}
+	if readPath != "/channel/general/note.md" {
+		t.Fatalf("read middleware path = %q", readPath)
+	}
+
+	var changePath string
+	writeView := newMiddlewareFS(base, Actor{}, func(_ context.Context, op WriteOp) (WriteResult, error) {
+		changePath = op.ChangeSet.Target
+		return WriteResult{}, nil
+	})
+	writeAlias := newAliasFS(writeView, []pathAlias{{Alias: "/knowledge", Target: "/channel/general"}})
+	if _, err := writeAlias.(vfs.WritableFS).WriteFileAtomic("/knowledge/note.md", []byte("updated"), vfs.WriteOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	if changePath != "/channel/general/note.md" {
+		t.Fatalf("changeset target = %q", changePath)
+	}
+}
+
+func TestAliasFS_MoveAliasOntoCanonicalPathIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	canonicalDir := filepath.Join(root, "agent", "jared")
+	if err := os.MkdirAll(canonicalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(canonicalDir, "note.md")
+	if err := os.WriteFile(file, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := NewDirFS(root, config.FilesConfig{}).WithDocsetRoots([]string{"/agent/jared"})
+	if err := dir.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	sh := shell.NewShell(newAliasFS(dir, []pathAlias{{Alias: "/jared", Target: "/agent/jared"}}))
+	var out, errOut bytes.Buffer
+	if code := sh.ExecPipeline("mv /jared/note.md /agent/jared/note.md", &out, &errOut, nil); code != 0 {
+		t.Fatalf("mv exit = %d, stderr = %q", code, errOut.String())
+	}
+	data, err := os.ReadFile(file)
+	if err != nil || string(data) != "keep" {
+		t.Fatalf("same-file move removed content: %q, %v", data, err)
+	}
+}
+
+type failingReadFS struct{ err error }
+
+func (f failingReadFS) Stat(string) (*vfs.FileInfo, error)     { return nil, f.err }
+func (f failingReadFS) ReadDir(string) ([]vfs.FileInfo, error) { return nil, f.err }
+func (f failingReadFS) ReadFile(string) ([]byte, error)        { return nil, f.err }
+
+func TestAliasFS_DoesNotHideReadErrorsWithSyntheticAncestors(t *testing.T) {
+	want := errors.New("read middleware denied")
+	fsys := newAliasFS(failingReadFS{err: want}, []pathAlias{{Alias: "/legacy/shared", Target: "/channel/general"}})
+	if _, err := fsys.Stat("/legacy"); !errors.Is(err, want) {
+		t.Fatalf("Stat error = %v, want %v", err, want)
+	}
+	if _, err := fsys.ReadDir("/legacy"); !errors.Is(err, want) {
+		t.Fatalf("ReadDir error = %v, want %v", err, want)
+	}
+}
+
+func TestAliasFS_RewritesNamedMountFileInfoAndPreservesFileType(t *testing.T) {
+	docs := t.TempDir()
+	if err := os.WriteFile(filepath.Join(docs, "readme.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(docs, "folder"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(docs, "folder", "note.md"), []byte("note"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	merge := NewMergeFS()
+	merge.Mount("docs", NewDirFS(docs, config.FilesConfig{}))
+	fsys := newAliasFS(merge, []pathAlias{
+		{Alias: "/readme", Target: "/docs/readme.md"},
+		{Alias: "/legacy", Target: "/docs/folder"},
+	})
+
+	entries, err := fsys.ReadDir("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]vfs.FileInfo{}
+	for _, entry := range entries {
+		byName[entry.FileName] = entry
+	}
+	if entry := byName["readme"]; entry.Dir || entry.FilePath != "/readme" {
+		t.Fatalf("file alias entry = %+v", entry)
+	}
+	children, err := fsys.ReadDir("/legacy")
+	if err != nil || len(children) != 1 || children[0].FilePath != "/legacy/note.md" {
+		t.Fatalf("named-mount alias listing = %+v, %v", children, err)
+	}
+}
+
+func TestAliasFS_CanonicalizesRemoveSnapshotWithoutMutatingCaller(t *testing.T) {
+	snapshot := &vfs.TreeSnapshot{Root: "/knowledge/old", Ops: []vfs.TreeOp{{RelPath: ".", Kind: "dir"}}}
+	var got vfs.ChangeSet
+	writeView := newMiddlewareFS(failingReadFS{err: os.ErrNotExist}, Actor{}, func(_ context.Context, op WriteOp) (WriteResult, error) {
+		got = op.ChangeSet
+		return WriteResult{}, nil
+	})
+	fsys := newAliasFS(writeView, []pathAlias{{Alias: "/knowledge", Target: "/channel/general"}})
+	err := fsys.(vfs.WritableFS).RemoveAll("/knowledge/old", vfs.RemoveOpts{Expected: snapshot})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Target != "/channel/general/old" || got.RemoveAll.Opts.Expected.Root != "/channel/general/old" {
+		t.Fatalf("canonical remove changeset = %+v", got)
+	}
+	if snapshot.Root != "/knowledge/old" {
+		t.Fatalf("caller snapshot mutated to %q", snapshot.Root)
+	}
+	snapshot.Ops[0].Kind = "file"
+	if got.RemoveAll.Opts.Expected.Ops[0].Kind != "dir" {
+		t.Fatal("canonical changeset shares the caller's snapshot operations")
+	}
+}
+
+func TestServerCanonicalChangeSetCopiesRemoveSnapshot(t *testing.T) {
+	s := grantTestServer()
+	ds := s.auth.Docsets["alfie"]
+	ds.Paths = []config.PathMapping{{Source: "/user/alfie"}}
+	ds.Aliases = []string{"/alfie"}
+	s.auth.Docsets["alfie"] = ds
+	snapshot := &vfs.TreeSnapshot{Root: "/alfie/old", Ops: []vfs.TreeOp{{RelPath: ".", Kind: "dir"}}}
+	remove := &vfs.RemoveAllChange{Opts: vfs.RemoveOpts{Expected: snapshot}}
+
+	got := s.canonicalChangeSet(vfs.ChangeSet{Target: "/alfie/old", Action: vfs.ChangeActionRemoveAll, RemoveAll: remove})
+	snapshot.Ops[0].Kind = "file"
+	if got.Target != "/user/alfie/old" || got.RemoveAll.Opts.Expected.Root != "/user/alfie/old" {
+		t.Fatalf("canonical changeset = %+v", got)
+	}
+	if got.RemoveAll.Opts.Expected.Ops[0].Kind != "dir" {
+		t.Fatal("canonical changeset shares the caller's snapshot operations")
+	}
+}

--- a/pkg/openlore/authz.go
+++ b/pkg/openlore/authz.go
@@ -51,6 +51,54 @@ func (s *Server) validateGrants() error {
 			owner[root] = name
 		}
 	}
+	// Aliases are rewritten before authorization. Reject ambiguous namespace
+	// shapes so no alias can shadow or bypass another docset boundary.
+	type rootSpec struct {
+		docset string
+		path   string
+		alias  bool
+	}
+	var roots []rootSpec
+	for name, ds := range s.auth.Docsets {
+		for _, pm := range ds.Paths {
+			roots = append(roots, rootSpec{docset: name, path: displayPath(pm)})
+		}
+		if len(ds.Aliases) > 0 && len(ds.Paths) == 0 {
+			return fmt.Errorf("auth config: docset %q declares aliases without a canonical path", name)
+		}
+		for _, raw := range ds.Aliases {
+			if !strings.HasPrefix(raw, "/") {
+				return fmt.Errorf("auth config: docset %q alias %q must be absolute", name, raw)
+			}
+			clean := vfs.CleanPath(raw)
+			if clean != raw {
+				return fmt.Errorf("auth config: docset %q alias %q must be normalized as %q", name, raw, clean)
+			}
+			roots = append(roots, rootSpec{docset: name, path: clean, alias: true})
+		}
+	}
+	if s.merge != nil {
+		for _, mount := range s.merge.mountPaths() {
+			roots = append(roots, rootSpec{docset: "<mount>", path: mount})
+		}
+	}
+	for i, candidate := range roots {
+		if !candidate.alias {
+			continue
+		}
+		for j, other := range roots {
+			if i == j {
+				continue
+			}
+			if pathWithinRoot(candidate.path, other.path) || pathWithinRoot(other.path, candidate.path) {
+				kind := "canonical path"
+				if other.alias {
+					kind = "alias"
+				}
+				return fmt.Errorf("auth config: docset %q alias %q overlaps docset %q %s %q", candidate.docset, candidate.path, other.docset, kind, other.path)
+			}
+		}
+	}
 	return nil
 }
 
@@ -64,6 +112,58 @@ func displayPath(pm config.PathMapping) string {
 	return vfs.CleanPath(d)
 }
 
+func primaryDisplayPath(ds config.DocsetSpec) string {
+	if len(ds.Paths) == 0 {
+		return ""
+	}
+	return displayPath(ds.Paths[0])
+}
+
+// canonicalPath resolves aliases across all configured docsets. Validation
+// rejects overlaps, but longest-prefix selection keeps this helper deterministic
+// before startup validation and for direct library use.
+func (s *Server) canonicalPath(p string) string {
+	clean := vfs.CleanPath(p)
+	bestAlias := ""
+	bestTarget := ""
+	for _, ds := range s.auth.Docsets {
+		target := primaryDisplayPath(ds)
+		for _, raw := range ds.Aliases {
+			alias := vfs.CleanPath(raw)
+			if pathWithinRoot(alias, clean) && len(alias) > len(bestAlias) {
+				bestAlias = alias
+				bestTarget = target
+			}
+		}
+	}
+	if bestAlias == "" {
+		return clean
+	}
+	return replacePathRoot(clean, bestAlias, bestTarget)
+}
+
+func (s *Server) aliasesForIdentity(id Identity) []pathAlias {
+	var aliases []pathAlias
+	for name, grantName := range id.Grants {
+		ds, ok := s.auth.Docsets[name]
+		if !ok {
+			continue
+		}
+		grant, ok := s.grants.get(grantName)
+		if !ok {
+			continue
+		}
+		target := primaryDisplayPath(ds)
+		if target == "" || !grant.CanRead(ds, target) {
+			continue
+		}
+		for _, alias := range ds.Aliases {
+			aliases = append(aliases, pathAlias{Alias: alias, Target: target})
+		}
+	}
+	return aliases
+}
+
 // mostSpecificDocset resolves the single docset that governs display path p: the
 // one whose display root is the longest prefix of p, across ALL configured
 // docsets (not just the ones an identity holds a grant on). Every docset is an
@@ -72,7 +172,7 @@ func displayPath(pm config.PathMapping) string {
 // reaches into a nested docset. Ties on root length are broken by docset name
 // for determinism (overlapping identical roots are an ambiguous config).
 func (s *Server) mostSpecificDocset(p string) (string, config.DocsetSpec, bool) {
-	clean := vfs.CleanPath(p)
+	clean := s.canonicalPath(p)
 	bestLen := -1
 	bestName := ""
 	var bestDS config.DocsetSpec
@@ -140,6 +240,7 @@ func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string
 	if !scopeGrantsWrite(id.Scopes) {
 		return false // token scope ceiling: only full authority may write
 	}
+	p = s.canonicalPath(p)
 	ds, grant, ok := s.grantForPath(id, p)
 	if !ok {
 		return false

--- a/pkg/openlore/authz_test.go
+++ b/pkg/openlore/authz_test.go
@@ -127,6 +127,77 @@ func TestValidateGrants_RejectsDuplicateDisplayRoots(t *testing.T) {
 	}
 }
 
+func TestValidateGrants_Aliases(t *testing.T) {
+	tests := []struct {
+		name    string
+		docsets map[string]config.DocsetSpec
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			docsets: map[string]config.DocsetSpec{
+				"jared": {Paths: []config.PathMapping{{Source: "/agent/jared"}}, Aliases: []string{"/jared"}},
+				"adil":  {Paths: []config.PathMapping{{Source: "/user/adil"}}, Aliases: []string{"/adil"}},
+			},
+		},
+		{
+			name:    "without canonical path",
+			docsets: map[string]config.DocsetSpec{"jared": {Aliases: []string{"/jared"}}},
+			wantErr: true,
+		},
+		{
+			name:    "relative",
+			docsets: map[string]config.DocsetSpec{"jared": {Paths: []config.PathMapping{{Source: "/agent/jared"}}, Aliases: []string{"jared"}}},
+			wantErr: true,
+		},
+		{
+			name: "overlapping canonical path",
+			docsets: map[string]config.DocsetSpec{
+				"jared": {Paths: []config.PathMapping{{Source: "/agent/jared"}}, Aliases: []string{"/legacy"}},
+				"other": {Paths: []config.PathMapping{{Source: "/legacy/private"}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "overlapping aliases",
+			docsets: map[string]config.DocsetSpec{
+				"jared": {Paths: []config.PathMapping{{Source: "/agent/jared"}}, Aliases: []string{"/legacy"}},
+				"other": {Paths: []config.PathMapping{{Source: "/agent/other"}}, Aliases: []string{"/legacy/private"}},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{authEnforced: true, grants: newGrantRegistry(), auth: &config.AuthConfig{Docsets: tt.docsets}}
+			err := s.validateGrants()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateGrants() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateGrants_RejectsAliasOverlappingMount(t *testing.T) {
+	for _, alias := range []string{"/jobs", "/jobs/private"} {
+		t.Run(alias, func(t *testing.T) {
+			merge := NewMergeFS()
+			merge.MountSystem("jobs", NewFSAdapter(fstest.MapFS{"status": {Data: []byte("ok")}}))
+			s := &Server{
+				authEnforced: true,
+				grants:       newGrantRegistry(),
+				merge:        merge,
+				auth: &config.AuthConfig{Docsets: map[string]config.DocsetSpec{
+					"jared": {Paths: []config.PathMapping{{Source: "/agent/jared"}}, Aliases: []string{alias}},
+				}},
+			}
+			if err := s.validateGrants(); err == nil {
+				t.Fatalf("expected alias %q to conflict with /jobs mount", alias)
+			}
+		})
+	}
+}
+
 // TestSessionPublishTargets_ResolvesInboxPath pins that a publish target
 // carries the docset's resolved inbox path (not just its name), so `publish`
 // routes into /docset/inbox/... where the publish grant actually permits writes.

--- a/pkg/openlore/docsets_test.go
+++ b/pkg/openlore/docsets_test.go
@@ -31,8 +31,9 @@ func enforcedDocsetServer() *Server {
 					Readonly: boolPtr(true),
 				},
 				"home": {
-					Paths: []config.PathMapping{{Source: "/home/agent", Display: "/home/agent"}},
-					Inbox: "inbox",
+					Paths:   []config.PathMapping{{Source: "/home/agent", Display: "/home/agent"}},
+					Aliases: []string{"/agent"},
+					Inbox:   "inbox",
 				},
 			},
 		},
@@ -65,7 +66,7 @@ func TestSessionDocsets_Enforced(t *testing.T) {
 	got := s.sessionDocsets(agentIdentity())
 
 	// Sorted by name.
-	wantOrder := []string{"archive", "backend", "home", "public"}
+	wantOrder := []string{"archive", "backend", "home", "home", "public"}
 	if len(got) != len(wantOrder) {
 		t.Fatalf("got %d docsets, want %d: %+v", len(got), len(wantOrder), got)
 	}
@@ -105,6 +106,10 @@ func TestSessionDocsets_Enforced(t *testing.T) {
 	}
 	if !home.Writable {
 		t.Fatalf("home should be writable")
+	}
+	alias := got[3]
+	if alias.Paths[0] != "/agent" || alias.AliasTarget != "/home/agent" || alias.Home || alias.Inbox {
+		t.Fatalf("home alias row = %+v", alias)
 	}
 }
 

--- a/pkg/openlore/read_tracking_fs.go
+++ b/pkg/openlore/read_tracking_fs.go
@@ -19,9 +19,9 @@ import (
 // last-read hash no longer matches. A successful write updates the tracked hash
 // so a caller can write the same file repeatedly after a single read.
 //
-// It sits outside scopedWriteFS so it observes all reads and all
-// writes, and forwards the optional scope introspection (vfs.WriteScopeFS) used
-// by `spawn` fail-fast checks.
+// It sits outside scopedWriteFS so it observes all reads and all writes, but
+// inside aliasFS so aliases share canonical CAS state. It forwards the optional
+// scope introspection (vfs.WriteScopeFS) used by `spawn` fail-fast checks.
 type readTrackingFS struct {
 	vfs.WritableFS // read/write delegation (Stat, ReadDir, SetWriteable, Mkdir, …)
 

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -497,7 +497,7 @@ func (s *Server) writeConflictPolicy(p string) vfs.WriteConflictPolicy {
 	if global == "" {
 		global = vfs.DefaultWriteConflictPolicy
 	}
-	clean := vfs.CleanPath(p)
+	clean := s.canonicalPath(p)
 	for _, ds := range s.auth.Docsets {
 		if ds.WriteConflictPolicy == "" {
 			continue
@@ -633,8 +633,19 @@ func (s *Server) CommitChangeSet(ctx context.Context, actor Actor, cs vfs.Change
 	if s.writeLog == nil {
 		return WriteResult{}, vfs.ErrReadOnly
 	}
+	cs = s.canonicalChangeSet(cs)
 	h, err := s.writeLog.Submit(ctx, actor, cs)
 	return WriteResult{Hash: h}, err
+}
+
+func (s *Server) canonicalChangeSet(cs vfs.ChangeSet) vfs.ChangeSet {
+	cs.Target = s.canonicalPath(cs.Target)
+	if cs.RemoveAll != nil && cs.RemoveAll.Opts.Expected != nil {
+		remove := *cs.RemoveAll
+		remove.Opts.Expected = copyCanonicalSnapshot(remove.Opts.Expected, s.canonicalPath)
+		cs.RemoveAll = &remove
+	}
+	return cs
 }
 
 // registerPlugin wires any middleware a plugin provides into the admission,
@@ -780,12 +791,19 @@ func (s *Server) buildSessionFS(id Identity) vfs.FileSystem {
 	// Session CAS: track the hash of every file read (and written) so a
 	// later blind overwrite compare-and-swaps against the version the
 	// caller last saw, without naming a hash — an overwrite fails if the
-	// file changed since it was read. Outermost so it observes all reads;
-	// only meaningful (and only added) when the substrate is writable.
+	// file changed since it was read. Outside policy layers so it observes all
+	// reads, but inside aliasing so both paths share canonical CAS state. Only
+	// meaningful (and only added) when the substrate is writable.
 	if !s.config.Readonly {
 		if w, ok := sessionFS.(vfs.WritableFS); ok {
 			sessionFS = newReadTrackingFS(w)
 		}
+	}
+	// Expose this identity's aliases outermost so callers can retain the alias
+	// spelling while every internal operation, including CAS tracking, sees the
+	// canonical path. Ungranted aliases are never added to the session tree.
+	if aliases := s.aliasesForIdentity(id); len(aliases) > 0 {
+		sessionFS = newAliasFS(sessionFS, aliases)
 	}
 	return sessionFS
 }
@@ -852,9 +870,10 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 	return sh
 }
 
-// sessionDocsets resolves the docsets this session can access, with their
-// display paths, grant, and attributes — the per-session view surfaced by
-// `lore docsets`.
+// sessionDocsets resolves one row per accessible canonical or alias mount. A
+// docset's canonical paths are emitted first, followed by aliases targeting its
+// first path; `lore docsets` preserves this order for older consumers that use
+// the first row as the docset's mount.
 func (s *Server) sessionDocsets(id Identity) []cmds.DocsetInfo {
 	if len(id.Grants) == 0 {
 		return nil
@@ -866,20 +885,28 @@ func (s *Server) sessionDocsets(id Identity) []cmds.DocsetInfo {
 		if !ok {
 			continue
 		}
-		var paths []string
-		for _, pm := range ds.Paths {
-			paths = append(paths, displayPath(pm))
+		for i, pm := range ds.Paths {
+			out = append(out, cmds.DocsetInfo{
+				Name:     name,
+				Paths:    []string{displayPath(pm)},
+				Grant:    grantName,
+				Writable: writable[name],
+				Home:     i == 0 && name == id.HomeDocset,
+				Inbox:    inboxPath(ds) != "",
+			})
 		}
-		out = append(out, cmds.DocsetInfo{
-			Name:     name,
-			Paths:    paths,
-			Grant:    grantName,
-			Writable: writable[name],
-			Home:     name == id.HomeDocset,
-			Inbox:    inboxPath(ds) != "",
-		})
+		target := primaryDisplayPath(ds)
+		for _, alias := range ds.Aliases {
+			out = append(out, cmds.DocsetInfo{
+				Name:        name,
+				Paths:       []string{vfs.CleanPath(alias)},
+				AliasTarget: target,
+				Grant:       grantName,
+				Writable:    writable[name],
+			})
+		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -646,6 +646,16 @@ func (m *MergeFS) SystemMountPaths() []string {
 	return out
 }
 
+// mountPaths returns every named mount root, including control-plane mounts.
+// Alias validation uses it to prevent aliases from shadowing mounted backends.
+func (m *MergeFS) mountPaths() []string {
+	var out []string
+	for name := range m.mounts {
+		out = append(out, "/"+name)
+	}
+	return out
+}
+
 // SetWriteable fans out to every writable-capable backend (root + mounts).
 // Read-only backends (EmbedFS, FSAdapter) are skipped. It fails fast if no
 // backend can be made writable at all (e.g. a fully embedded, read-only

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -49,8 +49,12 @@ type CmdContext interface {
 type DocsetInfo struct {
 	// Name is the docset's logical name (its key in the auth config).
 	Name string
-	// Paths are the docset's display (virtual) paths in the filesystem.
+	// Paths contains the single display path represented by this row. It remains
+	// a slice so existing command consumers can parse canonical rows unchanged.
 	Paths []string
+	// AliasTarget is the canonical display path when this row represents an
+	// alias. Empty means the row is canonical.
+	AliasTarget string
 	// Grant is the grant name the session holds on this docset (ro/rw/publish).
 	Grant string
 	// Writable reports whether this session may write to the docset directly

--- a/pkg/shell/cmds/lore.go
+++ b/pkg/shell/cmds/lore.go
@@ -79,12 +79,12 @@ func init() {
 }
 
 // cmdLoreDocsets prints an aligned, greppable table of the session's accessible
-// docsets: name, direct access (r/rw), attribute tokens (home,publish),
-// and display paths.
+// docset mounts: name, grant, attribute tokens, display path, and canonical
+// target for alias rows.
 func cmdLoreDocsets(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	docsets := ctx.Docsets()
 
-	rows := [][4]string{{"DOCSET", "GRANT", "ATTRIBUTES", "PATHS"}}
+	rows := [][5]string{{"DOCSET", "GRANT", "ATTRIBUTES", "PATH", "TARGET"}}
 	for _, d := range docsets {
 		grant := d.Grant
 		if grant == "" {
@@ -97,15 +97,22 @@ func cmdLoreDocsets(ctx CmdContext, args []string, w io.Writer, errW io.Writer, 
 		if d.Inbox {
 			attrs = append(attrs, "inbox")
 		}
+		if d.AliasTarget != "" {
+			attrs = append(attrs, "alias")
+		}
 		attrStr := "-"
 		if len(attrs) > 0 {
 			attrStr = strings.Join(attrs, ",")
 		}
-		rows = append(rows, [4]string{d.Name, grant, attrStr, strings.Join(d.Paths, ",")})
+		target := d.AliasTarget
+		if target == "" {
+			target = "-"
+		}
+		rows = append(rows, [5]string{d.Name, grant, attrStr, strings.Join(d.Paths, ","), target})
 	}
 
 	// Column widths from every cell except the last column (which is ragged).
-	var w0, w1, w2 int
+	var w0, w1, w2, w3 int
 	for _, r := range rows {
 		if len(r[0]) > w0 {
 			w0 = len(r[0])
@@ -116,9 +123,12 @@ func cmdLoreDocsets(ctx CmdContext, args []string, w io.Writer, errW io.Writer, 
 		if len(r[2]) > w2 {
 			w2 = len(r[2])
 		}
+		if len(r[3]) > w3 {
+			w3 = len(r[3])
+		}
 	}
 	for _, r := range rows {
-		fmt.Fprintf(w, "%-*s  %-*s  %-*s  %s\n", w0, r[0], w1, r[1], w2, r[2], r[3])
+		fmt.Fprintf(w, "%-*s  %-*s  %-*s  %-*s  %s\n", w0, r[0], w1, r[1], w2, r[2], w3, r[3], r[4])
 	}
 	return 0
 }

--- a/pkg/shell/cmds/lore_test.go
+++ b/pkg/shell/cmds/lore_test.go
@@ -44,7 +44,8 @@ func TestLore_UnknownSubcommandExitsOne(t *testing.T) {
 
 func TestLoreDocsets_Table(t *testing.T) {
 	docsets := []cmds.DocsetInfo{
-		{Name: "public", Paths: []string{"/docs/public", "/docs/getting-started.md"}, Grant: "ro"},
+		{Name: "public", Paths: []string{"/docs/public"}, Grant: "ro"},
+		{Name: "public", Paths: []string{"/public"}, AliasTarget: "/docs/public", Grant: "ro"},
 		{Name: "backend", Paths: []string{"/docs/backend", "/docs/api"}, Grant: "rw", Writable: true},
 		{Name: "home", Paths: []string{"/home/backend"}, Grant: "rw", Writable: true, Home: true, Inbox: true},
 	}
@@ -53,26 +54,24 @@ func TestLoreDocsets_Table(t *testing.T) {
 		t.Fatalf("lore docsets exit = %d, want 0", code)
 	}
 	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
-	if len(lines) != 4 {
-		t.Fatalf("want header + 3 rows, got %d lines:\n%s", len(lines), out)
+	if len(lines) != 5 {
+		t.Fatalf("want header + 4 rows, got %d lines:\n%s", len(lines), out)
 	}
 	if !strings.HasPrefix(lines[0], "DOCSET") {
 		t.Fatalf("first line should be header, got %q", lines[0])
 	}
 	// Fields are grep/field-splittable.
-	assertRow := func(line, name, access, attrs, paths string) {
+	assertRow := func(line, name, access, attrs, mount, target string) {
 		t.Helper()
 		f := strings.Fields(line)
-		if f[0] != name || f[1] != access || f[2] != attrs {
-			t.Fatalf("row %q: got name=%q access=%q attrs=%q; want %q %q %q", line, f[0], f[1], f[2], name, access, attrs)
-		}
-		if !strings.HasSuffix(strings.TrimRight(line, " "), paths) {
-			t.Fatalf("row %q: paths should end with %q", line, paths)
+		if len(f) != 5 || f[0] != name || f[1] != access || f[2] != attrs || f[3] != mount || f[4] != target {
+			t.Fatalf("row %q: got %v; want %q %q %q %q %q", line, f, name, access, attrs, mount, target)
 		}
 	}
-	assertRow(lines[1], "public", "ro", "-", "/docs/public,/docs/getting-started.md")
-	assertRow(lines[2], "backend", "rw", "-", "/docs/backend,/docs/api")
-	assertRow(lines[3], "home", "rw", "home,inbox", "/home/backend")
+	assertRow(lines[1], "public", "ro", "-", "/docs/public", "-")
+	assertRow(lines[2], "public", "ro", "alias", "/public", "/docs/public")
+	assertRow(lines[3], "backend", "rw", "-", "/docs/backend,/docs/api", "-")
+	assertRow(lines[4], "home", "rw", "home,inbox", "/home/backend", "-")
 }
 
 func TestLoreDocsets_EmptyShowsHeaderOnly(t *testing.T) {
@@ -80,7 +79,7 @@ func TestLoreDocsets_EmptyShowsHeaderOnly(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if strings.TrimRight(out, "\n") != "DOCSET  GRANT  ATTRIBUTES  PATHS" {
+	if strings.TrimRight(out, "\n") != "DOCSET  GRANT  ATTRIBUTES  PATH  TARGET" {
 		t.Fatalf("empty docsets should print header only, got:\n%q", out)
 	}
 }

--- a/pkg/shell/cmds/mv.go
+++ b/pkg/shell/cmds/mv.go
@@ -55,7 +55,12 @@ func CmdMv(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.
 	if destinationInfo, statErr := ctx.FS().Stat(ctx.Resolve(destination)); statErr == nil && destinationInfo.Dir {
 		destination = path.Join(destination, path.Base(resolvedSource))
 	}
-	if resolvedSource == ctx.Resolve(destination) {
+	resolvedDestination := ctx.Resolve(destination)
+	if canonicalizer, ok := ctx.FS().(vfs.PathCanonicalizer); ok {
+		resolvedSource = canonicalizer.CanonicalPath(resolvedSource)
+		resolvedDestination = canonicalizer.CanonicalPath(resolvedDestination)
+	}
+	if resolvedSource == resolvedDestination {
 		return 0
 	}
 

--- a/pkg/vfs/vfs.go
+++ b/pkg/vfs/vfs.go
@@ -202,6 +202,13 @@ type WriteScopeFS interface {
 	CanWrite(path string) bool
 }
 
+// PathCanonicalizer is optionally implemented by filesystems that expose more
+// than one virtual path for the same file. Commands use it when path identity
+// matters, such as avoiding a move from an alias onto its canonical path.
+type PathCanonicalizer interface {
+	CanonicalPath(path string) string
+}
+
 // ReadTracker is optionally implemented by a session filesystem that remembers
 // the content hash of every file read during the session. It lets the write
 // seam compare-and-swap a whole-file overwrite against the version the caller


### PR DESCRIPTION
## Summary

- add durable `aliases` to docsets, with aliases mirroring the first canonical path
- expose aliases in each authorized session while canonicalizing authorization, hooks, changesets, events, storage, and CAS state
- reject aliases that overlap canonical paths, other aliases, or named/system mounts
- report one `lore docsets` row per mount, with alias rows pointing at their canonical target
- make `mv` treat alias/canonical spellings of the same file as a no-op

## Example

```json
{
  \"docsets\": {
    \"jared\": {
      \"paths\": [\"/agent/jared\"],
      \"aliases\": [\"/jared\"]
    }
  }
}
```

Both `/agent/jared/notes.md` and `/jared/notes.md` access the same file. `$HOME`, policy, middleware, and emitted changes use `/agent/jared`.

## Validation

- `go test ./...`
- `git diff --check`