### PR TITLE
fix: allow aliases beneath canonical ancestors

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,9 @@ Both `/agent/jared/notes.md` and `/jared/notes.md` access the same file. Shell
 navigation preserves the path the caller used, but authorization, approvals,
 changesets, hooks, events, inboxes, and `$HOME` use `/agent/jared` as the
 canonical identity. Aliases must be absolute, normalized, and must not overlap
-another canonical path or alias.
+another alias, mount, or canonical path at or beneath the alias. A broad
+canonical ancestor such as `/` may contain an alias because alias requests are
+rewritten to their canonical target before authorization.
 
 ### Home Directory
 

--- a/pkg/openlore/authz.go
+++ b/pkg/openlore/authz.go
@@ -57,6 +57,7 @@ func (s *Server) validateGrants() error {
 		docset string
 		path   string
 		alias  bool
+		mount  bool
 	}
 	var roots []rootSpec
 	for name, ds := range s.auth.Docsets {
@@ -79,7 +80,7 @@ func (s *Server) validateGrants() error {
 	}
 	if s.merge != nil {
 		for _, mount := range s.merge.mountPaths() {
-			roots = append(roots, rootSpec{docset: "<mount>", path: mount})
+			roots = append(roots, rootSpec{docset: "<mount>", path: mount, mount: true})
 		}
 	}
 	for i, candidate := range roots {
@@ -90,13 +91,25 @@ func (s *Server) validateGrants() error {
 			if i == j {
 				continue
 			}
-			if pathWithinRoot(candidate.path, other.path) || pathWithinRoot(other.path, candidate.path) {
-				kind := "canonical path"
-				if other.alias {
-					kind = "alias"
-				}
-				return fmt.Errorf("auth config: docset %q alias %q overlaps docset %q %s %q", candidate.docset, candidate.path, other.docset, kind, other.path)
+			overlaps := pathWithinRoot(candidate.path, other.path) || pathWithinRoot(other.path, candidate.path)
+			if !overlaps {
+				continue
 			}
+			// A broad canonical docset may contain an alias. Alias requests are
+			// rewritten before scope and authorization, so the target's more-
+			// specific boundary still governs them. The reverse remains unsafe:
+			// an alias containing a canonical root would shadow that boundary.
+			strictCanonicalAncestor := !other.alias && !other.mount && other.path != candidate.path && pathWithinRoot(other.path, candidate.path)
+			if strictCanonicalAncestor {
+				continue
+			}
+			kind := "canonical path"
+			if other.alias {
+				kind = "alias"
+			} else if other.mount {
+				kind = "mount"
+			}
+			return fmt.Errorf("auth config: docset %q alias %q overlaps docset %q %s %q", candidate.docset, candidate.path, other.docset, kind, other.path)
 		}
 	}
 	return nil

--- a/pkg/openlore/authz_test.go
+++ b/pkg/openlore/authz_test.go
@@ -141,6 +141,13 @@ func TestValidateGrants_Aliases(t *testing.T) {
 			},
 		},
 		{
+			name: "valid beneath canonical ancestor",
+			docsets: map[string]config.DocsetSpec{
+				"openlore": {Paths: []config.PathMapping{{Source: "/"}}},
+				"jared":    {Paths: []config.PathMapping{{Source: "/agent/jared"}}, Aliases: []string{"/jared"}},
+			},
+		},
+		{
 			name:    "without canonical path",
 			docsets: map[string]config.DocsetSpec{"jared": {Aliases: []string{"/jared"}}},
 			wantErr: true,


### PR DESCRIPTION
## Summary

Production keeps the OpenLore product-doc docset at `/`, while migrated docsets need aliases such as `/jared` → `/agent/jared`. Alias requests are rewritten before authorization, so a broad canonical ancestor does not create ambiguity and the target child docset remains authoritative.

This follow-up:

- permits an alias beneath a strict canonical ancestor such as `/`
- still rejects aliases that contain or equal canonical boundaries
- still rejects alias/alias and named/system-mount overlaps in either direction

## Validation

- `go test ./...`
- focused security review: no blockers
- production dry-run reproduced the original rejection against the live config