### PR TITLE
feat: overlay writable content at root

### DIFF
--- a/assets/config/openlore.yml
+++ b/assets/config/openlore.yml
@@ -9,6 +9,10 @@ default_cwd: /
 auth_file: ./lore.json
 data_dir: ./data
 
+# Disk-backed lore is overlaid at the virtual root. Its directory hierarchy is
+# the namespace; lore.json independently defines docsets and authorization.
+writable_dir: ./published
+
 # Global write lock. The substrate boots read-only by default; set false to
 # enable the experimental writable substrate so authenticated identities can
 # create/overwrite files within their writable docsets (per-identity/per-docset
@@ -55,25 +59,3 @@ tokens:
   audience: https://openlore.sh
   access_ttl: 30m
   refresh_ttl: 720h
-
-folders:
-  - name: knowledge
-    path: ./published/knowledge
-  - name: jared
-    path: ./published/jared
-  - name: claw
-    path: ./published/claw
-  - name: cor
-    path: ./published/cor
-  - name: ray
-    path: ./published/ray
-  - name: razer
-    path: ./published/razer
-  - name: miles
-    path: ./published/miles
-  - name: zeb
-    path: ./published/zeb
-  - name: adil
-    path: ./published/adil
-  - name: alfie
-    path: ./published/alfie

--- a/cmd/openlore/main.go
+++ b/cmd/openlore/main.go
@@ -119,7 +119,9 @@ func main() {
 				config.WithConfigFile(*mcpConfig),
 				config.WithEmbeddedConfig(embeddedCfg, ""),
 			}
