### PR TITLE
fix: mount production docset containers

### DIFF
--- a/openlore.sh/openlore.yml
+++ b/openlore.sh/openlore.yml
@@ -57,23 +57,12 @@ tokens:
   refresh_ttl: 720h
 
 folders:
-  - name: knowledge
-    path: ./published/knowledge
-  - name: jared
-    path: ./published/jared
-  - name: claw
-    path: ./published/claw
-  - name: cor
-    path: ./published/cor
-  - name: ray
-    path: ./published/ray
-  - name: razer
-    path: ./published/razer
-  - name: miles
-    path: ./published/miles
-  - name: zeb
-    path: ./published/zeb
-  - name: adil
-    path: ./published/adil
-  - name: alfie
-    path: ./published/alfie
+  # Organizational containers are mounted once; lore.json defines the child
+  # docsets and their grants. The parent paths themselves have no docset, so
+  # direct writes to /agent, /user, or /channel remain denied.
+  - name: agent
+    path: ./published/agent
+  - name: user
+    path: ./published/user
+  - name: channel
+    path: ./published/channel


### PR DESCRIPTION
## Summary

Prepare openlore.sh for the production docset layout migration by replacing the old per-docset mounts with organizational container mounts:

- `/agent` → `published/agent`
- `/user` → `published/user`
- `/channel` → `published/channel`

`lore.json` continues to own child docsets and grants, so direct writes to the container roots remain denied.

This is required for canonical paths such as `/agent/jared` and `/channel/general`; the old embedded mounts would conflict with the compatibility aliases `/jared` and `/knowledge`.

## Validation

- workflow-equivalent linux/amd64 build with this config embedded
- `go test ./...`
- production dry-run identified the old mount collision before any data was changed