+			var resolvedCfg config.Config
 			if cfg, err := config.New(cfgOpts...); err == nil {
+				resolvedCfg = cfg
 				if len(files.Allowed) == 0 {
 					files.Allowed = cfg.Files.Allowed
 				}
@@ -138,7 +140,13 @@ func main() {
 				}
 				vfs = openlore.NewDirFS(absDir, files)
 			} else if loreFS := assets.Lore(); loreFS != nil {
-				vfs = openlore.NewFSAdapter(loreFS)
+				lower := openlore.NewFSAdapter(loreFS)
+				if resolvedCfg.WritableDir != "" {
+					upper := openlore.NewDirFS(resolvedCfg.WritableDir, files)
+					vfs = openlore.NewOverlayFS(upper, lower)
+				} else {
+					vfs = lower
+				}
 			} else {
 				fmt.Fprintln(os.Stderr, "error: no directory specified and no embedded docs found")
 				mcpCmd.Usage()
@@ -481,8 +489,16 @@ func main() {
 		opts = append(opts, openlore.WithReadonly(*readonly))
 	}
 
-	// Create server
-	srv, err := openlore.NewServer(rootDir, opts...)
+	// Create server. Embedded docs are installed as the lower layer during
+	// construction so a configured writable_dir can be the upper layer before
+	// the ordered write log is initialized.
+	var srv *openlore.Server
+	var err error
+	if rootDir == "" && assets.Lore() != nil {
+		srv, err = openlore.NewServerWithLowerFS(assets.Lore(), opts...)
+	} else {
+		srv, err = openlore.NewServer(rootDir, opts...)
+	}
 	if err != nil {
 		slog.Error("failed to create server", "error", err)
 		os.Exit(1)
@@ -494,13 +510,6 @@ func main() {
 	srv.RegisterPlugin(openlore.NewInboxPlugin())
 
 	cmds.VersionString = assets.Version()
-
-	// Mount embedded docs if present and no directory was given on the CLI
-	if rootDir == "" {
-		if loreFS := assets.Lore(); loreFS != nil {
-			srv.SetRootFS(loreFS)
-		}
-	}
 
 	cfg := srv.Config()
 

--- a/docs/docsets-command.md
+++ b/docs/docsets-command.md
@@ -117,9 +117,6 @@ In `NewServer`, when `!authEnforced` (no auth file), populate the empty policy:
 
 ```go
 paths := []config.PathMapping{{Source: "/", Display: "/"}}
-for _, f := range cfg.Folders { // fold folder mounts in
-    paths = append(paths, config.PathMapping{Source: "/" + f.Name, Display: "/" + f.Name})
-}
 s.auth.Docsets = map[string]config.DocsetSpec{"public": {Paths: paths}}
 s.auth.Lore    = map[string][]string{"default": {"public"}}
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,9 @@ type Config struct {
 	MOTD            string
 	AuthFile        string
 	SkillsDir       string
+	// WritableDir is the disk-backed content root layered over embedded docs.
+	// Its directory hierarchy is exposed directly at the virtual root.
+	WritableDir string
 	// DataDir is the server's writable control-plane data root. Distinct from
 	// docset content. Defaults to ./.openlore.
 	DataDir         string
@@ -41,7 +44,6 @@ type Config struct {
 	CAKeysFile   string
 	HostCertFile string
 	Files        FilesConfig
-	Folders      []FolderConfig
 	Passkeys     PasskeysConfig
 	// Shellexec is the external-command middleware config (pre_read, pre_commit,
 	// post_write) run by the built-in shellexec plugin. Replaces the legacy
@@ -155,12 +157,6 @@ type FilesConfig struct {
 	Allowed []string
 	Denied  []string
 	Ignore  []string
-}
-
-// FolderConfig defines an additional named folder mount.
-type FolderConfig struct {
-	Name string
-	Path string
 }
 
 // AuthConfig is loaded from lore.json.
@@ -317,6 +313,7 @@ type fileConfig struct {
 	MOTDFile            string           `yaml:"motd_file"`
 	AuthFile            string           `yaml:"auth_file"`
 	SkillsDir           string           `yaml:"skills_dir"`
+	WritableDir         string           `yaml:"writable_dir"`
 	DataDir             string           `yaml:"data_dir"`
 	HTTPPort            int              `yaml:"http_port"`
 	ExternalSSHPort     int              `yaml:"external_ssh_port"`
@@ -328,7 +325,6 @@ type fileConfig struct {
 	HostCertFile        string           `yaml:"host_cert_file"`
 	DefaultCwd          string           `yaml:"default_cwd"`
 	Files               *filesYAML       `yaml:"files"`
-	Folders             []FolderConfig   `yaml:"folders"`
 	Passkeys            *passkeysYAML    `yaml:"passkeys"`
 	Shellexec           *ShellexecConfig `yaml:"shellexec"`
 	Readonly            *bool            `yaml:"readonly"`
@@ -458,6 +454,9 @@ func WithConfigFile(path string) Option {
 		if fc.SkillsDir != "" {
 			cfg.SkillsDir = fc.SkillsDir
 		}
+		if fc.WritableDir != "" {
+			cfg.WritableDir = fc.WritableDir
+		}
 		if fc.DataDir != "" {
 			cfg.DataDir = fc.DataDir
 		}
@@ -492,9 +491,6 @@ func WithConfigFile(path string) Option {
 			if len(fc.Files.Ignore) > 0 {
 				cfg.Files.Ignore = fc.Files.Ignore
 			}
-		}
-		if len(fc.Folders) > 0 {
-			cfg.Folders = fc.Folders
 		}
 		if fc.Shellexec != nil {
 			cfg.Shellexec = *fc.Shellexec
@@ -570,6 +566,9 @@ func WithEmbeddedConfig(data []byte, motdFallback string) Option {
 			if fc.SkillsDir != "" {
 				cfg.SkillsDir = fc.SkillsDir
 			}
+			if fc.WritableDir != "" {
+				cfg.WritableDir = fc.WritableDir
+			}
 			if fc.DataDir != "" {
 				cfg.DataDir = fc.DataDir
 			}
@@ -604,9 +603,6 @@ func WithEmbeddedConfig(data []byte, motdFallback string) Option {
 				if len(fc.Files.Ignore) > 0 {
 					cfg.Files.Ignore = fc.Files.Ignore
 				}
-			}
-			if len(fc.Folders) > 0 {
-				cfg.Folders = fc.Folders
 			}
 			if fc.Shellexec != nil {
 				cfg.Shellexec = *fc.Shellexec
@@ -742,6 +738,14 @@ func WithSkillsDir(dir string) Option {
 func WithDataDir(dir string) Option {
 	return func(cfg *Config) error {
 		cfg.DataDir = dir
+		return nil
+	}
+}
+
+// WithWritableDir sets the disk-backed content root layered over embedded docs.
+func WithWritableDir(dir string) Option {
+	return func(cfg *Config) error {
+		cfg.WritableDir = dir
 		return nil
 	}
 }

--- a/internal/config/writable_dir_test.go
+++ b/internal/config/writable_dir_test.go
@@ -1,0 +1,13 @@
+package config
+
+import "testing"
+
+func TestEmbeddedConfigParsesWritableDir(t *testing.T) {
+	cfg, err := New(WithEmbeddedConfig([]byte("writable_dir: ./published\n"), ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WritableDir != "./published" {
+		t.Fatalf("WritableDir = %q", cfg.WritableDir)
+	}
+}

--- a/openlore.sh/Dockerfile
+++ b/openlore.sh/Dockerfile
@@ -16,6 +16,7 @@ RUN CGO_ENABLED=0 go build -o openlore ./cmd/openlore
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates
 WORKDIR /app
+RUN mkdir -p /app/published
 COPY --from=builder /app/openlore .
 COPY --from=builder /app/openlore.sh/skills ./skills
 COPY --from=builder /app/openlore.sh/motd.txt ./motd.txt
@@ -23,5 +24,6 @@ COPY --from=builder /app/openlore.sh/motd.txt ./motd.txt
 # served at /legal by the HTTP server.
 
 EXPOSE 2222 8080
+VOLUME ["/app/published"]
 
 CMD ["./openlore", "--skills-dir", "./skills"]

--- a/openlore.sh/openlore.yml
+++ b/openlore.sh/openlore.yml
@@ -9,6 +9,10 @@ default_cwd: /
 auth_file: ./lore.json
 data_dir: ./data
 
+# Disk-backed lore is overlaid at the virtual root. Its directory hierarchy is
+# the namespace; lore.json independently defines docsets and authorization.
+writable_dir: ./published
+
 # Global write lock. The substrate boots read-only by default; set false to
 # enable the experimental writable substrate so authenticated identities can
 # create/overwrite files within their writable docsets (per-identity/per-docset
@@ -55,25 +59,3 @@ tokens:
   audience: https://openlore.sh
   access_ttl: 30m
   refresh_ttl: 720h
-
-folders:
-  - name: knowledge
-    path: ./published/knowledge
-  - name: jared
-    path: ./published/jared
-  - name: claw
-    path: ./published/claw
-  - name: cor
-    path: ./published/cor
-  - name: ray
-    path: ./published/ray
-  - name: razer
-    path: ./published/razer
-  - name: miles
-    path: ./published/miles
-  - name: zeb
-    path: ./published/zeb
-  - name: adil
-    path: ./published/adil
-  - name: alfie
-    path: ./published/alfie

--- a/openlore.sh/setup.sh
+++ b/openlore.sh/setup.sh
@@ -25,7 +25,7 @@ fi
 
 echo "==> Setting up $INSTALL_DIR..."
 mkdir -p "$INSTALL_DIR/skills" "$INSTALL_DIR/.ssh"
-mkdir -p "$INSTALL_DIR/published"/{knowledge,research,pipeline,runbooks,memory}
+mkdir -p "$INSTALL_DIR/published"
 
 echo "==> Installing binary..."
 cp "$BINARY" "$INSTALL_DIR/openlore"

--- a/openlore.yml.example
+++ b/openlore.yml.example
@@ -9,6 +9,11 @@
 # Config file version. Used for migration between config formats.
 version: "1"
 
+# Optional disk-backed content root. When the binary includes embedded docs,
+# this directory is overlaid at the same virtual root: its filesystem hierarchy
+# defines paths, while lore.json independently defines docsets and access.
+# writable_dir: ./published
+
 # ── Server ────────────────────────────────────────────
 
 # SSH server port. Agents connect here.
@@ -179,14 +184,6 @@ files:
     - "*.pem"
     - "*.p12"
     - ".DS_Store"
-
-# Mount additional directories under named paths in the virtual filesystem.
-# Each folder appears as a top-level directory in the shell.
-# folders:
-#   - name: api-docs
-#     path: /var/docs/api
-#   - name: runbooks
-#     path: /var/docs/runbooks
 
 # ── Skills ────────────────────────────────────────────
 

--- a/pkg/openlore/options.go
+++ b/pkg/openlore/options.go
@@ -14,9 +14,6 @@ type Option = config.Option
 // FilesConfig controls which files are served.
 type FilesConfig = config.FilesConfig
 
-// FolderConfig defines an additional named folder mount.
-type FolderConfig = config.FolderConfig
-
 // AuthConfig is loaded from auth.json.
 type AuthConfig = config.AuthConfig
 
@@ -48,6 +45,7 @@ var (
 	WithIgnorePatterns  = config.WithIgnorePatterns
 	WithLogger          = config.WithLogger
 	WithSkillsDir       = config.WithSkillsDir
+	WithWritableDir     = config.WithWritableDir
 	WithHTTPPort        = config.WithHTTPPort
 	WithMCPPath         = config.WithMCPPath
 	WithMCPEnabled      = config.WithMCPEnabled

--- a/pkg/openlore/overlay_fs.go
+++ b/pkg/openlore/overlay_fs.go
@@ -1,0 +1,207 @@
+package openlore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"sync"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+// OverlayFS exposes a writable directory over a read-only filesystem at one
+// virtual root. Upper entries shadow lower entries; directories are merged.
+// Deletes of lower-backed paths are rejected because the overlay deliberately
+// has no persistent whiteout format.
+type OverlayFS struct {
+	upper *DirFS
+	lower vfs.FileSystem
+	mu    sync.Mutex
+}
+
+// NewOverlayFS creates a filesystem with upper as its writable layer and lower
+// as its read-only fallback.
+func NewOverlayFS(upper *DirFS, lower vfs.FileSystem) *OverlayFS {
+	return &OverlayFS{upper: upper, lower: lower}
+}
+
+func (o *OverlayFS) SetWriteable() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.upper.SetWriteable()
+}
+
+func (o *OverlayFS) SetReadonly() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.upper.SetReadonly()
+}
+
+func (o *OverlayFS) Stat(p string) (*vfs.FileInfo, error) {
+	info, err := o.upper.Stat(p)
+	if err == nil || !errors.Is(err, fs.ErrNotExist) || o.lower == nil {
+		return info, err
+	}
+	return o.lower.Stat(p)
+}
+
+func (o *OverlayFS) ReadFile(p string) ([]byte, error) {
+	b, err := o.upper.ReadFile(p)
+	if err == nil || !errors.Is(err, fs.ErrNotExist) || o.lower == nil {
+		return b, err
+	}
+	return o.lower.ReadFile(p)
+}
+
+func (o *OverlayFS) ReadDir(p string) ([]vfs.FileInfo, error) {
+	upperInfo, upperErr := o.upper.Stat(p)
+	if upperErr != nil {
+		if !errors.Is(upperErr, fs.ErrNotExist) || o.lower == nil {
+			return nil, upperErr
+		}
+		return o.lower.ReadDir(p)
+	}
+	upper, err := o.upper.ReadDir(p)
+	if err != nil || o.lower == nil || !upperInfo.Dir {
+		return upper, err
+	}
+	lowerInfo, lowerErr := o.lower.Stat(p)
+	if lowerErr != nil {
+		if errors.Is(lowerErr, fs.ErrNotExist) {
+			return upper, nil
+		}
+		return nil, lowerErr
+	}
+	if !lowerInfo.Dir {
+		return upper, nil
+	}
+	lower, err := o.lower.ReadDir(p)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(upper))
+	entries := append([]vfs.FileInfo(nil), upper...)
+	for _, entry := range upper {
+		seen[entry.FileName] = struct{}{}
+	}
+	for _, entry := range lower {
+		if _, ok := seen[entry.FileName]; !ok {
+			entries = append(entries, entry)
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].FileName < entries[j].FileName })
+	return entries, nil
+}
+
+func (o *OverlayFS) WriteFileAtomic(p string, content []byte, opts vfs.WriteOpts) (string, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if _, err := o.upper.Stat(p); err == nil {
+		return o.upper.WriteFileAtomic(p, content, opts)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+
+	if o.lower == nil {
+		return o.upper.WriteFileAtomic(p, content, opts)
+	}
+	info, err := o.lower.Stat(p)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return o.upper.WriteFileAtomic(p, content, opts)
+		}
+		return "", err
+	}
+	if info.Dir {
+		return "", fmt.Errorf("cannot write file over directory: %s", p)
+	}
+	lowerContent, err := o.lower.ReadFile(p)
+	if err != nil {
+		return "", err
+	}
+	current := sha256.Sum256(lowerContent)
+	currentHash := hex.EncodeToString(current[:])
+	if opts.IfNoneMatch || (opts.IfMatch != nil && *opts.IfMatch != currentHash) {
+		return "", &vfs.PreconditionError{Path: vfs.CleanPath(p), Current: currentHash}
+	}
+	return o.upper.WriteFileAtomic(p, content, vfs.WriteOpts{IfNoneMatch: true})
+}
+
+func (o *OverlayFS) Mkdir(p string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	parent := path.Dir(vfs.CleanPath(p))
+	info, err := o.Stat(parent)
+	if err != nil || !info.Dir {
+		return fmt.Errorf("mkdir parent %s is not a directory", parent)
+	}
+	if err := o.materializeDocsetRoot(p); err != nil {
+		return err
+	}
+	if err := o.upper.materializeDir(parent); err != nil {
+		return err
+	}
+	return o.upper.Mkdir(p)
+}
+
+func (o *OverlayFS) MkdirAll(p string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := o.materializeDocsetRoot(p); err != nil {
+		return err
+	}
+	return o.upper.MkdirAll(p)
+}
+
+func (o *OverlayFS) materializeDocsetRoot(p string) error {
+	root, ok := o.upper.docsetRootFor(vfs.CleanPath(p))
+	if !ok {
+		return fmt.Errorf("cannot create folder outside a docset: %s", p)
+	}
+	if root == "/" {
+		return nil
+	}
+	info, err := o.Stat(root)
+	if err != nil || !info.Dir {
+		return fmt.Errorf("docset root does not exist: %s", root)
+	}
+	return o.upper.materializeDir(root)
+}
+
+func (o *OverlayFS) Remove(p string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := o.rejectLowerRemoval(p); err != nil {
+		return err
+	}
+	return o.upper.Remove(p)
+}
+
+func (o *OverlayFS) RemoveAll(p string, opts vfs.RemoveOpts) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if err := o.rejectLowerRemoval(p); err != nil {
+		return err
+	}
+	return o.upper.RemoveAll(p, opts)
+}
+
+func (o *OverlayFS) rejectLowerRemoval(p string) error {
+	if o.lower == nil {
+		return nil
+	}
+	if _, err := o.lower.Stat(p); err == nil {
+		return fmt.Errorf("%w: lower-layer path cannot be removed: %s", vfs.ErrReadOnly, p)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+var _ vfs.WritableFS = (*OverlayFS)(nil)

--- a/pkg/openlore/overlay_fs_test.go
+++ b/pkg/openlore/overlay_fs_test.go
@@ -1,0 +1,160 @@
+package openlore
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+func newTestOverlay(t *testing.T) (*OverlayFS, string) {
+	t.Helper()
+	upperDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(upperDir, "shared"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(upperDir, "upper-dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(upperDir, "shared", "upper.md"), []byte("upper"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lower := NewFSAdapter(fstest.MapFS{
+		"lower.md":        &fstest.MapFile{Data: []byte("lower")},
+		"shared/lower.md": &fstest.MapFile{Data: []byte("lower child")},
+		"shared/upper.md": &fstest.MapFile{Data: []byte("shadowed")},
+		"upper-dir":       &fstest.MapFile{Data: []byte("lower file")},
+	})
+	overlay := NewOverlayFS(NewDirFS(upperDir, config.FilesConfig{}), lower)
+	if err := overlay.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	return overlay, upperDir
+}
+
+func TestOverlayFSReadsUpperAndLowerAndMergesDirectories(t *testing.T) {
+	overlay, _ := newTestOverlay(t)
+
+	if got, err := overlay.ReadFile("/lower.md"); err != nil || string(got) != "lower" {
+		t.Fatalf("lower read = %q, %v", got, err)
+	}
+	if got, err := overlay.ReadFile("/shared/upper.md"); err != nil || string(got) != "upper" {
+		t.Fatalf("shadowed read = %q, %v", got, err)
+	}
+	entries, err := overlay.ReadDir("/shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[0].FileName != "lower.md" || entries[1].FileName != "upper.md" {
+		t.Fatalf("merged entries = %+v", entries)
+	}
+	if _, err := overlay.ReadDir("/upper-dir"); err != nil {
+		t.Fatalf("upper directory must shadow lower file: %v", err)
+	}
+}
+
+func TestOverlayFSWritesAgainstVisibleLowerCAS(t *testing.T) {
+	overlay, upperDir := newTestOverlay(t)
+	sum := sha256.Sum256([]byte("lower"))
+	want := hex.EncodeToString(sum[:])
+
+	stale := "stale"
+	if _, err := overlay.WriteFileAtomic("/lower.md", []byte("new"), vfs.WriteOpts{IfMatch: &stale}); err == nil {
+		t.Fatal("stale lower write: want precondition error")
+	}
+	if _, err := overlay.WriteFileAtomic("/lower.md", []byte("new"), vfs.WriteOpts{IfMatch: &want}); err != nil {
+		t.Fatalf("matching lower write: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(upperDir, "lower.md")); err != nil || string(got) != "new" {
+		t.Fatalf("upper copy = %q, %v", got, err)
+	}
+	if _, err := overlay.WriteFileAtomic("/shared/lower.md", []byte("new"), vfs.WriteOpts{IfNoneMatch: true}); err == nil {
+		t.Fatal("create-only over lower file: want precondition error")
+	}
+}
+
+func TestOverlayFSRejectsLowerBackedRemoval(t *testing.T) {
+	overlay, upperDir := newTestOverlay(t)
+
+	if err := overlay.Remove("/lower.md"); !errors.Is(err, vfs.ErrReadOnly) {
+		t.Fatalf("remove lower = %v, want ErrReadOnly", err)
+	}
+	if err := os.WriteFile(filepath.Join(upperDir, "only-upper.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := overlay.Remove("/only-upper.md"); err != nil {
+		t.Fatalf("remove upper: %v", err)
+	}
+}
+
+func TestNewServerWithLowerFSUsesWritableDirAtRoot(t *testing.T) {
+	upperDir := t.TempDir()
+	lower := fstest.MapFS{"embedded.md": &fstest.MapFile{Data: []byte("embedded")}}
+	s, err := NewServerWithLowerFS(lower, WithWritableDir(upperDir), WithReadonly(false))
+	if err != nil {
+		t.Fatalf("NewServerWithLowerFS: %v", err)
+	}
+	defer s.Shutdown(context.Background())
+	if s.writeLog == nil {
+		t.Fatal("writable overlay must initialize write log")
+	}
+	if got, err := s.merge.ReadFile("/embedded.md"); err != nil || string(got) != "embedded" {
+		t.Fatalf("embedded read = %q, %v", got, err)
+	}
+	if _, err := s.merge.WriteFileAtomic("/agent/jared/note.md", []byte("hi"), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("overlay write: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(upperDir, "agent", "jared", "note.md")); err != nil || string(got) != "hi" {
+		t.Fatalf("physical write = %q, %v", got, err)
+	}
+}
+
+func TestOverlayFSMkdirAllMaterializesLowerOnlyNestedDocset(t *testing.T) {
+	upperDir := t.TempDir()
+	upper := NewDirFS(upperDir, config.FilesConfig{}).WithDocsetRoots([]string{"/", "/agent/jared"})
+	lower := NewFSAdapter(fstest.MapFS{
+		"agent/jared/existing.md": &fstest.MapFile{Data: []byte("existing")},
+	})
+	overlay := NewOverlayFS(upper, lower)
+	if err := overlay.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	if err := overlay.MkdirAll("/agent/jared/new/deep"); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if info, err := os.Stat(filepath.Join(upperDir, "agent", "jared", "new", "deep")); err != nil || !info.IsDir() {
+		t.Fatalf("physical nested dir: info=%v err=%v", info, err)
+	}
+	if root, ok := upper.docsetRootFor("/agent/jared/new"); !ok || root != "/agent/jared" {
+		t.Fatalf("docset root = %q, %v", root, ok)
+	}
+}
+
+func TestOverlayFSRejectsDeletingNestedDocsetRoot(t *testing.T) {
+	upperDir := t.TempDir()
+	root := filepath.Join(upperDir, "agent", "jared")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "note.md"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	upper := NewDirFS(upperDir, config.FilesConfig{}).WithDocsetRoots([]string{"/", "/agent/jared"})
+	overlay := NewOverlayFS(upper, nil)
+	if err := overlay.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	if err := overlay.RemoveAll("/agent/jared", vfs.RemoveOpts{}); err == nil {
+		t.Fatal("RemoveAll nested docset root: want error")
+	}
+	if got, err := os.ReadFile(filepath.Join(root, "note.md")); err != nil || string(got) != "keep" {
+		t.Fatalf("nested docset content = %q, %v", got, err)
+	}
+}

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -110,7 +110,7 @@ type Server struct {
 // rootDir is the primary directory to serve (can be empty if using Mount).
 // Options are applied using the functional options pattern via config.Option.
 func NewServer(rootDir string, opts ...config.Option) (*Server, error) {
-	return newServerWithRoot(rootDir, nil, opts...)
+	return newServerWithRoot(rootDir, nil, nil, opts...)
 }
 
 // NewServerWithRootFS creates a server whose root filesystem is a caller-supplied
@@ -120,14 +120,21 @@ func NewServer(rootDir string, opts ...config.Option) (*Server, error) {
 // SetRootBashFS runs after SetWriteable()/newWriteLog and would leave the log
 // with no writable backend at construction time.
 func NewServerWithRootFS(root vfs.FileSystem, opts ...config.Option) (*Server, error) {
-	return newServerWithRoot("", root, opts...)
+	return newServerWithRoot("", root, nil, opts...)
+}
+
+// NewServerWithLowerFS creates a server with a read-only lower filesystem.
+// When writable_dir is configured, its disk tree is layered over lower at the
+// same virtual root and receives all writes.
+func NewServerWithLowerFS(lower fs.FS, opts ...config.Option) (*Server, error) {
+	return newServerWithRoot("", nil, NewFSAdapter(lower), opts...)
 }
 
 // newServerWithRoot is the shared constructor. When rootFS is non-nil it becomes
 // the merge root (rootDir is ignored); otherwise rootDir (if non-empty) is served
 // via a DirFS. The root is installed before the writable block so the write log's
 // substrate is live at construction.
-func newServerWithRoot(rootDir string, rootFS vfs.FileSystem, opts ...config.Option) (*Server, error) {
+func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...config.Option) (*Server, error) {
 	cfg, err := config.New(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
@@ -183,14 +190,11 @@ func newServerWithRoot(rootDir string, rootFS vfs.FileSystem, opts ...config.Opt
 		}
 	} else {
 		// No auth file: run in trusted/unenforced mode as a single `public`
-		// docset rooted at "/", with any folder mounts folded in. The anonymous
-		// identity holds an `rw` grant on it (see anonymousIdentity), so every
-		// consumer reuses the normal docset machinery.
-		paths := []config.PathMapping{{Source: "/", Display: "/"}}
-		for _, f := range cfg.Folders {
-			paths = append(paths, config.PathMapping{Source: "/" + f.Name, Display: "/" + f.Name})
-		}
-		s.auth.Docsets = map[string]config.DocsetSpec{"public": {Paths: paths}}
+		// docset rooted at "/". The anonymous identity holds an `rw` grant on it
+		// (see anonymousIdentity), so every consumer reuses normal docset scoping.
+		s.auth.Docsets = map[string]config.DocsetSpec{"public": {
+			Paths: []config.PathMapping{{Source: "/", Display: "/"}},
+		}}
 	}
 
 	// Collect docset root display paths so DirFS.Mkdir can enforce the
@@ -224,13 +228,19 @@ func newServerWithRoot(rootDir string, rootFS vfs.FileSystem, opts ...config.Opt
 	} else if rootDir != "" {
 		dirFS := NewDirFS(rootDir, cfg.Files).WithDocsetRoots(docsetRoots)
 		s.merge.SetRoot(dirFS)
-	}
-
-	// Set up additional folders. Each folder mount is itself a docset, so any
-	// non-root path within it is a valid Mkdir target (default boundary).
-	for _, folder := range cfg.Folders {
-		folderFS := NewDirFS(folder.Path, cfg.Files)
-		s.merge.Mount(folder.Name, folderFS)
+	} else if cfg.WritableDir != "" {
+		info, err := os.Stat(cfg.WritableDir)
+		if err != nil || !info.IsDir() {
+			return nil, fmt.Errorf("writable_dir %q is not a directory", cfg.WritableDir)
+		}
+		upper := NewDirFS(cfg.WritableDir, cfg.Files).WithDocsetRoots(docsetRoots)
+		if lowerFS != nil {
+			s.merge.SetRoot(NewOverlayFS(upper, lowerFS))
+		} else {
+			s.merge.SetRoot(upper)
+		}
+	} else if lowerFS != nil {
+		s.merge.SetRoot(lowerFS)
 	}
 
 	// Enable the experimental writable substrate when the global lock is open.

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -188,6 +188,13 @@ func (d *DirFS) insideDocset(clean string) bool {
 	if len(d.docsetRoots) == 0 {
 		return clean != "/"
 	}
+	// A nested docset root remains protected even when another docset (such as
+	// "/") contains it.
+	for _, root := range d.docsetRoots {
+		if clean == root {
+			return false
+		}
+	}
 	for _, root := range d.docsetRoots {
 		if root == "/" {
 			if clean != "/" {
@@ -224,18 +231,36 @@ func (d *DirFS) docsetRootFor(clean string) (string, bool) {
 		}
 		return "", false
 	}
+	best := ""
 	for _, root := range d.docsetRoots {
 		if root == "/" {
-			if clean != "/" {
-				return "/", true
+			if clean != "/" && best == "" {
+				best = "/"
 			}
 			continue
 		}
-		if strings.HasPrefix(clean, root+"/") {
-			return root, true
+		if strings.HasPrefix(clean, root+"/") && len(root) > len(best) {
+			best = root
 		}
 	}
-	return "", false
+	return best, best != ""
+}
+
+// materializeDir creates physical upper-layer scaffolding after an overlay has
+// already established that the virtual directory is valid and visible.
+func (d *DirFS) materializeDir(p string) error {
+	clean := vfs.CleanPath(p)
+	if isTrashPath(clean) || isIgnored(clean, d.files) {
+		return fmt.Errorf("access denied: %s", p)
+	}
+	d.stateMu.RLock()
+	defer d.stateMu.RUnlock()
+	if !d.writeable {
+		return vfs.ErrReadOnly
+	}
+	d.commitMu.Lock()
+	defer d.commitMu.Unlock()
+	return os.MkdirAll(d.resolve(clean), 0o755)
 }
 
 // MkdirAll creates p and any missing ancestors (mkdir -p). The enclosing docset


### PR DESCRIPTION
## Summary
- add a single `writable_dir` upper filesystem layered over embedded docs at `/`
- remove the separate `folders` namespace configuration so `lore.json` alone defines docsets and aliases
- preserve visible-file CAS during copy-up and reject lower-layer deletion without whiteouts
- update the openlore.sh image and provisioning for one persistent `published` root

## Verification
- `go test ./...`
- `go build -o /tmp/openlore-writable-overlay ./cmd/openlore`

## Rollout
After deployment, production content will be moved under `published/agent`, `published/user`, and `published/channel`, then `lore.json` will switch canonical paths while retaining old paths as aliases.