### PR TITLE
feat(authz): add role-based docset access

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,23 +203,23 @@ OpenLore is built on [Wish](https://github.com/charmbracelet/wish) from Charmbra
 |---------|-------------|
 | `whoami` | Print your identity |
 | `lore` | Introspection dispatcher (run `lore` for subcommands) |
-| `lore docsets` | List the docsets you can access, their grant, paths, and attributes |
+| `lore docsets` | List the docsets you can access, their grants, paths, and attributes |
 | `lore meta` | Emit each document's frontmatter as NDJSON, cwd-scoped (see [Plugins](#plugins)) |
 
 `lore docsets` prints an aligned, greppable table:
 
 ```
 $ lore docsets
-DOCSET    GRANT    ATTRIBUTES   PATH             TARGET
-public    ro       -            /docs/public     -
-backend   rw       -            /docs/backend    -
-home      rw       home,inbox   /home/backend    -
-home      rw       alias        /backend         /home/backend
+DOCSET    GRANTS      ATTRIBUTES   PATH             TARGET
+public    ro          -            /docs/public     -
+backend   publish,rw  inbox        /docs/backend    -
+home      rw          home         /home/backend    -
+home      rw          alias        /backend         /home/backend
 ```
 
-- `GRANT` is the named grant you hold on the docset: `ro` (read the whole docset),
-  `rw` (read + write anywhere in it), or `publish` (read the whole docset, create/edit
-  only within its inbox, never delete).
+- `GRANTS` is the sorted set of grants contributed by your roles: `ro` (read
+  the whole docset), `rw` (read + write anywhere in it), or `publish` (read the
+  whole docset, create/edit only within its inbox, never delete).
 - `ATTRIBUTES` is a comma-joined set of tokens (`-` if none): `home` (your `$HOME`
   docset), `inbox` (the docset declares an inbox folder), or `alias` (this mount
   resolves to the canonical path in `TARGET`). Canonical rows always precede
@@ -332,10 +332,9 @@ Key properties:
 - **Read-only by default.** The substrate boots read-only; writes require
   `readonly: false` (or per-identity write scope). Embedded-docs binaries can
   never be made writable.
-- **Scoped per identity.** Every write is authorized against the identity's
-  per-docset grant — an `rw` grant writes anywhere in its docset, a `publish`
-  grant only within the docset's inbox — so agents sharing a docset can't write
-  each other's space.
+- **Scoped through RBAC.** Every write is authorized against current role
+  membership and the governing docset ACL. An `rw` grant writes anywhere in
+  its docset, while `publish` writes only within the docset's inbox.
 - **Compare-and-swap by default.** Overwrites are rejected (not silently
   clobbered) if the file changed since you read it (`write_conflict_policy: hash`,
   overridable to `last_write_wins`). Append and `patch` are always CAS.
@@ -740,29 +739,36 @@ Create a `lore.json` to control access per public key:
   "allow_keyless": true,
   "unknown_identity": "allow",
   "default_cwd": "/docs",
+  "roles": {
+    "backend": { "allow": { "capabilities": ["spawn"] } }
+  },
   "docsets": {
-    "public": { "paths": ["/docs/public"] },
+    "public": {
+      "paths": ["/docs/public"],
+      "access": { "allow": { "guest": "ro", "backend": "ro" } }
+    },
     "backend": {
       "paths": ["/docs/api", {"internal/specs": "/docs/specs"}],
-      "aliases": ["/api"]
+      "aliases": ["/api"],
+      "access": { "allow": { "backend": "rw" } }
     }
   },
-  "default": { "public": "ro" },
   "identities": [
     {
       "name": "backend-agent",
       "public_key": "ssh-ed25519 AAAA...",
-      "docsets": { "public": "ro", "backend": "rw" },
+      "roles": ["backend"],
       "home": "backend"
     }
   ]
 }
 ```
 
-Each identity holds a named **grant** on each docset it can access — `ro`
-(read), `rw` (read + write), or `publish` (read all, create/edit only in the
-docset's inbox, no deletes). The `default` map is the grant set for keyless /
-unrecognized callers.
+Docsets grant exact role names `ro`, `rw`, or plugin grant types such as
+`publish`. Multiple roles contribute grants independently; any matching docset
+deny wins. Capability allows union across roles and any deny wins. Keyless and
+unknown allowed callers use the built-in `guest` role, which may only receive
+read-only grants.
 
 ### Path Aliases
 
@@ -789,7 +795,7 @@ rewritten to their canonical target before authorization.
 
 ### Home Directory
 
-An identity can name one of its granted docsets as its `home`. That docset's
+An identity can name a unique docset as its `home`. That docset's
 display path becomes the session's `$HOME`, enabling `~` and `~/path` expansion
 and letting `cd` with no arguments jump home. The session still starts in the
 default working directory (`default_cwd`) — `home` only sets `$HOME`, not where
@@ -799,7 +805,7 @@ you land on connect:
 {
   "name": "backend-agent",
   "public_key": "ssh-ed25519 AAAA...",
-  "docsets": { "public": "ro", "backend-home": "rw" },
+  "roles": ["backend"],
   "home": "backend-home"
 }
 ```
@@ -810,8 +816,8 @@ ssh -p 2222 server "cat ~/notes.md"
 ssh -p 2222 server "cd && pwd"    # -> /home/backend
 ```
 
-The `home` docset must be one of the identity's granted docsets. Give it an
-`inbox` (with an `rw` grant) to hand each agent its own writable personal space.
+The owner receives implicit `rw` on its home without an access entry. Nested
+docsets remain separate boundaries and do not inherit that implicit access.
 
 ### Managing Identities
 
@@ -819,8 +825,7 @@ The `home` docset must be one of the identity's granted docsets. Give it an
 openlore identity add \
   --name my-agent \
   --key "ssh-ed25519 AAAA..." \
-  --docset backend \
-  --grant rw \
+  --role backend \
   --home backend \
   --auth ./lore.json
 ```
@@ -828,10 +833,14 @@ openlore identity add \
 The `--key` flag is optional: an identity can exist as a passkey/token-only
 login target with no SSH key.
 
+Role policy is managed with `openlore role add|remove`, `role grant|revoke`,
+`role deny|undeny`, and `role capability allow|deny|remove`. Membership is
+managed with `openlore identity role add|remove --identity NAME --role ROLE`.
+
 ### Unknown Identity Handling
 
 In `lore.json`:
-- `"unknown_identity": "allow"` (default) — unrecognized keys get the `default` grant map
+- `"unknown_identity": "allow"` (default) — unrecognized keys resolve as `guest`
 - `"unknown_identity": "deny"` — reject unrecognized keys
 
 ## HTTP Front Page

--- a/assets/lore/auth.md
+++ b/assets/lore/auth.md
@@ -4,14 +4,71 @@
 
 By default, any SSH client can connect. No keys required.
 
-## Docsets & Lore
+## RBAC Quick Start
 
-Access control is built on two concepts:
+Create `lore.json` next to `openlore.yml`. This example gives keyless visitors
+read-only public docs, reviewers read-only backend docs, and engineers
+read/write backend docs:
 
-- **Docsets** — atomic document collections with path mappings (an agent's workspace)
-- **Lore** — named compositions of docsets (what an identity can access)
+```json
+{
+  "allow_keyless": true,
+  "unknown_identity": "deny",
+  "roles": {
+    "reviewer": {},
+    "engineer": {}
+  },
+  "docsets": {
+    "public": {
+      "paths": ["/docs/public"],
+      "access": {
+        "allow": { "guest": "ro", "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "backend": {
+      "paths": ["/docs/backend"],
+      "access": {
+        "allow": { "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "engineer-home": {
+      "paths": [{ "homes/engineer": "/home/engineer" }]
+    }
+  },
+  "identities": [
+    {
+      "name": "engineering-agent",
+      "public_key": "ssh-ed25519 AAAA...",
+      "roles": ["engineer", "reviewer"],
+      "home": "engineer-home"
+    }
+  ]
+}
+```
 
-Each identity references a lore name, which resolves to one or more docsets. When multiple docsets are in a lore, each appears as a subdirectory.
+Enable it in `openlore.yml`:
+
+```yaml
+auth_file: ./lore.json
+readonly: false # keep true if no role should be able to write
+```
+
+Then start OpenLore normally. No role-management commands are required; edit
+`lore.json` and restart the server after changing file-backed policy.
+
+### How access is resolved
+
+- `roles` declares the exact role names available to identities. Roles are flat
+  and do not inherit.
+- `docsets` own access policy. `access.allow` maps each role to `ro`, `rw`, or a
+  plugin grant such as `publish`.
+- An identity may have multiple roles. Their allows are combined, while any
+  matching role in a docset's `access.deny` denies the entire docset.
+- `guest` is built in for keyless and allowed unknown callers. It can only be
+  granted read-only access.
+- A unique `home` docset is implicitly read/write for its owner and needs no
+  access entry. Nested docsets remain separate access boundaries.
+- A docset without a matching allow is inaccessible.
 
 ## Publishing
 
@@ -70,53 +127,11 @@ Override it per docset in `lore.json` (takes precedence for paths in that docset
 }
 ```
 
-## Public Key Auth
-
-Create a `lore.json` to control per-agent access:
-
-```json
-{
-  "docsets": {
-    "public": { "paths": ["/docs/public"] },
-    "backend": { "paths": ["/docs/api", "/docs/backend"], "publish_dir": "./published/backend" },
-    "frontend": { "paths": ["/docs/frontend", "/docs/shared"] }
-  },
-  "lore": {
-    "default": ["public"],
-    "backend": ["public", "backend"],
-    "engineering": ["public", "backend", "frontend"]
-  },
-  "identities": [
-    {
-      "name": "backend-agent",
-      "public_key": "ssh-ed25519 AAAA...",
-      "lore": "backend"
-    },
-    {
-      "name": "eng-lead",
-      "public_key": "ssh-ed25519 AAAA...",
-      "lore": "engineering"
-    }
-  ]
-}
-```
-
-## Adding Identities
-
-Use the CLI:
-
-```bash
-openlore identity add \
-  --name my-agent \
-  --key "ssh-ed25519 AAAA..." \
-  --lore backend \
-  --auth ./lore.json
-```
-
 ## Unknown Identity Handling
 
 In `lore.json`:
-- `"unknown_identity": "allow"` — unrecognized keys get the "default" lore
+- `"unknown_identity": "allow"` — unrecognized keys receive the built-in
+  `guest` role
 - `"unknown_identity": "deny"` — unrecognized keys are rejected
 
 ## Federated Access (WIF)

--- a/assets/skills/teach.md
+++ b/assets/skills/teach.md
@@ -81,49 +81,69 @@ can run.
 
 ## Setting Up Access Control
 
-If you want different agents to see different docs, ship a `lore.json`. Docsets
-name a set of paths; lores group docsets; identities map an SSH public key to a
-lore. Start from `lore.json.example` in the repo.
+If you want different agents to have different access, create a `lore.json`
+next to `openlore.yml`. This quick start gives keyless visitors read-only access
+to public docs, reviewers read-only access to backend docs, and engineers
+read/write access to backend docs:
 
 ```json
 {
-  "allow_keyless": false,
-  "docsets": {
-    "public":  { "paths": ["/getting-started.md", "/public"] },
-    "backend": { "paths": ["/api", "/backend"] }
+  "allow_keyless": true,
+  "unknown_identity": "deny",
+  "roles": {
+    "reviewer": {},
+    "engineer": {}
   },
-  "lore": {
-    "default": ["public"],
-    "backend": ["public", "backend"]
+  "docsets": {
+    "public": {
+      "paths": ["/docs/public"],
+      "access": {
+        "allow": { "guest": "ro", "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "backend": {
+      "paths": ["/docs/backend"],
+      "access": {
+        "allow": { "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "engineer-home": {
+      "paths": [{ "homes/engineer": "/home/engineer" }]
+    }
   },
   "identities": [
     {
-      "name": "my-agent",
+      "name": "engineering-agent",
       "public_key": "ssh-ed25519 AAAA...",
-      "lore": "backend"
+      "roles": ["engineer", "reviewer"],
+      "home": "engineer-home"
     }
   ]
 }
 ```
 
-- `docsets` — named groups of paths (into the served tree).
-- `lore` — each lore is a **list of docset names**; an identity's lore is the
-  union of those docsets' paths. `default` is the lore used by keyless/unknown
-  clients.
-- `identities` — bind an SSH public key to a lore.
-- `allow_keyless` — `false` requires a known public key; `true` (default) lets
-  any client connect as the `default` lore.
+- `roles` declares the role names identities may use. Role names are exact and
+  roles do not inherit from one another.
+- Each docset's `access.allow` maps roles to `ro`, `rw`, or a plugin grant such
+  as `publish`. Grants from multiple roles are combined; a role listed in
+  `access.deny` denies the entire docset and overrides all allows.
+- `guest` is built in. It represents keyless and allowed unknown callers and
+  can only be granted read-only access.
+- An identity may have multiple roles. Its unique `home` docset is implicitly
+  read/write for that identity, so it needs no access entry.
+- A docset without a matching allow is inaccessible. Nested docsets are
+  separate access boundaries, including inside a home.
 
-Point the server at it either by setting `auth_file: ./lore.json` in
-`openlore.yml`, or with a flag:
-```bash
-openlore --auth lore.json ./docs
+Enable the file in `openlore.yml`, then start OpenLore normally:
+
+```yaml
+auth_file: ./lore.json
+readonly: false # keep true if no role should be able to write
 ```
 
-Add a public key without hand-editing the JSON:
-```bash
-openlore identity add --name my-agent --key "ssh-ed25519 AAAA..." --lore backend --auth lore.json
-```
+Set `allow_keyless` to `false` if every SSH connection must present a known
+key. Set `unknown_identity` to `allow` only if unknown keys should receive the
+built-in `guest` role.
 
 ## Using the GitHub Action
 

--- a/cmd/openlore/main.go
+++ b/cmd/openlore/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -21,6 +22,292 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	gossh "golang.org/x/crypto/ssh"
 )
+
+type stringList []string
+
+func (s *stringList) String() string     { return strings.Join(*s, ",") }
+func (s *stringList) Set(v string) error { *s = append(*s, v); return nil }
+
+func loadPolicy(path string) (openlore.AuthConfig, error) {
+	var auth openlore.AuthConfig
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return auth, err
+	}
+	err = json.Unmarshal(b, &auth)
+	return auth, err
+}
+func savePolicy(path string, auth openlore.AuthConfig) error {
+	if err := openlore.ValidateAuthConfig(&auth); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(auth, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0644)
+}
+
+func runIdentityCommand(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: identity add|role")
+	}
+	if args[0] == "add" {
+		fs := flag.NewFlagSet("identity add", flag.ContinueOnError)
+		name := fs.String("name", "", "")
+		key := fs.String("key", "", "")
+		comment := fs.String("comment", "", "")
+		home := fs.String("home", "", "")
+		path := fs.String("auth", "./lore.json", "")
+		var roles stringList
+		fs.Var(&roles, "role", "")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *name == "" || *name == "guest" {
+			return fmt.Errorf("invalid or reserved identity name %q", *name)
+		}
+		auth, err := loadPolicy(*path)
+		if err != nil {
+			return err
+		}
+		seen := map[string]bool{}
+		for _, role := range roles {
+			if seen[role] {
+				return fmt.Errorf("duplicate role %q", role)
+			}
+			seen[role] = true
+			if role != "guest" {
+				if _, ok := auth.Roles[role]; !ok {
+					return fmt.Errorf("unknown role %q", role)
+				}
+			}
+		}
+		if *home != "" {
+			if _, ok := auth.Docsets[*home]; !ok {
+				return fmt.Errorf("unknown home docset %q", *home)
+			}
+			for _, id := range auth.Identities {
+				if id.Home == *home {
+					return fmt.Errorf("home docset %q already belongs to %q", *home, id.Name)
+				}
+			}
+		}
+		for _, id := range auth.Identities {
+			if id.Name == *name {
+				return fmt.Errorf("identity %q already exists", *name)
+			}
+		}
+		if *key != "" {
+			if _, _, _, _, err := gossh.ParseAuthorizedKey([]byte(*key)); err != nil {
+				return fmt.Errorf("invalid SSH public key: %w", err)
+			}
+		}
+		auth.Identities = append(auth.Identities, openlore.AuthIdentity{Name: *name, PublicKey: strings.TrimSpace(*key), Comment: *comment, Home: *home, Roles: roles})
+		if err := savePolicy(*path, auth); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "Added identity %q\n", *name)
+		return nil
+	}
+	if args[0] == "role" && len(args) > 1 {
+		fs := flag.NewFlagSet("identity role", flag.ContinueOnError)
+		identity := fs.String("identity", "", "")
+		role := fs.String("role", "", "")
+		path := fs.String("auth", "./lore.json", "")
+		if err := fs.Parse(args[2:]); err != nil {
+			return err
+		}
+		auth, err := loadPolicy(*path)
+		if err != nil {
+			return err
+		}
+		if _, ok := auth.Roles[*role]; !ok {
+			return fmt.Errorf("unknown role %q", *role)
+		}
+		for i := range auth.Identities {
+			if auth.Identities[i].Name == *identity {
+				if args[1] == "add" {
+					for _, r := range auth.Identities[i].Roles {
+						if r == *role {
+							return savePolicy(*path, auth)
+						}
+					}
+					auth.Identities[i].Roles = append(auth.Identities[i].Roles, *role)
+				} else if args[1] == "remove" {
+					rs := auth.Identities[i].Roles[:0]
+					for _, r := range auth.Identities[i].Roles {
+						if r != *role {
+							rs = append(rs, r)
+						}
+					}
+					auth.Identities[i].Roles = rs
+				} else {
+					return fmt.Errorf("usage: identity role add|remove")
+				}
+				return savePolicy(*path, auth)
+			}
+		}
+		return fmt.Errorf("unknown identity %q", *identity)
+	}
+	return fmt.Errorf("usage: identity add|role add|remove")
+}
+
+func runRoleCommand(args []string, out io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: role add|remove|grant|revoke|deny|undeny|capability")
+	}
+	fs := flag.NewFlagSet("role "+args[0], flag.ContinueOnError)
+	name := fs.String("name", "", "")
+	role := fs.String("role", "", "")
+	docset := fs.String("docset", "", "")
+	grant := fs.String("grant", "", "")
+	comment := fs.String("comment", "", "")
+	capability := fs.String("capability", "", "")
+	effect := fs.String("effect", "", "")
+	path := fs.String("auth", "./lore.json", "")
+	parseFrom := 1
+	capAction := ""
+	if args[0] == "capability" {
+		if len(args) < 2 {
+			return fmt.Errorf("capability action required")
+		}
+		capAction = args[1]
+		parseFrom = 2
+	}
+	if err := fs.Parse(args[parseFrom:]); err != nil {
+		return err
+	}
+	auth, err := loadPolicy(*path)
+	if err != nil {
+		return err
+	}
+	if auth.Roles == nil {
+		auth.Roles = map[string]config.RoleSpec{}
+	}
+	if *role == "" {
+		*role = *name
+	}
+	spec, exists := auth.Roles[*role]
+	switch args[0] {
+	case "add":
+		if *role == "guest" {
+			return fmt.Errorf("guest is reserved")
+		}
+		if *role == "" || exists {
+			return fmt.Errorf("invalid or existing role %q", *role)
+		}
+		auth.Roles[*role] = config.RoleSpec{Comment: *comment}
+	case "remove":
+		if *role == "guest" {
+			return fmt.Errorf("guest is reserved")
+		}
+		if !exists {
+			return fmt.Errorf("unknown role %q", *role)
+		}
+		for _, id := range auth.Identities {
+			for _, r := range id.Roles {
+				if r == *role {
+					return fmt.Errorf("role %q is referenced by identity %q", *role, id.Name)
+				}
+			}
+		}
+		for n, ds := range auth.Docsets {
+			if _, ok := ds.Access.Allow[*role]; ok {
+				return fmt.Errorf("role %q is referenced by docset %q", *role, n)
+			}
+			for _, r := range ds.Access.Deny {
+				if r == *role {
+					return fmt.Errorf("role %q is referenced by docset %q", *role, n)
+				}
+			}
+		}
+		delete(auth.Roles, *role)
+	case "grant", "revoke", "deny", "undeny":
+		if !exists && *role != "guest" {
+			return fmt.Errorf("unknown role %q", *role)
+		}
+		ds, ok := auth.Docsets[*docset]
+		if !ok {
+			return fmt.Errorf("unknown docset %q", *docset)
+		}
+		if ds.Access.Allow == nil {
+			ds.Access.Allow = map[string]string{}
+		}
+		if args[0] == "grant" {
+			if *grant == "" {
+				return fmt.Errorf("grant required")
+			}
+			ds.Access.Allow[*role] = *grant
+		} else if args[0] == "revoke" {
+			delete(ds.Access.Allow, *role)
+		} else if args[0] == "deny" {
+			found := false
+			for _, r := range ds.Access.Deny {
+				found = found || r == *role
+			}
+			if !found {
+				ds.Access.Deny = append(ds.Access.Deny, *role)
+			}
+		} else {
+			rs := ds.Access.Deny[:0]
+			for _, r := range ds.Access.Deny {
+				if r != *role {
+					rs = append(rs, r)
+				}
+			}
+			ds.Access.Deny = rs
+		}
+		auth.Docsets[*docset] = ds
+	case "capability":
+		if *role == "guest" {
+			return fmt.Errorf("guest capability mutation is forbidden")
+		}
+		if !exists || *capability == "" {
+			return fmt.Errorf("unknown role or empty capability")
+		}
+		add := func(xs []string) []string {
+			for _, x := range xs {
+				if x == *capability {
+					return xs
+				}
+			}
+			return append(xs, *capability)
+		}
+		remove := func(xs []string) []string {
+			out := xs[:0]
+			for _, x := range xs {
+				if x != *capability {
+					out = append(out, x)
+				}
+			}
+			return out
+		}
+		if capAction == "allow" {
+			spec.Allow.Capabilities = add(spec.Allow.Capabilities)
+		} else if capAction == "deny" {
+			spec.Deny.Capabilities = add(spec.Deny.Capabilities)
+		} else if capAction == "remove" {
+			if *effect == "allow" {
+				spec.Allow.Capabilities = remove(spec.Allow.Capabilities)
+			} else if *effect == "deny" {
+				spec.Deny.Capabilities = remove(spec.Deny.Capabilities)
+			} else {
+				return fmt.Errorf("effect must be allow or deny")
+			}
+		} else {
+			return fmt.Errorf("invalid capability action")
+		}
+		auth.Roles[*role] = spec
+	default:
+		return fmt.Errorf("unknown role command %q", args[0])
+	}
+	if err := savePolicy(*path, auth); err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "Updated role policy")
+	return nil
+}
 
 func main() {
 	// Handle subcommands before flag parsing
@@ -185,120 +472,21 @@ func main() {
 
 		case "identity":
 			if len(os.Args) < 3 {
-				fmt.Fprintf(os.Stderr, "Usage: openlore identity <command>\n\n")
-				fmt.Fprintf(os.Stderr, "Commands:\n")
-				fmt.Fprintf(os.Stderr, "  add    Add a public key identity to lore.json\n")
+				fmt.Fprintln(os.Stderr, "Usage: openlore identity add|role add|remove")
 				os.Exit(1)
 			}
-
-			switch os.Args[2] {
-			case "add":
-				idCmd := flag.NewFlagSet("identity add", flag.ExitOnError)
-				name := idCmd.String("name", "", "identity name (required)")
-				key := idCmd.String("key", "", "SSH public key (optional: an identity may be passkey/token-only)")
-				docset := idCmd.String("docset", "", "docset to grant access to (required)")
-				grant := idCmd.String("grant", "ro", "grant on the docset: ro, rw, or publish")
-				authPath := idCmd.String("auth", "./lore.json", "path to lore.json")
-				comment := idCmd.String("comment", "", "optional comment")
-				home := idCmd.String("home", "", "docset in the identity's grants to use as home ($HOME)")
-				idCmd.Usage = func() {
-					fmt.Fprintf(os.Stderr, "Usage: openlore identity add [flags]\n\n")
-					fmt.Fprintf(os.Stderr, "Add an identity with a per-docset grant to lore.json.\n\n")
-					idCmd.PrintDefaults()
-				}
-				idCmd.Parse(os.Args[3:])
-
-				if *name == "" || *docset == "" || *grant == "" {
-					idCmd.Usage()
-					os.Exit(1)
-				}
-
-				// Validate the public key when one is given (it is optional).
-				if *key != "" {
-					if _, _, _, _, err := gossh.ParseAuthorizedKey([]byte(*key)); err != nil {
-						fmt.Fprintf(os.Stderr, "error: invalid SSH public key: %v\n", err)
-						os.Exit(1)
-					}
-				}
-
-				// Load or create auth config
-				var auth openlore.AuthConfig
-				data, readErr := os.ReadFile(*authPath)
-				if readErr == nil {
-					if err := json.Unmarshal(data, &auth); err != nil {
-						fmt.Fprintf(os.Stderr, "error: parsing %s: %v\n", *authPath, err)
-						os.Exit(1)
-					}
-				} else if os.IsNotExist(readErr) {
-					auth.Docsets = map[string]openlore.DocsetSpec{
-						"all": {Paths: []openlore.PathMapping{{Source: "/", Display: "/"}}},
-					}
-				} else {
-					fmt.Fprintf(os.Stderr, "error: reading %s: %v\n", *authPath, readErr)
-					os.Exit(1)
-				}
-
-				// Check the docset exists.
-				if _, ok := auth.Docsets[*docset]; !ok {
-					fmt.Fprintf(os.Stderr, "error: docset %q not found in %s\n", *docset, *authPath)
-					fmt.Fprintf(os.Stderr, "Available docsets: ")
-					for k := range auth.Docsets {
-						fmt.Fprintf(os.Stderr, "%s ", k)
-					}
-					fmt.Fprintln(os.Stderr)
-					os.Exit(1)
-				}
-
-				// If a home docset is given, it must be the granted docset.
-				if *home != "" && *home != *docset {
-					fmt.Fprintf(os.Stderr, "error: home docset %q is not in the identity's grants\n", *home)
-					os.Exit(1)
-				}
-
-				// Check for duplicate keys (only when a key is provided).
-				if *key != "" {
-					for _, ident := range auth.Identities {
-						if strings.TrimSpace(ident.PublicKey) == strings.TrimSpace(*key) {
-							fmt.Fprintf(os.Stderr, "error: public key already exists for identity %q\n", ident.Name)
-							os.Exit(1)
-						}
-					}
-				}
-
-				// Add identity
-				newIdent := openlore.AuthIdentity{
-					Name:    *name,
-					Docsets: map[string]string{*docset: *grant},
-				}
-				if *key != "" {
-					newIdent.PublicKey = strings.TrimSpace(*key)
-				}
-				if *comment != "" {
-					newIdent.Comment = *comment
-				}
-				if *home != "" {
-					newIdent.Home = *home
-				}
-				auth.Identities = append(auth.Identities, newIdent)
-
-				// Write back
-				out, err := json.MarshalIndent(auth, "", "  ")
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "error: marshaling JSON: %v\n", err)
-					os.Exit(1)
-				}
-				if err := os.WriteFile(*authPath, append(out, '\n'), 0644); err != nil {
-					fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", *authPath, err)
-					os.Exit(1)
-				}
-
-				fmt.Printf("Added identity %q with %s grant on docset %q to %s\n", *name, *grant, *docset, *authPath)
-				os.Exit(0)
-
-			default:
-				fmt.Fprintf(os.Stderr, "Unknown identity command: %s\n", os.Args[2])
+			if err := runIdentityCommand(os.Args[2:], os.Stdout); err != nil {
+				fmt.Fprintln(os.Stderr, "error:", err)
 				os.Exit(1)
 			}
+			return
+
+		case "role":
+			if err := runRoleCommand(os.Args[2:], os.Stdout); err != nil {
+				fmt.Fprintln(os.Stderr, "error:", err)
+				os.Exit(1)
+			}
+			return
 
 		case "token":
 			if len(os.Args) < 3 {

--- a/cmd/openlore/main_test.go
+++ b/cmd/openlore/main_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func policyFile(t *testing.T, auth config.AuthConfig) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "lore.json")
+	b, err := json.Marshal(auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, b, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func readPolicy(t *testing.T, p string) config.AuthConfig {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var auth config.AuthConfig
+	if err := json.Unmarshal(b, &auth); err != nil {
+		t.Fatal(err)
+	}
+	return auth
+}
+
+func TestRoleAndIdentityCommands(t *testing.T) {
+	auth := config.AuthConfig{
+		Roles:   map[string]config.RoleSpec{"reader": {}, "other": {}},
+		Docsets: map[string]config.DocsetSpec{"docs": {Paths: []config.PathMapping{{Source: "/docs"}}}, "home": {Paths: []config.PathMapping{{Source: "/home"}}}},
+	}
+	p := policyFile(t, auth)
+	role := func(args ...string) {
+		t.Helper()
+		args = append(args, "-auth", p)
+		if err := runRoleCommand(args, &bytes.Buffer{}); err != nil {
+			t.Fatalf("role %v: %v", args, err)
+		}
+	}
+	identity := func(args ...string) {
+		t.Helper()
+		args = append(args, "-auth", p)
+		if err := runIdentityCommand(args, &bytes.Buffer{}); err != nil {
+			t.Fatalf("identity %v: %v", args, err)
+		}
+	}
+
+	t.Run("role add with comment", func(t *testing.T) {
+		role("add", "-name", "editor", "-comment", "Edits docs")
+		if got := readPolicy(t, p).Roles["editor"].Comment; got != "Edits docs" {
+			t.Fatalf("comment = %q", got)
+		}
+	})
+	t.Run("grant overwrite revoke deny undeny", func(t *testing.T) {
+		role("grant", "-role", "editor", "-docset", "docs", "-grant", "ro")
+		role("grant", "-role", "editor", "-docset", "docs", "-grant", "rw")
+		if got := readPolicy(t, p).Docsets["docs"].Access.Allow["editor"]; got != "rw" {
+			t.Fatalf("grant = %q", got)
+		}
+		role("deny", "-role", "editor", "-docset", "docs")
+		if got := readPolicy(t, p).Docsets["docs"].Access.Deny; len(got) != 1 || got[0] != "editor" {
+			t.Fatalf("deny = %v", got)
+		}
+		role("undeny", "-role", "editor", "-docset", "docs")
+		role("revoke", "-role", "editor", "-docset", "docs")
+		ds := readPolicy(t, p).Docsets["docs"]
+		if len(ds.Access.Deny) != 0 || ds.Access.Allow["editor"] != "" {
+			t.Fatalf("access = %+v", ds.Access)
+		}
+	})
+	t.Run("capabilities", func(t *testing.T) {
+		role("capability", "allow", "-role", "editor", "-capability", "spawn")
+		role("capability", "deny", "-role", "editor", "-capability", "spawn")
+		r := readPolicy(t, p).Roles["editor"]
+		if len(r.Allow.Capabilities) != 1 || len(r.Deny.Capabilities) != 1 {
+			t.Fatalf("role = %+v", r)
+		}
+		role("capability", "remove", "-effect", "allow", "-role", "editor", "-capability", "spawn")
+		role("capability", "remove", "-effect", "deny", "-role", "editor", "-capability", "spawn")
+		r = readPolicy(t, p).Roles["editor"]
+		if len(r.Allow.Capabilities)+len(r.Deny.Capabilities) != 0 {
+			t.Fatalf("role = %+v", r)
+		}
+	})
+	t.Run("identity roles", func(t *testing.T) {
+		identity("add", "-name", "alice", "-role", "reader", "-role", "editor")
+		identity("add", "-name", "nobody")
+		a := readPolicy(t, p)
+		if len(a.Identities) != 2 || len(a.Identities[0].Roles) != 2 || len(a.Identities[1].Roles) != 0 {
+			t.Fatalf("identities = %+v", a.Identities)
+		}
+		identity("role", "add", "-identity", "nobody", "-role", "other")
+		identity("role", "remove", "-identity", "nobody", "-role", "other")
+		if got := readPolicy(t, p).Identities[1].Roles; len(got) != 0 {
+			t.Fatalf("roles = %v", got)
+		}
+	})
+	t.Run("guest docset", func(t *testing.T) {
+		role("grant", "-role", "guest", "-docset", "docs", "-grant", "ro")
+		if got := readPolicy(t, p).Docsets["docs"].Access.Allow["guest"]; got != "ro" {
+			t.Fatalf("grant = %q", got)
+		}
+		role("revoke", "-role", "guest", "-docset", "docs")
+		if _, ok := readPolicy(t, p).Docsets["docs"].Access.Allow["guest"]; ok {
+			t.Fatal("guest grant remains")
+		}
+	})
+}
+
+func TestCommandPolicyValidationFailures(t *testing.T) {
+	public, _, _ := ed25519.GenerateKey(bytes.NewReader(bytes.Repeat([]byte{7}, ed25519.SeedSize)))
+	key, err := gossh.NewPublicKey(public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyText := strings.TrimSpace(string(gossh.MarshalAuthorizedKey(key)))
+	tests := []struct {
+		name     string
+		auth     config.AuthConfig
+		run      func(string) error
+		contains string
+	}{
+		{"duplicate identity", config.AuthConfig{Roles: map[string]config.RoleSpec{}, Docsets: map[string]config.DocsetSpec{}, Identities: []config.AuthIdentity{{Name: "alice"}}}, func(p string) error {
+			return runIdentityCommand([]string{"add", "-name", "alice", "-auth", p}, &bytes.Buffer{})
+		}, "already exists"},
+		{"normalized key", config.AuthConfig{Roles: map[string]config.RoleSpec{}, Docsets: map[string]config.DocsetSpec{}, Identities: []config.AuthIdentity{{Name: "alice", PublicKey: keyText + " old"}}}, func(p string) error {
+			return runIdentityCommand([]string{"add", "-name", "bob", "-key", keyText + " new", "-auth", p}, &bytes.Buffer{})
+		}, "share public key"},
+		{"home deny", config.AuthConfig{Roles: map[string]config.RoleSpec{"r": {}}, Docsets: map[string]config.DocsetSpec{"home": {Paths: []config.PathMapping{{Source: "/home"}}, Access: config.DocsetAccess{Deny: []string{"r"}}}}}, func(p string) error {
+			return runIdentityCommand([]string{"add", "-name", "alice", "-home", "home", "-role", "r", "-auth", p}, &bytes.Buffer{})
+		}, "denied on its home"},
+		{"remove identity reference", config.AuthConfig{Roles: map[string]config.RoleSpec{"r": {}}, Docsets: map[string]config.DocsetSpec{}, Identities: []config.AuthIdentity{{Name: "alice", Roles: []string{"r"}}}}, func(p string) error {
+			return runRoleCommand([]string{"remove", "-role", "r", "-auth", p}, &bytes.Buffer{})
+		}, "referenced by identity"},
+		{"remove docset reference", config.AuthConfig{Roles: map[string]config.RoleSpec{"r": {}}, Docsets: map[string]config.DocsetSpec{"docs": {Paths: []config.PathMapping{{Source: "/docs"}}, Access: config.DocsetAccess{Allow: map[string]string{"r": "ro"}}}}}, func(p string) error {
+			return runRoleCommand([]string{"remove", "-role", "r", "-auth", p}, &bytes.Buffer{})
+		}, "referenced by docset"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := policyFile(t, tt.auth)
+			before, _ := os.ReadFile(p)
+			err := tt.run(p)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("error = %v, want %q", err, tt.contains)
+			}
+			after, _ := os.ReadFile(p)
+			if !bytes.Equal(before, after) {
+				t.Fatal("rejected command changed JSON")
+			}
+		})
+	}
+}

--- a/internal/config/auth_home_test.go
+++ b/internal/config/auth_home_test.go
@@ -23,7 +23,7 @@ func TestLoadAuthConfigHomeValid(t *testing.T) {
 			"agent-home": {"paths": [{"published/agent": "/home/agent"}]}
 		},
 		"identities": [
-			{"name": "a1", "public_key": "ssh-ed25519 AAAA", "docsets": {"public": "ro", "agent-home": "rw"}, "home": "agent-home"}
+			{"name": "a1", "docsets": {"public": "ro", "agent-home": "rw"}, "home": "agent-home"}
 		]
 	}`)
 
@@ -36,23 +36,23 @@ func TestLoadAuthConfigHomeValid(t *testing.T) {
 	}
 }
 
-func TestLoadAuthConfigHomeNotInGrants(t *testing.T) {
+func TestLoadAuthConfigHomeDoesNotRequireLegacyGrant(t *testing.T) {
 	p := writeAuth(t, `{
 		"docsets": {
 			"public": {"paths": ["/docs/public"]},
 			"other": {"paths": ["/docs/other"]}
 		},
 		"identities": [
-			{"name": "a1", "public_key": "ssh-ed25519 AAAA", "docsets": {"public": "ro"}, "home": "other"}
+			{"name": "a1", "docsets": {"public": "ro"}, "home": "other"}
 		]
 	}`)
 
-	if _, err := LoadAuthConfig(p); err == nil {
-		t.Fatal("expected error for home docset not in grants, got nil")
+	if _, err := LoadAuthConfig(p); err != nil {
+		t.Fatalf("home ownership is independent of legacy grants: %v", err)
 	}
 }
 
-func TestLoadAuthConfigUnknownDocset(t *testing.T) {
+func TestLoadAuthConfigIgnoresLegacyUnknownDocset(t *testing.T) {
 	p := writeAuth(t, `{
 		"docsets": {"public": {"paths": ["/docs/public"]}},
 		"identities": [
@@ -60,8 +60,8 @@ func TestLoadAuthConfigUnknownDocset(t *testing.T) {
 		]
 	}`)
 
-	if _, err := LoadAuthConfig(p); err == nil {
-		t.Fatal("expected error for grant on unknown docset, got nil")
+	if _, err := LoadAuthConfig(p); err != nil {
+		t.Fatalf("legacy identity grants must be ignored: %v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/aakarim/go-openlore/pkg/vfs"
+	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
 )
 
@@ -165,10 +167,27 @@ type AuthConfig struct {
 	UnknownIdentity string                `json:"unknown_identity,omitempty"`
 	DefaultCwd      string                `json:"default_cwd,omitempty"`
 	Docsets         map[string]DocsetSpec `json:"docsets"`
-	// Default is the docset→grant map applied to keyless / unrecognized callers
-	// (the former `lore.default`). Empty = no access for anonymous sessions.
+	Roles           map[string]RoleSpec   `json:"roles,omitempty"`
+	// Default is a legacy authority field retained only for JSON parsing. It is ignored.
 	Default    map[string]string `json:"default,omitempty"`
 	Identities []AuthIdentity    `json:"identities"`
+}
+
+type CapabilityRules struct {
+	Capabilities []string `json:"capabilities,omitempty"`
+}
+
+// RoleSpec is a reusable set of capabilities. Docset grants are resource-side
+// ACL entries, not properties of the role itself.
+type RoleSpec struct {
+	Comment string          `json:"comment,omitempty"`
+	Allow   CapabilityRules `json:"allow,omitempty"`
+	Deny    CapabilityRules `json:"deny,omitempty"`
+}
+
+type DocsetAccess struct {
+	Allow map[string]string `json:"allow,omitempty"`
+	Deny  []string          `json:"deny,omitempty"`
 }
 
 // AuthTokensConfig controls the bearer-token issuer for the MCP + HTTP API.
@@ -196,7 +215,8 @@ type JWKSSpec struct {
 
 // DocsetSpec defines a named set of path mappings.
 type DocsetSpec struct {
-	Paths []PathMapping `json:"paths"`
+	Paths  []PathMapping `json:"paths"`
+	Access DocsetAccess  `json:"access,omitempty"`
 	// Aliases are alternate display roots for the first path. They expose the
 	// same content while the first path remains canonical for home, inbox,
 	// policy, hooks, and changesets.
@@ -233,6 +253,14 @@ type PathMapping struct {
 	Display string // the path shown in the shell (empty = same as Source)
 }
 
+// MarshalJSON preserves the two input forms accepted by UnmarshalJSON.
+func (p PathMapping) MarshalJSON() ([]byte, error) {
+	if p.Display == "" || p.Display == p.Source {
+		return json.Marshal(p.Source)
+	}
+	return json.Marshal(map[string]string{p.Source: p.Display})
+}
+
 // UnmarshalJSON supports both string and {"source": "display"} forms.
 func (p *PathMapping) UnmarshalJSON(data []byte) error {
 	// Try string first
@@ -258,23 +286,21 @@ func (p *PathMapping) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// AuthIdentity defines a user identity and its per-docset grants.
+// AuthIdentity defines a user identity and its role membership.
 type AuthIdentity struct {
 	Name    string `json:"name"`
 	Comment string `json:"comment,omitempty"`
 	// PublicKey is optional: an identity may exist purely as a passkey/token
 	// login target (no SSH key). Empty = no SSH public-key auth for this identity.
-	PublicKey string `json:"public_key,omitempty"`
-	// Docsets maps a docset name to the grant this identity holds on it
-	// (e.g. "ro", "rw", "publish"). Grant names must be registered grant types
-	// at server startup, else the server refuses to boot (fail-closed).
+	PublicKey string   `json:"public_key,omitempty"`
+	Roles     []string `json:"roles,omitempty"`
+	// Docsets is a legacy authority field retained only for JSON parsing. It is ignored.
 	Docsets map[string]string `json:"docsets"`
 	// Home names the docset that serves as this identity's home directory. Its
 	// display path becomes $HOME and the session's initial working directory.
-	// Must be one of the docsets in the identity's grants. Empty = no home.
+	// Home ownership provides implicit rw unless a nested docset takes precedence.
 	Home string `json:"home,omitempty"`
-	// Capabilities are the extra capabilities this identity holds, e.g.
-	// "spawn" to authorize the async external-work command.
+	// Capabilities is a legacy authority field retained only for JSON parsing. It is ignored.
 	Capabilities []string `json:"capabilities,omitempty"`
 
 	// Match lists the token-claim predicates that resolve TO this identity.
@@ -915,34 +941,122 @@ func LoadAuthConfig(path string) (*AuthConfig, error) {
 		return nil, err
 	}
 
-	// Every docset referenced by an identity's grants or by the anonymous
-	// default must exist; home must be one of the identity's granted docsets.
-	// Grant *names* are validated against the registered grant types at server
-	// startup (fail-closed), not here — config parsing does not know the plugin
-	// set.
-	for name, grant := range auth.Default {
-		if grant == "" {
-			return nil, fmt.Errorf("default grant for docset %q is empty", name)
+	if err := ValidateAuthConfig(&auth); err != nil {
+		return nil, err
+	}
+	return &auth, nil
+}
+
+// ValidateAuthConfig validates a parsed static authorization policy. Legacy
+// authority fields are deliberately ignored.
+func ValidateAuthConfig(auth *AuthConfig) error {
+	if _, ok := auth.Roles["guest"]; ok {
+		return fmt.Errorf("role %q is reserved", "guest")
+	}
+	validateNames := func(where string, values []string) error {
+		seen := map[string]bool{}
+		for _, value := range values {
+			if value == "" || strings.TrimSpace(value) != value {
+				return fmt.Errorf("%s contains an empty or untrimmed name", where)
+			}
+			if seen[value] {
+				return fmt.Errorf("%s contains duplicate %q", where, value)
+			}
+			seen[value] = true
 		}
-		if _, ok := auth.Docsets[name]; !ok {
-			return nil, fmt.Errorf("default references unknown docset %q", name)
+		return nil
+	}
+	for name, role := range auth.Roles {
+		if name == "" || strings.TrimSpace(name) != name {
+			return fmt.Errorf("invalid role name %q", name)
+		}
+		if err := validateNames(fmt.Sprintf("role %q allow capabilities", name), role.Allow.Capabilities); err != nil {
+			return err
+		}
+		if err := validateNames(fmt.Sprintf("role %q deny capabilities", name), role.Deny.Capabilities); err != nil {
+			return err
 		}
 	}
+	homes := map[string]string{}
+	identities := map[string]bool{}
+	keys := map[string]string{}
 	for _, ident := range auth.Identities {
-		for name, grant := range ident.Docsets {
-			if grant == "" {
-				return nil, fmt.Errorf("identity %q grant for docset %q is empty", ident.Name, name)
+		if ident.Name == "" || strings.TrimSpace(ident.Name) != ident.Name {
+			return fmt.Errorf("invalid identity name %q", ident.Name)
+		}
+		if ident.Name == "guest" || ident.Name == "anonymous" {
+			return fmt.Errorf("identity %q is reserved", ident.Name)
+		}
+		if identities[ident.Name] {
+			return fmt.Errorf("duplicate identity name %q", ident.Name)
+		}
+		identities[ident.Name] = true
+		if key := strings.TrimSpace(ident.PublicKey); key != "" {
+			parsed, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
+			if err != nil {
+				return fmt.Errorf("identity %q has invalid SSH public key: %w", ident.Name, err)
 			}
-			if _, ok := auth.Docsets[name]; !ok {
-				return nil, fmt.Errorf("identity %q references unknown docset %q", ident.Name, name)
+			normalized := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(parsed)))
+			if other, ok := keys[normalized]; ok {
+				return fmt.Errorf("identities %q and %q share public key", other, ident.Name)
+			}
+			keys[normalized] = ident.Name
+		}
+		if err := validateNames(fmt.Sprintf("identity %q roles", ident.Name), ident.Roles); err != nil {
+			return err
+		}
+		for _, role := range ident.Roles {
+			if role == "guest" {
+				return fmt.Errorf("identity %q cannot be assigned reserved role guest", ident.Name)
+			}
+			if _, ok := auth.Roles[role]; !ok {
+				return fmt.Errorf("identity %q references unknown role %q", ident.Name, role)
 			}
 		}
 		if ident.Home != "" {
-			if _, ok := ident.Docsets[ident.Home]; !ok {
-				return nil, fmt.Errorf("identity %q home docset %q is not in its grants", ident.Name, ident.Home)
+			if _, ok := auth.Docsets[ident.Home]; !ok {
+				return fmt.Errorf("identity %q references unknown home docset %q", ident.Name, ident.Home)
+			}
+			if other, ok := homes[ident.Home]; ok {
+				return fmt.Errorf("identities %q and %q share home docset %q", other, ident.Name, ident.Home)
+			}
+			homes[ident.Home] = ident.Name
+		}
+	}
+	for docset, ds := range auth.Docsets {
+		for role, grant := range ds.Access.Allow {
+			if grant == "" || strings.TrimSpace(grant) != grant {
+				return fmt.Errorf("docset %q has invalid grant for role %q", docset, role)
+			}
+			if role != "guest" {
+				if _, ok := auth.Roles[role]; !ok {
+					return fmt.Errorf("docset %q references unknown role %q", docset, role)
+				}
+			}
+		}
+		if err := validateNames(fmt.Sprintf("docset %q deny roles", docset), ds.Access.Deny); err != nil {
+			return err
+		}
+		for _, role := range ds.Access.Deny {
+			if role != "guest" {
+				if _, ok := auth.Roles[role]; !ok {
+					return fmt.Errorf("docset %q denies unknown role %q", docset, role)
+				}
+			}
+		}
+	}
+	for _, ident := range auth.Identities {
+		if ident.Home != "" {
+			ds := auth.Docsets[ident.Home]
+			for _, denied := range ds.Access.Deny {
+				for _, role := range ident.Roles {
+					if denied == role {
+						return fmt.Errorf("identity %q role %q is denied on its home %q", ident.Name, role, ident.Home)
+					}
+				}
 			}
 		}
 	}
 
-	return &auth, nil
+	return nil
 }

--- a/lore.json.example
+++ b/lore.json.example
@@ -1,136 +1,45 @@
 {
   "allow_keyless": true,
   "unknown_identity": "allow",
-  "default_cwd": "/docs",
-
-  "//tokens": "Bearer-token auth for the MCP + HTTP API is SERVER config: set the `tokens:` block in openlore.yml, not here. lore.json is access policy (who can see what); token issuance is infrastructure.",
-
-  "//grants": "An identity holds a named GRANT on each docset it can access. Core grants: `ro` (read the whole docset) and `rw` (read + write anywhere in the docset). The inbox plugin adds `publish` (read the whole docset, no deletes, create/edit only within the docset's `inbox` folder). A grant name with no registered handler makes the server refuse to start.",
-
-  "//okf": "Add an `okf` block to a docset to validate Open Knowledge Format documents on write across that docset's subtree. `patterns` (default [\"*.md\"]) are basename globs; `enforce` (default true) rejects non-conformant writes (false = log and allow). A write is governed by the OKF config of the docset that OWNS its path (longest matching display root, same as grants). Scope narrower subtrees with nested docsets: `personal` below has no okf, but the nested `personal-wiki` docset enforces OKF only under /home/personal/wiki without re-declaring any grants (writes still authorize through the parent's grant).",
-
-  "docsets": {
-    "public": {
-      "paths": [
-        "/docs/public",
-        "/docs/getting-started.md"
-      ]
+  "default_cwd": "/docs/public",
+  "roles": {
+    "engineer": {
+      "comment": "Engineering agents",
+      "allow": { "capabilities": ["spawn"] }
     },
-    "frontend": {
-      "paths": [
-        "/docs/frontend",
-        "/docs/shared",
-        "/docs/components"
-      ]
-    },
-    "backend": {
-      "paths": [
-        "/docs/backend",
-        "/docs/api",
-        {"internal/db-schema": "/docs/database"},
-        "/docs/shared"
-      ],
-      "inbox": "inbox",
-      "max_write_size": 5000000
-    },
-    "backend-home": {
-      "paths": [
-        {"published/backend-home": "/home/backend"}
-      ],
-      "aliases": ["/backend"],
-      "inbox": "inbox"
-    },
-    "ops": {
-      "paths": [
-        "/docs/infrastructure",
-        {"internal/runbooks/on-call.md": "/docs/runbooks/on-call.md"},
-        "/docs/deployment"
-      ]
-    },
-    "wiki": {
-      "//": "OKF enforced across this whole docset: any *.md write must be a conformant OKF concept (parseable YAML frontmatter with a non-empty `type`), else it is rejected before it hits disk.",
-      "paths": [
-        "/docs/wiki"
-      ],
-      "okf": {
-        "patterns": ["*.md"],
-        "enforce": true
-      }
-    },
-    "personal": {
-      "//": "No okf here: writes anywhere under /home/personal are unvalidated…",
-      "paths": [
-        {"published/personal": "/home/personal"}
-      ],
-      "inbox": "inbox"
-    },
-    "personal-wiki": {
-      "//": "…except this nested docset, which owns /home/personal/wiki (longer matching root) and enforces OKF only there. It carries no grants, so it does not change who can write — writes still authorize through the parent `personal` grant; it only attaches OKF to the subtree.",
-      "paths": [
-        {"published/personal/wiki": "/home/personal/wiki"}
-      ],
-      "okf": {}
+    "reviewer": {
+      "allow": { "capabilities": ["review"] },
+      "deny": { "capabilities": ["spawn"] }
     }
   },
-
-  "//default": "The docset→grant map applied to keyless / unrecognized callers. Omit for no anonymous access.",
-  "default": {
-    "public": "ro"
+  "docsets": {
+    "public": {
+      "paths": ["/docs/public"],
+      "access": { "allow": { "guest": "ro", "engineer": "rw", "reviewer": "ro" } }
+    },
+    "backend": {
+      "paths": ["/docs/backend"],
+      "inbox": "inbox",
+      "access": {
+        "allow": { "engineer": "rw", "reviewer": "publish" },
+        "deny": []
+      }
+    },
+    "engineer-home": {
+      "paths": [{ "published/engineer": "/home/engineer" }]
+    }
   },
-
   "identities": [
     {
-      "name": "frontend-agent",
-      "comment": "Claude agent for frontend team",
-      "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleFrontendKeyHere frontend-agent",
-      "docsets": {
-        "public": "ro",
-        "frontend": "rw"
-      }
-    },
-    {
       "name": "backend-agent",
-      "comment": "GPT agent for backend services",
+      "comment": "Backend automation",
       "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleBackendKeyHere backend-agent",
-      "docsets": {
-        "public": "ro",
-        "backend": "rw",
-        "backend-home": "rw"
-      },
-      "home": "backend-home"
+      "roles": ["engineer", "reviewer"],
+      "home": "engineer-home"
     },
     {
-      "name": "contributor",
-      "comment": "Outside collaborator: can read backend docs and drop files into its inbox, but cannot edit the rest or delete anything",
-      "docsets": {
-        "public": "ro",
-        "backend": "publish"
-      }
-    },
-    {
-      "name": "ops-agent",
-      "comment": "Infrastructure and deployment docs",
-      "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleOpsKeyHere ops-agent",
-      "docsets": {
-        "public": "ro",
-        "ops": "rw"
-      }
-    },
-    {
-      "name": "read-all",
-      "comment": "Full read access to all documentation",
-      "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleReadAllKeyHere admin",
-      "docsets": {
-        "public": "ro",
-        "frontend": "ro",
-        "backend": "ro",
-        "ops": "ro"
-      },
-      "//match": "Optional: extra token-claim predicates that resolve TO this identity. A token whose `sub` == the identity Name resolves here automatically; add `match` only to map additional subjects (aliases) or WIF assertions via `sub_prefix`/`aud`/`claims`. `scope` narrows (e.g. \"read\") and `ttl` caps matched WIF tokens. Exact `sub` beats pattern matches.",
-      "match": [
-        { "sub": "alice" },
-        { "sub_prefix": "repo:my-org/my-repo:", "aud": "https://docs.example.com", "scope": "read", "ttl": "15m" }
-      ]
+      "name": "passkey-only-reviewer",
+      "roles": ["reviewer"]
     }
   ]
 }

--- a/openlore.sh/docs/auth.md
+++ b/openlore.sh/docs/auth.md
@@ -4,14 +4,71 @@
 
 By default, any SSH client can connect. No keys required.
 
-## Docsets & Lore
+## RBAC Quick Start
 
-Access control is built on two concepts:
+Create `lore.json` next to `openlore.yml`. This example gives keyless visitors
+read-only public docs, reviewers read-only backend docs, and engineers
+read/write backend docs:
 
-- **Docsets** — atomic document collections with path mappings (an agent's workspace)
-- **Lore** — named compositions of docsets (what an identity can access)
+```json
+{
+  "allow_keyless": true,
+  "unknown_identity": "deny",
+  "roles": {
+    "reviewer": {},
+    "engineer": {}
+  },
+  "docsets": {
+    "public": {
+      "paths": ["/docs/public"],
+      "access": {
+        "allow": { "guest": "ro", "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "backend": {
+      "paths": ["/docs/backend"],
+      "access": {
+        "allow": { "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "engineer-home": {
+      "paths": [{ "homes/engineer": "/home/engineer" }]
+    }
+  },
+  "identities": [
+    {
+      "name": "engineering-agent",
+      "public_key": "ssh-ed25519 AAAA...",
+      "roles": ["engineer", "reviewer"],
+      "home": "engineer-home"
+    }
+  ]
+}
+```
 
-Each identity references a lore name, which resolves to one or more docsets. When multiple docsets are in a lore, each appears as a subdirectory.
+Enable it in `openlore.yml`:
+
+```yaml
+auth_file: ./lore.json
+readonly: false # keep true if no role should be able to write
+```
+
+Then start OpenLore normally. No role-management commands are required; edit
+`lore.json` and restart the server after changing file-backed policy.
+
+### How access is resolved
+
+- `roles` declares the exact role names available to identities. Roles are flat
+  and do not inherit.
+- `docsets` own access policy. `access.allow` maps each role to `ro`, `rw`, or a
+  plugin grant such as `publish`.
+- An identity may have multiple roles. Their allows are combined, while any
+  matching role in a docset's `access.deny` denies the entire docset.
+- `guest` is built in for keyless and allowed unknown callers. It can only be
+  granted read-only access.
+- A unique `home` docset is implicitly read/write for its owner and needs no
+  access entry. Nested docsets remain separate access boundaries.
+- A docset without a matching allow is inaccessible.
 
 ## Publishing
 
@@ -70,53 +127,11 @@ Override it per docset in `lore.json` (takes precedence for paths in that docset
 }
 ```
 
-## Public Key Auth
-
-Create a `lore.json` to control per-agent access:
-
-```json
-{
-  "docsets": {
-    "public": { "paths": ["/docs/public"] },
-    "backend": { "paths": ["/docs/api", "/docs/backend"], "publish_dir": "./published/backend" },
-    "frontend": { "paths": ["/docs/frontend", "/docs/shared"] }
-  },
-  "lore": {
-    "default": ["public"],
-    "backend": ["public", "backend"],
-    "engineering": ["public", "backend", "frontend"]
-  },
-  "identities": [
-    {
-      "name": "backend-agent",
-      "public_key": "ssh-ed25519 AAAA...",
-      "lore": "backend"
-    },
-    {
-      "name": "eng-lead",
-      "public_key": "ssh-ed25519 AAAA...",
-      "lore": "engineering"
-    }
-  ]
-}
-```
-
-## Adding Identities
-
-Use the CLI:
-
-```bash
-openlore identity add \
-  --name my-agent \
-  --key "ssh-ed25519 AAAA..." \
-  --lore backend \
-  --auth ./lore.json
-```
-
 ## Unknown Identity Handling
 
 In `lore.json`:
-- `"unknown_identity": "allow"` — unrecognized keys get the "default" lore
+- `"unknown_identity": "allow"` — unrecognized keys receive the built-in
+  `guest` role
 - `"unknown_identity": "deny"` — unrecognized keys are rejected
 
 ## Federated Access (WIF)

--- a/openlore.sh/skills/teach.md
+++ b/openlore.sh/skills/teach.md
@@ -46,29 +46,69 @@ The real power of OpenLore is baking your docs into a single binary that anyone 
 
 ## Setting Up Access Control
 
-If you want different agents to see different docs:
+If you want different agents to have different access, create a `lore.json`
+next to `openlore.yml`. This quick start gives keyless visitors read-only access
+to public docs, reviewers read-only access to backend docs, and engineers
+read/write access to backend docs:
 
-1. Create a `lore.json` (see `lore.json.example`):
-   ```json
-   {
-     "lore": {
-       "default": { "paths": ["/docs/public"] },
-       "backend": { "paths": ["/docs/api", "/docs/backend"] }
-     },
-     "identities": [
-       {
-         "name": "my-agent",
-         "public_key": "ssh-ed25519 AAAA...",
-         "lore": "backend"
-       }
-     ]
-   }
-   ```
+```json
+{
+  "allow_keyless": true,
+  "unknown_identity": "deny",
+  "roles": {
+    "reviewer": {},
+    "engineer": {}
+  },
+  "docsets": {
+    "public": {
+      "paths": ["/docs/public"],
+      "access": {
+        "allow": { "guest": "ro", "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "backend": {
+      "paths": ["/docs/backend"],
+      "access": {
+        "allow": { "reviewer": "ro", "engineer": "rw" }
+      }
+    },
+    "engineer-home": {
+      "paths": [{ "homes/engineer": "/home/engineer" }]
+    }
+  },
+  "identities": [
+    {
+      "name": "engineering-agent",
+      "public_key": "ssh-ed25519 AAAA...",
+      "roles": ["engineer", "reviewer"],
+      "home": "engineer-home"
+    }
+  ]
+}
+```
 
-2. Start with auth:
-   ```bash
-   openlore --auth lore.json ./docs
-   ```
+- `roles` declares the role names identities may use. Role names are exact and
+  roles do not inherit from one another.
+- Each docset's `access.allow` maps roles to `ro`, `rw`, or a plugin grant such
+  as `publish`. Grants from multiple roles are combined; a role listed in
+  `access.deny` denies the entire docset and overrides all allows.
+- `guest` is built in. It represents keyless and allowed unknown callers and
+  can only be granted read-only access.
+- An identity may have multiple roles. Its unique `home` docset is implicitly
+  read/write for that identity, so it needs no access entry.
+- A docset without a matching allow is inaccessible. Nested docsets are
+  separate access boundaries, including inside a home.
+
+Enable the file in `openlore.yml`, then start OpenLore normally:
+
+```yaml
+auth_file: ./lore.json
+readonly: false # keep true if no role should be able to write
+```
+
+Set `allow_keyless` to `false` if every SSH connection must present a known
+key. Set `unknown_identity` to `allow` only if unknown keys should receive the
+built-in `guest` role.
 
 ## Using the GitHub Action
 

--- a/pkg/openlore/alias_fs_test.go
+++ b/pkg/openlore/alias_fs_test.go
@@ -87,7 +87,8 @@ func TestServerAliasCanonicalizesAuthorizationAndChangesets(t *testing.T) {
 	ds.Aliases = []string{"/alfie"}
 	s.auth.Docsets["alfie"] = ds
 
-	id := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeFull}}
+	id := identityWithPolicy("alfie", "alfie-rw")
+	setCurrentPolicy(s, id)
 	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/note.md") {
 		t.Fatal("alias path should authorize through its canonical docset")
 	}

--- a/pkg/openlore/auth_middleware_test.go
+++ b/pkg/openlore/auth_middleware_test.go
@@ -30,13 +30,13 @@ func newTokenTestServer(t *testing.T, allowKeyless bool, unknownIdentity string)
 		auth: &config.AuthConfig{
 			AllowKeyless:    &keyless,
 			UnknownIdentity: unknownIdentity,
+			Roles:           map[string]config.RoleSpec{"alice": {}},
 			Docsets: map[string]config.DocsetSpec{
-				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}},
-				"secret": {Paths: []config.PathMapping{{Source: "/secret", Display: "/secret"}}},
+				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}, Access: config.DocsetAccess{Allow: map[string]string{"guest": "ro", "alice": "ro"}}},
+				"secret": {Paths: []config.PathMapping{{Source: "/secret", Display: "/secret"}}, Access: config.DocsetAccess{Allow: map[string]string{"alice": "rw"}}},
 			},
-			Default: map[string]string{"public": "ro"},
 			Identities: []config.AuthIdentity{
-				{Name: "alice", Docsets: map[string]string{"public": "ro", "secret": "rw"}},
+				{Name: "alice", Roles: []string{"alice"}},
 			},
 		},
 		config: config.Config{
@@ -50,6 +50,7 @@ func newTokenTestServer(t *testing.T, allowKeyless bool, unknownIdentity string)
 			},
 		},
 	}
+	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
 	if err := s.initAuth(); err != nil {
 		t.Fatalf("initAuth: %v", err)
 	}
@@ -64,7 +65,13 @@ func (s *Server) identityEcho() http.Handler {
 		if name == "" {
 			name = "anonymous"
 		}
-		w.Write([]byte(name + " " + grantsString(id.Grants)))
+		resolved := map[string]string{}
+		for docset := range s.auth.Docsets {
+			if grants, ok := s.effectiveGrantNames(id, docset); ok {
+				resolved[docset] = grants[len(grants)-1]
+			}
+		}
+		w.Write([]byte(name + " " + grantsString(resolved)))
 	})
 }
 
@@ -101,8 +108,8 @@ func TestAuthMiddleware_KeylessNoTokenIsAnonymous(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	if got := rec.Body.String(); got != "anonymous public:ro" {
-		t.Fatalf("body = %q, want %q", got, "anonymous public:ro")
+	if got := rec.Body.String(); got != "guest public:ro" {
+		t.Fatalf("body = %q, want %q", got, "guest public:ro")
 	}
 }
 
@@ -181,7 +188,7 @@ func TestAuthMiddleware_AnonymousTokenResolvesToDefault(t *testing.T) {
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
-	if got := rec.Body.String(); got != "anonymous public:ro" {
-		t.Fatalf("public token body = %q, want %q", got, "anonymous public:ro")
+	if got := rec.Body.String(); got != "guest public:ro" {
+		t.Fatalf("public token body = %q, want %q", got, "guest public:ro")
 	}
 }

--- a/pkg/openlore/authorization_store.go
+++ b/pkg/openlore/authorization_store.go
@@ -1,0 +1,42 @@
+package openlore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aakarim/go-openlore/internal/config"
+)
+
+// AuthorizationPolicy is current role membership and home ownership for a
+// fully authenticated principal. Policy semantics remain in Server.
+type AuthorizationPolicy struct {
+	IdentityName string
+	Roles        []string
+	HomeDocset   string
+}
+
+// AuthorizationStore separates authentication from current authorization.
+type AuthorizationStore interface {
+	ResolveAuthorization(context.Context, AuthenticatedPrincipal) (AuthorizationPolicy, error)
+}
+
+type fileAuthorizationStore struct{ auth *config.AuthConfig }
+
+func (f fileAuthorizationStore) ResolveAuthorization(_ context.Context, p AuthenticatedPrincipal) (AuthorizationPolicy, error) {
+	if p.IdentityName == "guest" || p.IdentityName == "" {
+		return AuthorizationPolicy{IdentityName: "guest", Roles: []string{"guest"}}, nil
+	}
+	for _, identity := range f.auth.Identities {
+		if identity.Name == p.IdentityName {
+			for _, role := range identity.Roles {
+				if role != "guest" {
+					if _, ok := f.auth.Roles[role]; !ok {
+						return AuthorizationPolicy{}, fmt.Errorf("unknown role %q", role)
+					}
+				}
+			}
+			return AuthorizationPolicy{IdentityName: identity.Name, Roles: append([]string(nil), identity.Roles...), HomeDocset: identity.Home}, nil
+		}
+	}
+	return AuthorizationPolicy{}, ErrUnknownIdentity
+}

--- a/pkg/openlore/authorize_test.go
+++ b/pkg/openlore/authorize_test.go
@@ -122,8 +122,8 @@ func TestAuthorize_PublicChoiceMintsAnonymousToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveClaims: %v", err)
 	}
-	if id.IdentityName != "" || id.Grants["public"] != "ro" {
-		t.Errorf("public token resolved to %q/%v, want anonymous with default grants", id.IdentityName, id.Grants)
+	if id.IdentityName != "guest" || id.Principal.IdentityName != "guest" {
+		t.Errorf("public token resolved to %+v, want guest principal", id)
 	}
 }
 
@@ -338,8 +338,8 @@ func TestMatchResolvesToIdentity(t *testing.T) {
 	if id.IdentityName != "alice" {
 		t.Fatalf("IdentityName = %q, want alice (via Match alias)", id.IdentityName)
 	}
-	if id.Grants["secret"] != "rw" {
-		t.Errorf("Grants = %v, want secret:rw", id.Grants)
+	if id.Principal.IdentityName != "alice" {
+		t.Errorf("principal = %+v, want alice", id.Principal)
 	}
 }
 

--- a/pkg/openlore/authz.go
+++ b/pkg/openlore/authz.go
@@ -1,19 +1,21 @@
 package openlore
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
+	"sort"
 	"strings"
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
-// validateGrants verifies that every grant name referenced by the auth config
-// (the anonymous default and each identity's docset grants) is a registered
-// grant type. It runs at startup, after plugins have registered their grant
-// types, so a config referencing an unregistered grant (e.g. `publish` without
-// the inbox plugin) fails closed rather than silently denying all access.
+// validateGrants verifies that every grant name referenced by a docset ACL is a
+// registered grant type. It runs at startup, after plugins have registered
+// their grant types, so a config referencing an unregistered grant (e.g.
+// `publish` without the inbox plugin) fails closed rather than silently denying
+// all access.
 func (s *Server) validateGrants() error {
 	if !s.authEnforced {
 		return nil
@@ -24,15 +26,15 @@ func (s *Server) validateGrants() error {
 		}
 		return nil
 	}
-	for docset, grant := range s.auth.Default {
-		if err := check(fmt.Sprintf("default grant for docset %q", docset), grant); err != nil {
-			return err
-		}
-	}
-	for _, ident := range s.auth.Identities {
-		for docset, grant := range ident.Docsets {
-			if err := check(fmt.Sprintf("identity %q grant for docset %q", ident.Name, docset), grant); err != nil {
+	for docset, ds := range s.auth.Docsets {
+		for role, grant := range ds.Access.Allow {
+			if err := check(fmt.Sprintf("docset %q role %q", docset, role), grant); err != nil {
 				return err
+			}
+			if role == "guest" {
+				if g, _ := s.grants.get(grant); g.AllowsWrite() {
+					return fmt.Errorf("auth config: guest grant %q on docset %q is writable", grant, docset)
+				}
 			}
 		}
 	}
@@ -115,6 +117,135 @@ func (s *Server) validateGrants() error {
 	return nil
 }
 
+func (s *Server) currentPolicy(id Identity) (AuthorizationPolicy, error) {
+	if s.authorizationStore == nil {
+		return AuthorizationPolicy{}, fmt.Errorf("authorization store unavailable")
+	}
+	p := id.Principal
+	if p.IdentityName == "" {
+		p.IdentityName = id.IdentityName
+	}
+	policy, err := s.authorizationStore.ResolveAuthorization(context.Background(), p)
+	if err != nil {
+		return AuthorizationPolicy{}, err
+	}
+	if policy.IdentityName != p.IdentityName {
+		return AuthorizationPolicy{}, fmt.Errorf("authorization identity %q does not match authenticated identity %q", policy.IdentityName, p.IdentityName)
+	}
+	guest := p.IdentityName == "guest"
+	if guest {
+		if len(policy.Roles) != 1 || policy.Roles[0] != "guest" || policy.HomeDocset != "" {
+			return AuthorizationPolicy{}, fmt.Errorf("invalid guest authorization policy")
+		}
+	} else if policy.IdentityName == "" {
+		return AuthorizationPolicy{}, fmt.Errorf("empty authorization identity")
+	}
+	seen := map[string]bool{}
+	for _, role := range policy.Roles {
+		if role == "" || strings.TrimSpace(role) != role || seen[role] {
+			return AuthorizationPolicy{}, fmt.Errorf("invalid or duplicate authorization role %q", role)
+		}
+		seen[role] = true
+		if role == "guest" {
+			if !guest {
+				return AuthorizationPolicy{}, fmt.Errorf("non-guest identity received guest role")
+			}
+		} else if _, ok := s.auth.Roles[role]; !ok {
+			return AuthorizationPolicy{}, fmt.Errorf("unknown authorization role %q", role)
+		}
+	}
+	if policy.HomeDocset != "" {
+		home, ok := s.auth.Docsets[policy.HomeDocset]
+		if !ok {
+			return AuthorizationPolicy{}, fmt.Errorf("unknown authorization home %q", policy.HomeDocset)
+		}
+		for _, denied := range home.Access.Deny {
+			if seen[denied] {
+				return AuthorizationPolicy{}, fmt.Errorf("authorization role %q is denied on home %q", denied, policy.HomeDocset)
+			}
+		}
+	}
+	return policy, nil
+}
+
+func (s *Server) effectiveGrantNames(id Identity, name string) ([]string, bool) {
+	if !s.authEnforced {
+		if name == "public" {
+			return []string{"rw"}, true
+		}
+		return nil, false
+	}
+	var policy AuthorizationPolicy
+	if id.policySnapshot != nil {
+		policy = *id.policySnapshot
+	} else {
+		var err error
+		policy, err = s.currentPolicy(id)
+		if err != nil {
+			return nil, false
+		}
+	}
+	ds, ok := s.auth.Docsets[name]
+	if !ok {
+		return nil, false
+	}
+	for _, denied := range ds.Access.Deny {
+		for _, role := range policy.Roles {
+			if denied == role {
+				return nil, false
+			}
+		}
+	}
+	names := map[string]bool{}
+	for _, role := range policy.Roles {
+		if grant := ds.Access.Allow[role]; grant != "" {
+			names[grant] = true
+		}
+	}
+	if policy.IdentityName != "guest" && policy.HomeDocset == name {
+		names["rw"] = true
+	}
+	out := make([]string, 0, len(names))
+	for grant := range names {
+		out = append(out, grant)
+	}
+	sort.Strings(out)
+	return out, len(out) > 0
+}
+
+func (s *Server) hasCurrentCapability(id Identity, capability string) bool {
+	id.policySnapshot = nil
+	policy, err := s.currentPolicy(id)
+	if err != nil {
+		return false
+	}
+	return s.hasCapabilityForPolicy(policy, capability)
+}
+
+func (s *Server) hasCapabilityForPolicy(policy AuthorizationPolicy, capability string) bool {
+	allowed := false
+	for _, roleName := range policy.Roles {
+		role, ok := s.auth.Roles[roleName]
+		if !ok {
+			if roleName == "guest" {
+				continue
+			}
+			return false
+		}
+		for _, denied := range role.Deny.Capabilities {
+			if denied == capability {
+				return false
+			}
+		}
+		for _, value := range role.Allow.Capabilities {
+			if value == capability {
+				allowed = true
+			}
+		}
+	}
+	return allowed
+}
+
 // displayPath returns a path mapping's cleaned display (virtual) path, falling
 // back to its source when no display override is set.
 func displayPath(pm config.PathMapping) string {
@@ -157,17 +288,23 @@ func (s *Server) canonicalPath(p string) string {
 
 func (s *Server) aliasesForIdentity(id Identity) []pathAlias {
 	var aliases []pathAlias
-	for name, grantName := range id.Grants {
+	for name := range s.auth.Docsets {
 		ds, ok := s.auth.Docsets[name]
 		if !ok {
 			continue
 		}
-		grant, ok := s.grants.get(grantName)
+		grantNames, ok := s.effectiveGrantNames(id, name)
 		if !ok {
 			continue
 		}
 		target := primaryDisplayPath(ds)
-		if target == "" || !grant.CanRead(ds, target) {
+		readable := false
+		for _, grantName := range grantNames {
+			if grant, ok := s.grants.get(grantName); ok && grant.CanRead(ds, target) {
+				readable = true
+			}
+		}
+		if target == "" || !readable {
 			continue
 		}
 		for _, alias := range ds.Aliases {
@@ -208,25 +345,26 @@ func (s *Server) mostSpecificDocset(p string) (string, config.DocsetSpec, bool) 
 	return bestName, bestDS, true
 }
 
-// grantForPath resolves the grant that governs display path p for this identity.
-// It finds the most-specific docset covering p (across all docsets) and returns
-// its grant only if the identity actually holds one on THAT docset. A grant on
-// an ancestor docset (e.g. the root docset) does not authorize p when a nested
-// docset carves it out and the identity has no grant on the nested docset.
-func (s *Server) grantForPath(id Identity, p string) (config.DocsetSpec, GrantType, bool) {
+// grantsForPath resolves the grants that govern display path p for this
+// identity. It finds the most-specific docset covering p (across all docsets)
+// and returns the grants contributed by the identity's roles on THAT docset. An
+// ancestor docset ACL does not authorize p when a nested docset carves it out.
+func (s *Server) grantsForPath(id Identity, p string) (config.DocsetSpec, []GrantType, bool) {
 	name, ds, ok := s.mostSpecificDocset(p)
 	if !ok {
 		return config.DocsetSpec{}, nil, false
 	}
-	grantName, ok := id.Grants[name]
+	grantNames, ok := s.effectiveGrantNames(id, name)
 	if !ok {
 		return config.DocsetSpec{}, nil, false // carved out: no grant on the governing docset
 	}
-	grant, ok := s.grants.get(grantName)
-	if !ok {
-		return config.DocsetSpec{}, nil, false
+	var grants []GrantType
+	for _, grantName := range grantNames {
+		if grant, ok := s.grants.get(grantName); ok {
+			grants = append(grants, grant)
+		}
 	}
-	return ds, grant, true
+	return ds, grants, len(grants) > 0
 }
 
 // allDocsetRoots returns the display roots of every configured docset — the full
@@ -247,6 +385,7 @@ func (s *Server) allDocsetRoots() []string {
 // write, the identity holds a grant on the docset containing p, that docset is
 // not per-docset readonly, and the grant permits the action on that path.
 func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string) bool {
+	id.policySnapshot = nil
 	if s.config.Readonly {
 		return false // global write lock closed
 	}
@@ -254,14 +393,29 @@ func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string
 		return false // token scope ceiling: only full authority may write
 	}
 	p = s.canonicalPath(p)
-	ds, grant, ok := s.grantForPath(id, p)
+	if action == vfs.ChangeActionRemoveAll {
+		for _, candidate := range s.auth.Docsets {
+			for _, pm := range candidate.Paths {
+				root := displayPath(pm)
+				if p != root && pathWithinRoot(p, root) {
+					return false // recursive delete would cross a nested docset boundary
+				}
+			}
+		}
+	}
+	ds, grants, ok := s.grantsForPath(id, p)
 	if !ok {
 		return false
 	}
 	if ds.Readonly != nil && *ds.Readonly {
 		return false // per-docset lock can only further restrict
 	}
-	return grant.CanWrite(ds, action, p)
+	for _, grant := range grants {
+		if grant.CanWrite(ds, action, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // readableRoots returns the display roots the identity may read: the display
@@ -270,18 +424,24 @@ func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string
 // build the session's read-scoping filesystem.
 func (s *Server) readableRoots(id Identity) []string {
 	var roots []string
-	for name, grantName := range id.Grants {
+	for name := range s.auth.Docsets {
 		ds, ok := s.auth.Docsets[name]
 		if !ok {
 			continue
 		}
-		grant, ok := s.grants.get(grantName)
+		grantNames, ok := s.effectiveGrantNames(id, name)
 		if !ok {
 			continue
 		}
 		for _, pm := range ds.Paths {
 			root := displayPath(pm)
-			if grant.CanRead(ds, root) {
+			readable := false
+			for _, grantName := range grantNames {
+				if grant, ok := s.grants.get(grantName); ok && grant.CanRead(ds, root) {
+					readable = true
+				}
+			}
+			if readable {
 				roots = append(roots, root)
 			}
 		}
@@ -301,6 +461,7 @@ func (s *Server) readableRoots(id Identity) []string {
 // docsets sharing the same backing filesystem.
 type scopedReadFS struct {
 	vfs.FileSystem
+	writable   vfs.WritableFS
 	roots      []string // cleaned readable display roots (granted docsets + system mounts)
 	boundaries []string // cleaned display roots of ALL docsets (carve-out boundaries)
 }
@@ -313,7 +474,51 @@ func newScopedReadFS(base vfs.FileSystem, roots, boundaries []string) *scopedRea
 		}
 		return out
 	}
-	return &scopedReadFS{FileSystem: base, roots: clean(roots), boundaries: clean(boundaries)}
+	writable, _ := base.(vfs.WritableFS)
+	return &scopedReadFS{FileSystem: base, writable: writable, roots: clean(roots), boundaries: clean(boundaries)}
+}
+
+func (s *scopedReadFS) SetWriteable() error {
+	if s.writable == nil {
+		return vfs.ErrReadOnly
+	}
+	return s.writable.SetWriteable()
+}
+func (s *scopedReadFS) SetReadonly() error {
+	if s.writable == nil {
+		return nil
+	}
+	return s.writable.SetReadonly()
+}
+func (s *scopedReadFS) WriteFileAtomic(p string, data []byte, opts vfs.WriteOpts) (string, error) {
+	if s.writable == nil {
+		return "", vfs.ErrReadOnly
+	}
+	return s.writable.WriteFileAtomic(p, data, opts)
+}
+func (s *scopedReadFS) Mkdir(p string) error {
+	if s.writable == nil {
+		return vfs.ErrReadOnly
+	}
+	return s.writable.Mkdir(p)
+}
+func (s *scopedReadFS) MkdirAll(p string) error {
+	if s.writable == nil {
+		return vfs.ErrReadOnly
+	}
+	return s.writable.MkdirAll(p)
+}
+func (s *scopedReadFS) Remove(p string) error {
+	if s.writable == nil {
+		return vfs.ErrReadOnly
+	}
+	return s.writable.Remove(p)
+}
+func (s *scopedReadFS) RemoveAll(p string, opts vfs.RemoveOpts) error {
+	if s.writable == nil {
+		return vfs.ErrReadOnly
+	}
+	return s.writable.RemoveAll(p, opts)
 }
 
 // within reports whether p is readable: some readable root covers it, and no

--- a/pkg/openlore/authz_test.go
+++ b/pkg/openlore/authz_test.go
@@ -18,19 +18,31 @@ func grantTestServer() *Server {
 		grants:       newGrantRegistry(),
 		config:       config.Config{Readonly: false},
 		auth: &config.AuthConfig{
+			Roles: map[string]config.RoleSpec{"alfie-rw": {}, "alfie-ro": {}, "alfie-publish": {}, "root-rw": {}, "all-rw": {}, "backend-publish": {}},
 			Docsets: map[string]config.DocsetSpec{
-				"alfie": {Paths: []config.PathMapping{{Source: "/alfie", Display: "/alfie"}}, Inbox: "inbox"},
-				"miles": {Paths: []config.PathMapping{{Source: "/miles", Display: "/miles"}}, Inbox: "inbox"},
+				"alfie": {Paths: []config.PathMapping{{Source: "/alfie", Display: "/alfie"}}, Inbox: "inbox", Access: config.DocsetAccess{Allow: map[string]string{"alfie-rw": "rw", "alfie-ro": "ro", "alfie-publish": "publish", "all-rw": "rw"}}},
+				"miles": {Paths: []config.PathMapping{{Source: "/miles", Display: "/miles"}}, Inbox: "inbox", Access: config.DocsetAccess{Allow: map[string]string{"all-rw": "rw"}}},
 			},
 		},
 	}
 	s.registerPlugin(NewInboxPlugin())
+	s.authorizationStore = &mutableAuthorizationStore{}
 	return s
+}
+
+func identityWithPolicy(name string, roles ...string) Identity {
+	p := AuthorizationPolicy{IdentityName: name, Roles: roles}
+	return Identity{IdentityName: name, Principal: AuthenticatedPrincipal{IdentityName: name}, policySnapshot: &p, Scopes: []string{ScopeFull}}
+}
+
+func setCurrentPolicy(s *Server, id Identity) {
+	s.authorizationStore.(*mutableAuthorizationStore).policy = *id.policySnapshot
 }
 
 func TestIdentityCanWrite_RW(t *testing.T) {
 	s := grantTestServer()
-	id := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeFull}}
+	id := identityWithPolicy("alfie", "alfie-rw")
+	setCurrentPolicy(s, id)
 
 	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/notes.md") {
 		t.Fatal("rw should write anywhere in its docset")
@@ -46,7 +58,8 @@ func TestIdentityCanWrite_RW(t *testing.T) {
 
 func TestIdentityCanWrite_RO(t *testing.T) {
 	s := grantTestServer()
-	id := Identity{IdentityName: "bob", Grants: map[string]string{"alfie": "ro"}, Scopes: []string{ScopeFull}}
+	id := identityWithPolicy("bob", "alfie-ro")
+	setCurrentPolicy(s, id)
 	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/notes.md") {
 		t.Fatal("ro must never write")
 	}
@@ -55,7 +68,8 @@ func TestIdentityCanWrite_RO(t *testing.T) {
 func TestIdentityCanWrite_Publish(t *testing.T) {
 	s := grantTestServer()
 	// miles holds publish on alfie: create/edit only within /alfie/inbox, no deletes.
-	id := Identity{IdentityName: "miles", Grants: map[string]string{"alfie": "publish"}, Scopes: []string{ScopeFull}}
+	id := identityWithPolicy("miles", "alfie-publish")
+	setCurrentPolicy(s, id)
 
 	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/inbox/from-miles.md") {
 		t.Fatal("publish should write inside the inbox")
@@ -76,12 +90,15 @@ func TestIdentityCanWrite_Publish(t *testing.T) {
 
 func TestIdentityCanWrite_ScopeAndLockCeilings(t *testing.T) {
 	s := grantTestServer()
-	id := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeRead}}
+	id := identityWithPolicy("alfie", "alfie-rw")
+	setCurrentPolicy(s, id)
+	id.Scopes = []string{ScopeRead}
 	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/alfie/notes.md") {
 		t.Fatal("a read-scoped token must not write even with an rw grant")
 	}
 
-	full := Identity{IdentityName: "alfie", Grants: map[string]string{"alfie": "rw"}, Scopes: []string{ScopeFull}}
+	full := identityWithPolicy("alfie", "alfie-rw")
+	setCurrentPolicy(s, full)
 	s.config.Readonly = true
 	if s.identityCanWrite(full, vfs.ChangeActionWrite, "/alfie/notes.md") {
 		t.Fatal("the global write lock must block all writes")
@@ -94,8 +111,7 @@ func TestValidateGrants(t *testing.T) {
 		authEnforced: true,
 		grants:       newGrantRegistry(), // only ro/rw
 		auth: &config.AuthConfig{
-			Docsets:    map[string]config.DocsetSpec{"alfie": {}},
-			Identities: []config.AuthIdentity{{Name: "miles", Docsets: map[string]string{"alfie": "publish"}}},
+			Docsets: map[string]config.DocsetSpec{"alfie": {Access: config.DocsetAccess{Allow: map[string]string{"writer": "publish"}}}},
 		},
 	}
 	if err := s.validateGrants(); err == nil {
@@ -210,11 +226,7 @@ func TestValidateGrants_RejectsAliasOverlappingMount(t *testing.T) {
 // routes into /docset/inbox/... where the publish grant actually permits writes.
 func TestSessionPublishTargets_ResolvesInboxPath(t *testing.T) {
 	s := grantTestServer()
-	id := Identity{
-		IdentityName: "miles",
-		Grants:       map[string]string{"alfie": "publish"},
-		Scopes:       []string{ScopeFull},
-	}
+	id := identityWithPolicy("miles", "alfie-publish")
 	targets := s.sessionPublishTargets(id)
 	if len(targets) != 1 {
 		t.Fatalf("want 1 publish target, got %d: %+v", len(targets), targets)
@@ -233,10 +245,11 @@ func TestSessionPublishTargets_ResolvesInboxPath(t *testing.T) {
 func TestGrantForPath_NestedDocsetOverridesAncestor(t *testing.T) {
 	s := grantTestServer()
 	// Add a root docset "/" alongside the existing /alfie and /miles docsets.
-	s.auth.Docsets["openlore"] = config.DocsetSpec{Paths: []config.PathMapping{{Source: "/", Display: "/"}}}
+	s.auth.Docsets["openlore"] = config.DocsetSpec{Paths: []config.PathMapping{{Source: "/", Display: "/"}}, Access: config.DocsetAccess{Allow: map[string]string{"root-rw": "rw"}}}
 
 	// Identity holds rw on the root docset only — no grant on /alfie.
-	id := Identity{IdentityName: "anon", Grants: map[string]string{"openlore": "rw"}, Scopes: []string{ScopeFull}}
+	id := identityWithPolicy("anon", "root-rw")
+	setCurrentPolicy(s, id)
 
 	// A root-level file is governed by the root docset → writable.
 	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/readme.md") {

--- a/pkg/openlore/docsets_test.go
+++ b/pkg/openlore/docsets_test.go
@@ -19,37 +19,40 @@ func enforcedDocsetServer() *Server {
 		grants:       newGrantRegistry(),
 		config:       config.Config{Readonly: false}, // global write lock open
 		auth: &config.AuthConfig{
+			Roles: map[string]config.RoleSpec{"agent": {}, "reader": {}, "publisher": {}},
 			Docsets: map[string]config.DocsetSpec{
-				"public": {Paths: []config.PathMapping{{Source: "/docs/public", Display: "/docs/public"}}},
+				"public": {Paths: []config.PathMapping{{Source: "/docs/public", Display: "/docs/public"}}, Access: config.DocsetAccess{Allow: map[string]string{"agent": "rw", "reader": "ro"}}},
 				"backend": {
 					Paths:        []config.PathMapping{{Source: "/docs/backend", Display: "/docs/backend"}},
 					Inbox:        "inbox",
 					MaxWriteSize: 5000,
+					Access:       config.DocsetAccess{Allow: map[string]string{"agent": "rw", "reader": "ro", "publisher": "publish"}},
 				},
 				"archive": {
 					Paths:    []config.PathMapping{{Source: "/docs/archive", Display: "/docs/archive"}},
 					Readonly: boolPtr(true),
+					Access:   config.DocsetAccess{Allow: map[string]string{"agent": "rw"}},
 				},
 				"home": {
 					Paths:   []config.PathMapping{{Source: "/home/agent", Display: "/home/agent"}},
 					Aliases: []string{"/agent"},
 					Inbox:   "inbox",
+					Access:  config.DocsetAccess{Allow: map[string]string{"agent": "rw"}},
 				},
 			},
 		},
 	}
+	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
 	s.registerPlugin(NewInboxPlugin())
 	return s
 }
 
 // agentIdentity is the full-authority identity used across the docset tests.
 func agentIdentity() Identity {
-	return Identity{
-		IdentityName: "agent",
-		Grants:       map[string]string{"public": "rw", "backend": "rw", "archive": "rw", "home": "rw"},
-		HomeDocset:   "home",
-		Scopes:       []string{ScopeFull},
-	}
+	id := identityWithPolicy("agent", "agent")
+	id.HomeDocset = "home"
+	id.policySnapshot.HomeDocset = "home"
+	return id
 }
 
 func docsetByName(ds []cmds.DocsetInfo, name string) (cmds.DocsetInfo, bool) {
@@ -83,8 +86,8 @@ func TestSessionDocsets_Enforced(t *testing.T) {
 	if public.Home || public.Inbox {
 		t.Fatalf("public should carry no attributes: %+v", public)
 	}
-	if public.Grant != "rw" {
-		t.Fatalf("public grant = %q, want rw", public.Grant)
+	if len(public.Grants) != 1 || public.Grants[0] != "rw" {
+		t.Fatalf("public grants = %v, want [rw]", public.Grants)
 	}
 
 	backend, _ := docsetByName(got, "backend")
@@ -127,7 +130,7 @@ func TestSessionDocsets_GlobalReadonlyMakesAllRead(t *testing.T) {
 func TestSessionDocsets_ReadOnlyGrantIsReadOnly(t *testing.T) {
 	s := enforcedDocsetServer()
 	// An identity with only ro grants (no identity name / not a writer).
-	id := Identity{Grants: map[string]string{"public": "ro", "backend": "ro"}}
+	id := identityWithPolicy("reader", "reader")
 
 	for _, d := range s.sessionDocsets(id) {
 		if d.Writable {
@@ -163,11 +166,7 @@ func TestSessionPublishTargets_OnlyWritableInboxDocsets(t *testing.T) {
 func TestSessionPublishTargets_PublishGrant(t *testing.T) {
 	s := enforcedDocsetServer()
 	// A publish grant on backend (which has an inbox) is a publish target.
-	id := Identity{
-		IdentityName: "miles",
-		Grants:       map[string]string{"backend": "publish"},
-		Scopes:       []string{ScopeFull},
-	}
+	id := identityWithPolicy("miles", "publisher")
 	targets := s.sessionPublishTargets(id)
 	if len(targets) != 1 || targets[0].Name != "backend" {
 		t.Fatalf("publish grant should yield backend as a target, got %+v", targets)
@@ -186,7 +185,7 @@ func TestSessionPublishTargets_UnenforcedHasNone(t *testing.T) {
 			},
 		},
 	}
-	id := Identity{Grants: map[string]string{"public": "rw"}, Scopes: []string{ScopeFull}}
+	id := Identity{Scopes: []string{ScopeFull}}
 	if targets := s.sessionPublishTargets(id); targets != nil {
 		t.Fatalf("unenforced mode has no publish inboxes, got %+v", targets)
 	}
@@ -204,7 +203,7 @@ func TestSessionDocsets_UnenforcedPublicIsWritable(t *testing.T) {
 			},
 		},
 	}
-	id := Identity{Grants: map[string]string{"public": "rw"}, Scopes: []string{ScopeFull}}
+	id := Identity{Scopes: []string{ScopeFull}}
 	got := s.sessionDocsets(id)
 	if len(got) != 1 || got[0].Name != "public" {
 		t.Fatalf("want single public docset, got %+v", got)

--- a/pkg/openlore/identity.go
+++ b/pkg/openlore/identity.go
@@ -38,17 +38,28 @@ func recognizedScope(s string) bool {
 
 // Identity represents a connected caller (SSH session or MCP/HTTP request).
 type Identity struct {
-	RemoteAddr   string
-	User         string
-	PublicKey    ssh.PublicKey
-	SessionID    string
-	ConnectedAt  time.Time
-	IdentityName string            // matched identity name from auth config
-	Grants       map[string]string // docset name → grant name (ro/rw/publish); nil = no access
-	Capabilities []string          // extra capabilities held (e.g. "spawn")
-	HomeDir      string            // display path of the identity's home docset ($HOME); empty = none
-	HomeDocset   string            // name of the identity's home docset; empty = none
-	Scopes       []string          // token scopes narrowing authority; {ScopeFull} = full authority
+	RemoteAddr     string
+	User           string
+	PublicKey      ssh.PublicKey
+	SessionID      string
+	ConnectedAt    time.Time
+	IdentityName   string // matched identity name from auth config
+	Principal      AuthenticatedPrincipal
+	policySnapshot *AuthorizationPolicy
+	HomeDir        string   // display path of the identity's home docset ($HOME); empty = none
+	HomeDocset     string   // name of the identity's home docset; empty = none
+	Scopes         []string // token scopes narrowing authority; {ScopeFull} = full authority
+}
+
+// AuthenticatedPrincipal is the stable, transport-neutral authentication
+// result passed to authorization. Subject is the original authenticated
+// subject; IdentityName is the claim-resolved local identity.
+type AuthenticatedPrincipal struct {
+	Subject      string
+	IdentityName string
+	Source       string
+	Claims       map[string]any
+	Scope        string
 }
 
 // OnConnectFunc is called when a new SSH session is established.

--- a/pkg/openlore/identity_context_test.go
+++ b/pkg/openlore/identity_context_test.go
@@ -13,11 +13,11 @@ import (
 func TestIdentityFromContext_RoundTrip(t *testing.T) {
 	s := &Server{merge: NewMergeFS()}
 
-	want := Identity{IdentityName: "frontend", Grants: map[string]string{"frontend": "rw"}, Scopes: []string{ScopeFull}}
+	want := Identity{IdentityName: "frontend", Principal: AuthenticatedPrincipal{IdentityName: "frontend"}, Scopes: []string{ScopeFull}}
 	ctx := contextWithIdentity(context.Background(), want)
 
 	got := s.identityFromContext(ctx)
-	if got.IdentityName != "frontend" || got.Grants["frontend"] != "rw" {
+	if got.IdentityName != "frontend" || got.Principal.IdentityName != "frontend" {
 		t.Fatalf("identity did not round-trip: %+v", got)
 	}
 	if len(got.Scopes) != 1 || got.Scopes[0] != ScopeFull {
@@ -35,16 +35,16 @@ func TestIdentityFromContext_AnonymousIsNotFull(t *testing.T) {
 			Docsets: map[string]config.DocsetSpec{
 				"public": {Paths: []config.PathMapping{{Source: "/", Display: "/"}}},
 			},
-			Default: map[string]string{"public": "ro"},
 		},
 	}
+	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
 
 	got := s.identityFromContext(context.Background())
-	if got.Grants["public"] != "ro" {
-		t.Fatalf("anonymous caller should resolve to default grants, got %v", got.Grants)
+	if got.IdentityName != "guest" || got.Principal.IdentityName != "guest" {
+		t.Fatalf("anonymous caller should resolve to guest, got %+v", got)
 	}
-	if len(got.Scopes) != 0 {
-		t.Fatalf("anonymous caller must not carry any scope (fail-closed), got %v", got.Scopes)
+	if !scopeGrantsWrite(got.Scopes) {
+		t.Fatalf("guest uses full transport scope; its grants remain read-only, got %v", got.Scopes)
 	}
 }
 

--- a/pkg/openlore/identitystore.go
+++ b/pkg/openlore/identitystore.go
@@ -128,13 +128,12 @@ func (d serverIdentityStore) Resolve(_ context.Context, claims Claims) (Identity
 func (s *Server) resolveClaims(claims Claims) (Identity, error) {
 	sub := claims.Subject
 
-	// A public/anonymous token resolves to the same read-only default identity a
+	// A public/anonymous token resolves to the same read-only guest identity a
 	// tokenless caller gets (§8.4).
 	if sub == "" || sub == anonymousSubject {
 		id := s.anonymousIdentity()
-		if claims.Scope != "" {
-			id.Scopes = []string{claims.Scope}
-		}
+		id.Scopes = []string{claims.Scope}
+		id.Principal = AuthenticatedPrincipal{Subject: sub, IdentityName: "guest", Source: "token", Claims: claims.Raw, Scope: claims.Scope}
 		return id, nil
 	}
 
@@ -150,7 +149,10 @@ func (s *Server) resolveClaims(claims Claims) (Identity, error) {
 			return Identity{}, ErrUnknownIdentity
 		}
 		// Posture allows unknowns: land in the read-only default lore.
-		return s.anonymousIdentity(), nil
+		id := s.anonymousIdentity()
+		id.Principal = AuthenticatedPrincipal{Subject: sub, IdentityName: "guest", Source: "token", Claims: claims.Raw, Scope: claims.Scope}
+		id.Scopes = []string{claims.Scope}
+		return id, nil
 	}
 
 	id, ok := s.identityForName(name)
@@ -158,9 +160,8 @@ func (s *Server) resolveClaims(claims Claims) (Identity, error) {
 		// A rule pointed at a nonexistent identity — fail closed.
 		return Identity{}, ErrUnknownIdentity
 	}
-	if claims.Scope != "" {
-		id.Scopes = []string{claims.Scope}
-	}
+	id.Scopes = []string{claims.Scope}
+	id.Principal = AuthenticatedPrincipal{Subject: sub, IdentityName: name, Source: "token", Claims: claims.Raw, Scope: claims.Scope}
 	return id, nil
 }
 
@@ -349,8 +350,7 @@ func (s *Server) identityForName(name string) (Identity, bool) {
 func (s *Server) identityFromAuth(ident config.AuthIdentity) Identity {
 	return Identity{
 		IdentityName: ident.Name,
-		Grants:       ident.Docsets,
-		Capabilities: ident.Capabilities,
+		Principal:    AuthenticatedPrincipal{Subject: ident.Name, IdentityName: ident.Name, Source: "local"},
 		HomeDir:      s.resolveHomeDir(ident.Home),
 		HomeDocset:   ident.Home,
 		Scopes:       []string{ScopeFull},

--- a/pkg/openlore/mcp_scoping_test.go
+++ b/pkg/openlore/mcp_scoping_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/aakarim/go-openlore/internal/config"
 )
 
-// newScopedTestAPI builds a Server with two docsets — "public" (in the default
-// lore) and "secret" (not in any lore) — and returns the JSON HTTP API handler
-// backed by the identity-scoped MCP shell. An unauthenticated caller resolves
-// to the anonymous "default" identity, so it must see only the public docset.
+// newScopedTestAPI builds a Server with two docsets — "public" (granted to
+// guest) and "secret" — and returns the JSON HTTP API handler backed by the
+// identity-scoped MCP shell. An unauthenticated caller resolves to guest, so it
+// must see only the public docset.
 func newScopedTestAPI(t *testing.T) http.Handler {
 	t.Helper()
 
@@ -35,13 +35,13 @@ func newScopedTestAPI(t *testing.T) http.Handler {
 		grants:       newGrantRegistry(),
 		auth: &config.AuthConfig{
 			Docsets: map[string]config.DocsetSpec{
-				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}},
+				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}, Access: config.DocsetAccess{Allow: map[string]string{"guest": "ro"}}},
 				"secret": {Paths: []config.PathMapping{{Source: "/secret", Display: "/secret"}}},
 			},
-			Default: map[string]string{"public": "ro"}, // secret deliberately excluded
 		},
 		config: config.Config{Readonly: true},
 	}
+	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
 
 	server := NewMCPServer(s.merge, withMCPShellFactory(s.shellForContext))
 	return NewMCPHTTPAPI(server).Handler("/api")

--- a/pkg/openlore/okf_plugin.go
+++ b/pkg/openlore/okf_plugin.go
@@ -7,8 +7,8 @@ import (
 	"path"
 
 	"github.com/aakarim/go-openlore/internal/config"
-	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/okf"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -24,7 +24,7 @@ import (
 // a global block, so OKF scoping reads the exact same display roots as authz and
 // can't drift from it. A write is governed by the OKF config of the docset that
 // owns its target path — the longest matching display root across all docsets,
-// exactly as grantForPath resolves grants. A child docset therefore includes a
+// exactly as grantsForPath resolves grants. A child docset therefore includes a
 // subtree (child carries OKF) or exempts it (child carries none, shadowing a
 // parent's OKF).
 //

--- a/pkg/openlore/options.go
+++ b/pkg/openlore/options.go
@@ -55,4 +55,5 @@ var (
 	WithPasskeys        = config.WithPasskeys
 	WithReadonly        = config.WithReadonly
 	LoadAuthConfig      = config.LoadAuthConfig
+	ValidateAuthConfig  = config.ValidateAuthConfig
 )

--- a/pkg/openlore/rbac_test.go
+++ b/pkg/openlore/rbac_test.go
@@ -1,0 +1,240 @@
+package openlore
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type mutableAuthorizationStore struct {
+	mu     sync.Mutex
+	policy AuthorizationPolicy
+	err    error
+	calls  int
+}
+
+func (m *mutableAuthorizationStore) ResolveAuthorization(context.Context, AuthenticatedPrincipal) (AuthorizationPolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	return m.policy, m.err
+}
+
+func (m *mutableAuthorizationStore) set(policy AuthorizationPolicy) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.policy = policy
+}
+func (m *mutableAuthorizationStore) callCount() int { m.mu.Lock(); defer m.mu.Unlock(); return m.calls }
+
+func rbacServer() (*Server, Identity, *mutableAuthorizationStore) {
+	store := &mutableAuthorizationStore{policy: AuthorizationPolicy{IdentityName: "alice", Roles: []string{"reader", "writer"}, HomeDocset: "home"}}
+	s := &Server{
+		authEnforced:       true,
+		grants:             newGrantRegistry(),
+		authorizationStore: store,
+		config:             config.Config{},
+		auth: &config.AuthConfig{
+			Roles: map[string]config.RoleSpec{"reader": {}, "writer": {}, "blocked": {}},
+			Docsets: map[string]config.DocsetSpec{
+				"docs":   {Paths: []config.PathMapping{{Source: "/docs"}}, Access: config.DocsetAccess{Allow: map[string]string{"reader": "ro", "writer": "rw"}}},
+				"home":   {Paths: []config.PathMapping{{Source: "/home"}}},
+				"nested": {Paths: []config.PathMapping{{Source: "/home/private"}}},
+			},
+		},
+	}
+	id := Identity{IdentityName: "alice", Principal: AuthenticatedPrincipal{IdentityName: "alice"}, Scopes: []string{ScopeFull}, HomeDocset: "home"}
+	return s, id, store
+}
+
+func TestBuildSessionFSReadSnapshotAndRuntimeWrites(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"docs", "extra"} {
+		if err := os.MkdirAll(filepath.Join(dir, name), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name, "note.md"), []byte(name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	merge := NewMergeFS()
+	merge.SetRoot(NewDirFS(dir, config.FilesConfig{}).WithDocsetRoots([]string{"/docs", "/extra"}))
+	if err := merge.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	store := &mutableAuthorizationStore{policy: AuthorizationPolicy{IdentityName: "alice", Roles: []string{"reader"}}}
+	s := &Server{authEnforced: true, grants: newGrantRegistry(), authorizationStore: store, merge: merge, auth: &config.AuthConfig{
+		Roles: map[string]config.RoleSpec{"reader": {}, "rw": {}, "extra": {}},
+		Docsets: map[string]config.DocsetSpec{
+			"docs":  {Paths: []config.PathMapping{{Source: "/docs"}}, Access: config.DocsetAccess{Allow: map[string]string{"reader": "ro", "rw": "rw"}}},
+			"extra": {Paths: []config.PathMapping{{Source: "/extra"}}, Access: config.DocsetAccess{Allow: map[string]string{"extra": "ro"}}},
+		},
+	}}
+	id := Identity{IdentityName: "alice", Principal: AuthenticatedPrincipal{IdentityName: "alice"}, Scopes: []string{ScopeFull}}
+	fsys := s.buildSessionFS(id)
+	if got := store.callCount(); got != 1 {
+		t.Fatalf("construction lookups = %d, want 1", got)
+	}
+	if b, err := fsys.ReadFile("/docs/note.md"); err != nil || string(b) != "docs" {
+		t.Fatalf("snapshot read = %q, %v", b, err)
+	}
+	if got := store.callCount(); got != 1 {
+		t.Fatalf("read performed policy lookup: %d", got)
+	}
+	if _, err := fsys.ReadFile("/extra/note.md"); err == nil {
+		t.Fatal("extra unexpectedly visible")
+	}
+
+	store.set(AuthorizationPolicy{IdentityName: "alice", Roles: []string{"rw", "extra"}})
+	if !fsys.(vfs.WriteScopeFS).CanWrite("/docs/new.md") {
+		t.Fatal("existing FS did not observe runtime rw grant")
+	}
+	if _, err := fsys.ReadFile("/extra/note.md"); err == nil {
+		t.Fatal("read snapshot expanded")
+	}
+	store.set(AuthorizationPolicy{IdentityName: "alice", Roles: nil})
+	if fsys.(vfs.WriteScopeFS).CanWrite("/docs/new.md") {
+		t.Fatal("existing FS retained revoked write")
+	}
+	if _, err := fsys.ReadFile("/docs/note.md"); err != nil {
+		t.Fatalf("read snapshot revoked: %v", err)
+	}
+}
+
+func TestRBACRemoveAllCannotCrossNestedDocset(t *testing.T) {
+	dir := t.TempDir()
+	privateFile := filepath.Join(dir, "parent", "tree", "private", "secret.md")
+	if err := os.MkdirAll(filepath.Dir(privateFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(privateFile, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	merge := NewMergeFS()
+	merge.SetRoot(NewDirFS(dir, config.FilesConfig{}).WithDocsetRoots([]string{"/parent", "/parent/tree/private"}))
+	if err := merge.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	store := &mutableAuthorizationStore{policy: AuthorizationPolicy{IdentityName: "alice", Roles: []string{"writer"}}}
+	s := &Server{
+		authEnforced:       true,
+		grants:             newGrantRegistry(),
+		authorizationStore: store,
+		merge:              merge,
+		auth: &config.AuthConfig{
+			Roles: map[string]config.RoleSpec{"writer": {}},
+			Docsets: map[string]config.DocsetSpec{
+				"parent":  {Paths: []config.PathMapping{{Source: "/parent"}}, Access: config.DocsetAccess{Allow: map[string]string{"writer": "rw"}}},
+				"private": {Paths: []config.PathMapping{{Source: "/parent/tree/private"}}},
+			},
+		},
+	}
+	id := Identity{IdentityName: "alice", Principal: AuthenticatedPrincipal{IdentityName: "alice"}, Scopes: []string{ScopeFull}}
+	fsys := s.buildSessionFS(id)
+	writable, ok := fsys.(vfs.WritableFS)
+	if !ok {
+		t.Fatal("session filesystem is not writable")
+	}
+	if err := writable.RemoveAll("/parent/tree", vfs.RemoveOpts{}); err == nil {
+		t.Fatal("recursive delete crossing nested docset succeeded")
+	}
+	if got, err := os.ReadFile(privateFile); err != nil || string(got) != "secret" {
+		t.Fatalf("nested docset content changed: %q, %v", got, err)
+	}
+}
+
+func TestAuthorizationPolicyValidationEdges(t *testing.T) {
+	s, id, store := rbacServer()
+	t.Run("zero role home owner", func(t *testing.T) {
+		store.set(AuthorizationPolicy{IdentityName: "alice", HomeDocset: "home"})
+		if _, err := s.currentPolicy(id); err != nil {
+			t.Fatalf("policy: %v", err)
+		}
+		if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/home/note.md") {
+			t.Fatal("implicit home rw denied")
+		}
+	})
+	t.Run("known and unknown role fails whole lookup", func(t *testing.T) {
+		store.set(AuthorizationPolicy{IdentityName: "alice", Roles: []string{"reader", "missing"}, HomeDocset: "home"})
+		if _, err := s.currentPolicy(id); err == nil {
+			t.Fatal("unknown role accepted")
+		}
+		if s.identityCanWrite(id, vfs.ChangeActionWrite, "/home/note.md") {
+			t.Fatal("invalid policy received home rw")
+		}
+	})
+	for _, tc := range []struct {
+		name, principal string
+		policy          AuthorizationPolicy
+	}{
+		{"malformed guest", "guest", AuthorizationPolicy{IdentityName: "guest", Roles: []string{"reader"}}},
+		{"malformed non-guest", "alice", AuthorizationPolicy{IdentityName: "alice", Roles: []string{"guest"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store.set(tc.policy)
+			check := id
+			check.IdentityName = tc.principal
+			check.Principal.IdentityName = tc.principal
+			if _, err := s.currentPolicy(check); err == nil {
+				t.Fatal("malformed policy accepted")
+			}
+		})
+	}
+	t.Run("role denied on dynamic home", func(t *testing.T) {
+		home := s.auth.Docsets["home"]
+		home.Access.Deny = []string{"reader"}
+		s.auth.Docsets["home"] = home
+		store.set(AuthorizationPolicy{IdentityName: "alice", Roles: []string{"reader"}, HomeDocset: "home"})
+		if _, err := s.currentPolicy(id); err == nil {
+			t.Fatal("home deny accepted")
+		}
+	})
+}
+
+func TestRBACMultiRoleGrantUnionAndDeny(t *testing.T) {
+	s, id, store := rbacServer()
+	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/docs/file.md") {
+		t.Fatal("rw from one role must authorize write despite another role's ro")
+	}
+	ds := s.auth.Docsets["docs"]
+	ds.Access.Deny = []string{"reader"}
+	s.auth.Docsets["docs"] = ds
+	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/docs/file.md") {
+		t.Fatal("matching deny must override every allow")
+	}
+	store.policy.Roles = []string{"writer"}
+	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/docs/file.md") {
+		t.Fatal("write must use current role policy")
+	}
+}
+
+func TestRBACImplicitHomeStopsAtNestedBoundary(t *testing.T) {
+	s, id, _ := rbacServer()
+	if !s.identityCanWrite(id, vfs.ChangeActionWrite, "/home/note.md") {
+		t.Fatal("owner must receive implicit rw on home")
+	}
+	if s.identityCanWrite(id, vfs.ChangeActionWrite, "/home/private/note.md") {
+		t.Fatal("implicit home access must stop at nested docset")
+	}
+}
+
+func TestRBACCapabilityDenyAndRuntimeLookup(t *testing.T) {
+	s, id, store := rbacServer()
+	s.auth.Roles["reader"] = config.RoleSpec{Allow: config.CapabilityRules{Capabilities: []string{"spawn"}}}
+	if !s.hasCurrentCapability(id, "spawn") {
+		t.Fatal("role capability allow should apply")
+	}
+	s.auth.Roles["writer"] = config.RoleSpec{Deny: config.CapabilityRules{Capabilities: []string{"spawn"}}}
+	if s.hasCurrentCapability(id, "spawn") {
+		t.Fatal("capability deny must win")
+	}
+	store.policy.Roles = []string{"reader"}
+	if !s.hasCurrentCapability(id, "spawn") {
+		t.Fatal("capability checks must observe current role membership")
+	}
+}

--- a/pkg/openlore/scoped_write_fs.go
+++ b/pkg/openlore/scoped_write_fs.go
@@ -6,10 +6,10 @@ import (
 
 // writeAuthorizer decides whether a session may perform a mutation action on a
 // display path. It is the per-operation authority: the server binds it to the
-// session identity's grants (Server.identityCanWrite), so two agents that can
-// both see the same docsets are still authorized independently per write, and a
-// grant like `publish` can permit create/edit only within an inbox while
-// denying deletes.
+// principal's current RBAC policy (Server.identityCanWrite), so two agents that
+// can see the same docsets are still authorized independently per write, and a
+// grant like `publish` can permit create/edit only within an inbox while denying
+// deletes.
 type writeAuthorizer func(action vfs.ChangeAction, p string) bool
 
 // scopedWriteFS gates a session's writes through a writeAuthorizer. Reads pass

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -94,13 +94,14 @@ type Server struct {
 	// Bearer-token auth for the MCP + HTTP API (docs/mcp-bearer-auth.md).
 	// identityStore is always set (resolves claims → Identity). The rest are
 	// non-nil only when auth.tokens is configured, which enables token auth.
-	identityStore IdentityStore
-	issuer        Issuer
-	refreshStore  RefreshTokenStore
-	clientStore   ClientStore
-	authCodes     *authCodeStore
-	authorizeReqs *authorizeStore
-	tokens        *tokenEndpoint
+	identityStore      IdentityStore
+	authorizationStore AuthorizationStore
+	issuer             Issuer
+	refreshStore       RefreshTokenStore
+	clientStore        ClientStore
+	authCodes          *authCodeStore
+	authorizeReqs      *authorizeStore
+	tokens             *tokenEndpoint
 	// oidc verifies external IdP assertions for the jwt-bearer (WIF) grant. It
 	// is non-nil only when oidc_issuers are configured alongside auth.tokens.
 	oidc OIDCVerifier
@@ -176,6 +177,7 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 			return nil, fmt.Errorf("loading auth config: %w", err)
 		}
 		s.auth = auth
+		s.authorizationStore = fileAuthorizationStore{auth: auth}
 		s.authEnforced = true
 
 		// Auth policy fields override config defaults
@@ -190,8 +192,8 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		}
 	} else {
 		// No auth file: run in trusted/unenforced mode as a single `public`
-		// docset rooted at "/". The anonymous identity holds an `rw` grant on it
-		// (see anonymousIdentity), so every consumer reuses normal docset scoping.
+		// docset rooted at "/". Unenforced sessions receive synthetic `rw`
+		// authority on it, so every consumer reuses normal docset scoping.
 		s.auth.Docsets = map[string]config.DocsetSpec{"public": {
 			Paths: []config.PathMapping{{Source: "/", Display: "/"}},
 		}}
@@ -448,7 +450,7 @@ func (s *Server) resolveIdentity(sess ssh.Session) Identity {
 		}
 	}
 
-	// Unrecognized key / keyless: the anonymous default identity.
+	// Unrecognized key / keyless: the reserved guest identity.
 	return withConn(conn, s.anonymousIdentity())
 }
 
@@ -459,6 +461,16 @@ func withConn(conn, resolved Identity) Identity {
 	resolved.RemoteAddr = conn.RemoteAddr
 	resolved.User = conn.User
 	resolved.PublicKey = conn.PublicKey
+	resolved.Principal.Source = "ssh"
+	resolved.Principal.Subject = resolved.IdentityName
+	resolved.Principal.Claims = map[string]any{"user": conn.User, "remote_addr": conn.RemoteAddr}
+	if conn.PublicKey != nil {
+		resolved.Principal.Claims["public_key_fingerprint"] = gossh.FingerprintSHA256(conn.PublicKey)
+		if cert, ok := conn.PublicKey.(*gossh.Certificate); ok {
+			resolved.Principal.Claims["certificate_serial"] = cert.Serial
+			resolved.Principal.Claims["certificate_principals"] = append([]string(nil), cert.ValidPrincipals...)
+		}
+	}
 	return resolved
 }
 
@@ -480,22 +492,6 @@ func (s *Server) resolveHomeDir(homeDocset string) string {
 		display = pm.Source
 	}
 	return vfs.CleanPath(display)
-}
-
-// hasWritableGrant reports whether the identity holds any grant that ever
-// permits writes (rw, publish, …). It drives coarse shell action gating: a
-// read-only identity (only `ro` grants) is offered no write verbs. Per-op
-// authorization still runs through identityCanWrite.
-func (s *Server) hasWritableGrant(id Identity) bool {
-	for name, grantName := range id.Grants {
-		if _, ok := s.auth.Docsets[name]; !ok {
-			continue
-		}
-		if grant, ok := s.grants.get(grantName); ok && grant.AllowsWrite() {
-			return true
-		}
-	}
-	return false
 }
 
 // writeConflictPolicy resolves the policy governing whole-file overwrites to
@@ -725,16 +721,6 @@ func (s *Server) postCommitChain() PostCommitHandler {
 	return chainPostCommit(terminal, s.postCommitMW...)
 }
 
-// hasCapability reports whether have contains want.
-func hasCapability(have []string, want string) bool {
-	for _, c := range have {
-		if c == want {
-			return true
-		}
-	}
-	return false
-}
-
 // buildSessionShell constructs a fully-configured shell scoped to the given
 // identity: a per-identity filesystem (read scoping, write authorization,
 // read-tracking CAS), capability-gated allowed actions, and
@@ -747,6 +733,16 @@ func hasCapability(have []string, want string) bool {
 // single source of the layered VFS shared by both the interactive shell and the
 // SFTP subsystem so both enforce identical read scoping and write authorization.
 func (s *Server) buildSessionFS(id Identity) vfs.FileSystem {
+	if s.authEnforced && id.policySnapshot == nil {
+		if policy, err := s.currentPolicy(id); err == nil {
+			id.policySnapshot = &policy
+			id.HomeDocset = policy.HomeDocset
+			id.HomeDir = s.resolveHomeDir(policy.HomeDocset)
+		} else {
+			deny := AuthorizationPolicy{}
+			id.policySnapshot = &deny
+		}
+	}
 	// Build per-session filesystem scoped to the identity's readable roots.
 	// Docsets are display-path subtrees of a shared backing filesystem, so read
 	// scoping is by path (not mount name): a session only sees the docsets it
@@ -772,25 +768,23 @@ func (s *Server) buildSessionFS(id Identity) vfs.FileSystem {
 	if s.writeLog != nil {
 		sessionFS = newMiddlewareFS(sessionFS, Actor{ID: id.User}, s.writeChain())
 	}
-	// canWrite is the coarse authority gate shared by the FS layer and the
-	// action layer: an identity may write only when auth is enforced, it is a
-	// named identity (not anonymous), its token scope grants write, and it holds
-	// at least one write-capable grant. A WIF token narrowed to `read` (or any
-	// non-`full` scope) is read-only here even if the underlying identity is
-	// write-capable — narrowing wins, fail-closed.
-	canWrite := s.authEnforced && id.IdentityName != "" && scopeGrantsWrite(id.Scopes) && s.hasWritableGrant(id)
-	// Per-op write authorization: every mutation is checked against the
-	// identity's grants (grant ∩ token scope ∩ readonly locks). This confines a
-	// session to exactly what its grants permit — an `rw` grant writes anywhere
-	// in its docset, a `publish` grant only creates/edits within the inbox and
-	// never deletes, and two identities sharing a docset are authorized
-	// independently per write. Anonymous/read-only identities get a nil
-	// authorizer (fully read-only). No-op when auth is not enforced.
+	// A write-capable session must be a named non-guest identity with full token
+	// scope. The per-operation authorizer below resolves current roles and grants;
+	// a read-scoped token remains read-only regardless of RBAC authority.
+	canWrite := s.authEnforced && id.IdentityName != "" && id.IdentityName != "guest" && scopeGrantsWrite(id.Scopes)
+	// Every mutation is checked against current role membership, the governing
+	// docset ACL, token scope, and readonly locks. A grant such as `publish` can
+	// further restrict actions and paths. Guest/read-only identities receive a
+	// nil authorizer and fail closed.
 	if s.authEnforced {
 		var authz writeAuthorizer
 		if canWrite {
+			// Writes deliberately resolve current policy on every operation. The
+			// session snapshot remains authoritative for its stable read view.
+			writeID := id
+			writeID.policySnapshot = nil
 			authz = func(action vfs.ChangeAction, p string) bool {
-				return s.identityCanWrite(id, action, p)
+				return s.identityCanWrite(writeID, action, p)
 			}
 		}
 		sessionFS = newScopedWriteFS(sessionFS, authz)
@@ -819,14 +813,22 @@ func (s *Server) buildSessionFS(id Identity) vfs.FileSystem {
 }
 
 func (s *Server) buildSessionShell(id Identity) *shell.Shell {
+	if s.authEnforced {
+		if policy, err := s.currentPolicy(id); err == nil {
+			id.policySnapshot = &policy
+			id.HomeDocset = policy.HomeDocset
+			id.HomeDir = s.resolveHomeDir(policy.HomeDocset)
+		} else {
+			deny := AuthorizationPolicy{}
+			id.policySnapshot = &deny
+			id.HomeDocset, id.HomeDir = "", ""
+		}
+	}
 	sessionFS := s.buildSessionFS(id)
-	// canWrite is the coarse authority gate shared by the FS layer and the
-	// action layer: an identity may write only when auth is enforced, it is a
-	// named identity (not anonymous), its token scope grants write, and it holds
-	// at least one write-capable grant. A WIF token narrowed to `read` (or any
-	// non-`full` scope) is read-only here even if the underlying identity is
-	// write-capable — narrowing wins, fail-closed.
-	canWrite := s.authEnforced && id.IdentityName != "" && scopeGrantsWrite(id.Scopes) && s.hasWritableGrant(id)
+	// Command visibility is snapshotted, but privileged operations are narrowed
+	// again at invocation. Guest, read-scoped, and currently read-only sessions
+	// do not see write verbs.
+	canWrite := s.authEnforced && id.IdentityName != "" && id.IdentityName != "guest" && len(s.writableDocsetNames(id)) > 0
 
 	sh := shell.NewShell(sessionFS)
 	if s.config.DefaultCwd != "" {
@@ -838,7 +840,7 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 	// Capability gating (Part B). Only applies when an auth config is
 	// present — without one (local `openlore .` or an embedded KB server
 	// that does its own scoping) the shell stays unrestricted. With auth,
-	// an unrecognized/anonymous identity is read-only; a recognized
+	// an unrecognized/guest identity is read-only; a recognized
 	// identity may write and publish within its docsets.
 	if s.authEnforced {
 		if canWrite {
@@ -846,13 +848,19 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 			// spawn runs an external command as the OpenLore service
 			// user, so it's gated on an explicit `spawn` capability
 			// (Part D) — never granted to ordinary writers.
-			if hasCapability(id.Capabilities, "spawn") {
+			if s.hasCapabilityForPolicy(*id.policySnapshot, "spawn") {
 				allowed = append(allowed, cmds.ActionSpawn)
 			}
 			sh.SetAllowedActions(allowed)
 		} else {
 			sh.SetAllowedActions(nil) // read-only (ActionRead implied)
 		}
+		sh.SetActionAuthorizer(func(action cmds.Action) bool {
+			if action == cmds.ActionSpawn {
+				return s.hasCurrentCapability(id, "spawn")
+			}
+			return true
+		})
 	}
 
 	// Per-session docset views for `lore docsets` and publish inboxes for
@@ -885,21 +893,27 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 // first path; `lore docsets` preserves this order for older consumers that use
 // the first row as the docset's mount.
 func (s *Server) sessionDocsets(id Identity) []cmds.DocsetInfo {
-	if len(id.Grants) == 0 {
-		return nil
-	}
 	writable := s.writableDocsetNames(id)
 	var out []cmds.DocsetInfo
-	for name, grantName := range id.Grants {
+	for name := range s.auth.Docsets {
 		ds, ok := s.auth.Docsets[name]
 		if !ok {
 			continue
+		}
+		grantNames, accessible := s.effectiveGrantNames(id, name)
+		if !accessible {
+			continue
+		}
+		legacyGrant := ""
+		if len(grantNames) == 1 && s.authorizationStore == nil {
+			legacyGrant = grantNames[0]
 		}
 		for i, pm := range ds.Paths {
 			out = append(out, cmds.DocsetInfo{
 				Name:     name,
 				Paths:    []string{displayPath(pm)},
-				Grant:    grantName,
+				Grants:   grantNames,
+				Grant:    legacyGrant,
 				Writable: writable[name],
 				Home:     i == 0 && name == id.HomeDocset,
 				Inbox:    inboxPath(ds) != "",
@@ -911,7 +925,8 @@ func (s *Server) sessionDocsets(id Identity) []cmds.DocsetInfo {
 				Name:        name,
 				Paths:       []string{vfs.CleanPath(alias)},
 				AliasTarget: target,
-				Grant:       grantName,
+				Grants:      grantNames,
+				Grant:       legacyGrant,
 				Writable:    writable[name],
 			})
 		}
@@ -928,13 +943,22 @@ func (s *Server) sessionPublishTargets(id Identity) []cmds.PublishTarget {
 		return nil
 	}
 	var out []cmds.PublishTarget
-	for name, grantName := range id.Grants {
+	for name := range s.auth.Docsets {
 		ds, ok := s.auth.Docsets[name]
 		if !ok {
 			continue
 		}
-		grant, ok := s.grants.get(grantName)
-		if !ok || !grant.AllowsWrite() {
+		grantNames, ok := s.effectiveGrantNames(id, name)
+		if !ok {
+			continue
+		}
+		write := false
+		for _, grantName := range grantNames {
+			if grant, ok := s.grants.get(grantName); ok && grant.AllowsWrite() {
+				write = true
+			}
+		}
+		if !write {
 			continue
 		}
 		inbox := inboxPath(ds)
@@ -966,7 +990,7 @@ func (s *Server) writableDocsetNames(id Identity) map[string]bool {
 	if id.IdentityName == "" || !scopeGrantsWrite(id.Scopes) {
 		return out
 	}
-	for name, grantName := range id.Grants {
+	for name := range s.auth.Docsets {
 		ds, ok := s.auth.Docsets[name]
 		if !ok {
 			continue
@@ -974,27 +998,33 @@ func (s *Server) writableDocsetNames(id Identity) map[string]bool {
 		if ds.Readonly != nil && *ds.Readonly {
 			continue
 		}
-		if grant, ok := s.grants.get(grantName); ok && grant.AllowsWrite() {
-			out[name] = true
+		grantNames, ok := s.effectiveGrantNames(id, name)
+		if !ok {
+			continue
+		}
+		for _, grantName := range grantNames {
+			if grant, ok := s.grants.get(grantName); ok && grant.AllowsWrite() {
+				out[name] = true
+			}
 		}
 	}
 	return out
 }
 
 // anonymousIdentity returns the identity used for callers that present no
-// credential (keyless SSH, or an unauthenticated MCP/HTTP request): the auth
-// config's `default` docset→grant map when auth is enforced, or full access to
-// the synthetic `public` docset when it is not.
+// credential (keyless SSH, or an unauthenticated MCP/HTTP request). Enforced
+// sessions resolve the reserved guest role; unenforced sessions receive
+// synthetic public rw authority in effectiveGrantNames.
 func (s *Server) anonymousIdentity() Identity {
 	id := Identity{
 		SessionID:   generateSessionID(),
 		ConnectedAt: time.Now(),
 	}
 	if s.authEnforced {
-		id.Grants = s.auth.Default // nil ⇒ no access for anonymous sessions
+		id.IdentityName = "guest"
+		id.Principal = AuthenticatedPrincipal{Subject: "guest", IdentityName: "guest", Source: "guest"}
+		id.Scopes = []string{ScopeFull}
 	} else {
-		// Auth not enforced: full access to the synthetic `public` docset.
-		id.Grants = map[string]string{"public": "rw"}
 		id.Scopes = []string{ScopeFull}
 	}
 	return id

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -631,7 +631,7 @@ type MergeFS struct {
 	mounts map[string]vfs.FileSystem
 	// system marks mount names that are control-plane (e.g. "requests") rather
 	// than lore docsets. System mounts are always readable regardless of an
-	// identity's grants (see Server.readableRoots / SystemMountPaths).
+	// identity's RBAC policy (see Server.readableRoots / SystemMountPaths).
 	system map[string]bool
 }
 
@@ -661,7 +661,7 @@ func (m *MergeFS) MountSystem(name string, fs vfs.FileSystem) {
 }
 
 // SystemMountPaths returns the display paths ("/name") of every control-plane
-// (system) mount. These are always readable regardless of an identity's grants,
+// (system) mount. These are always readable regardless of an identity's roles,
 // so the read-scoping layer includes them.
 func (m *MergeFS) SystemMountPaths() []string {
 	var out []string

--- a/pkg/openlore/wif_test.go
+++ b/pkg/openlore/wif_test.go
@@ -44,16 +44,22 @@ func newWIFTestServer(t *testing.T, verifier OIDCVerifier) *Server {
 		auth: &config.AuthConfig{
 			AllowKeyless:    &keyless,
 			UnknownIdentity: "allow",
+			Roles:           map[string]config.RoleSpec{"alice": {}, "ci-indexer": {}},
 			Docsets: map[string]config.DocsetSpec{
-				"public": {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}},
-				"secret": {Paths: []config.PathMapping{{Source: "/secret", Display: "/secret"}}},
+				"public": {
+					Paths:  []config.PathMapping{{Source: "/public", Display: "/public"}},
+					Access: config.DocsetAccess{Allow: map[string]string{"guest": "ro", "alice": "ro", "ci-indexer": "ro"}},
+				},
+				"secret": {
+					Paths:  []config.PathMapping{{Source: "/secret", Display: "/secret"}},
+					Access: config.DocsetAccess{Allow: map[string]string{"alice": "rw", "ci-indexer": "rw"}},
+				},
 			},
-			Default: map[string]string{"public": "ro"},
 			Identities: []config.AuthIdentity{
-				{Name: "alice", Docsets: map[string]string{"public": "ro", "secret": "rw"}},
+				{Name: "alice", Roles: []string{"alice"}},
 				{
-					Name:    "ci-indexer",
-					Docsets: map[string]string{"public": "ro", "secret": "rw"},
+					Name:  "ci-indexer",
+					Roles: []string{"ci-indexer"},
 					Match: []config.IdentityMatch{{
 						SubPrefix: "repo:my-org/my-repo:",
 						Aud:       "https://openlore.test",
@@ -72,6 +78,7 @@ func newWIFTestServer(t *testing.T, verifier OIDCVerifier) *Server {
 			},
 		},
 	}
+	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
 	if err := s.initAuth(); err != nil {
 		t.Fatalf("initAuth: %v", err)
 	}
@@ -191,6 +198,21 @@ func TestWIF_ReadScopeShellIsReadOnly(t *testing.T) {
 	fullID, _ := s.identityForName("ci-indexer") // defaults to {full}
 	if sh := s.buildSessionShell(fullID); !sh.ActionAllowed(cmds.ActionWrite) {
 		t.Error("full-scope session should allow write")
+	}
+}
+
+func TestTokenScopesFailClosed(t *testing.T) {
+	s := newWIFTestServer(t, fakeVerifier{claims: ghClaims()})
+	for _, scope := range []string{"", "unknown"} {
+		t.Run(scope, func(t *testing.T) {
+			id, err := s.resolveClaims(Claims{Subject: "ci-indexer", Scope: scope})
+			if err != nil {
+				t.Fatalf("resolve claims: %v", err)
+			}
+			if scopeGrantsWrite(id.Scopes) {
+				t.Fatalf("scope %q unexpectedly grants write", scope)
+			}
+		})
 	}
 }
 

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -44,8 +44,8 @@ type CmdContext interface {
 }
 
 // DocsetInfo describes one docset a session can access. It is the per-session
-// view surfaced by `lore docsets` — the host resolves it from the identity's
-// grants at session creation.
+// view surfaced by `lore docsets` — the host resolves it from the session's
+// role-policy snapshot.
 type DocsetInfo struct {
 	// Name is the docset's logical name (its key in the auth config).
 	Name string
@@ -55,8 +55,10 @@ type DocsetInfo struct {
 	// AliasTarget is the canonical display path when this row represents an
 	// alias. Empty means the row is canonical.
 	AliasTarget string
-	// Grant is the grant name the session holds on this docset (ro/rw/publish).
+	// Grant is retained for standalone callers that provide one grant directly.
 	Grant string
+	// Grants are the effective grants contributed by the session's roles.
+	Grants []string
 	// Writable reports whether this session may write to the docset directly
 	// with the normal write verbs. This is the FS-authoritative answer.
 	Writable bool

--- a/pkg/shell/cmds/lore.go
+++ b/pkg/shell/cmds/lore.go
@@ -79,14 +79,17 @@ func init() {
 }
 
 // cmdLoreDocsets prints an aligned, greppable table of the session's accessible
-// docset mounts: name, grant, attribute tokens, display path, and canonical
+// docset mounts: name, grants, attribute tokens, display path, and canonical
 // target for alias rows.
 func cmdLoreDocsets(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	docsets := ctx.Docsets()
 
-	rows := [][5]string{{"DOCSET", "GRANT", "ATTRIBUTES", "PATH", "TARGET"}}
+	rows := [][5]string{{"DOCSET", "GRANTS", "ATTRIBUTES", "PATH", "TARGET"}}
 	for _, d := range docsets {
-		grant := d.Grant
+		grant := strings.Join(d.Grants, ",")
+		if grant == "" {
+			grant = d.Grant
+		}
 		if grant == "" {
 			grant = "ro"
 		}

--- a/pkg/shell/cmds/lore_test.go
+++ b/pkg/shell/cmds/lore_test.go
@@ -79,7 +79,7 @@ func TestLoreDocsets_EmptyShowsHeaderOnly(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0", code)
 	}
-	if strings.TrimRight(out, "\n") != "DOCSET  GRANT  ATTRIBUTES  PATH  TARGET" {
+	if strings.TrimRight(out, "\n") != "DOCSET  GRANTS  ATTRIBUTES  PATH  TARGET" {
 		t.Fatalf("empty docsets should print header only, got:\n%q", out)
 	}
 }

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -24,7 +24,8 @@ type Shell struct {
 	// "unrestricted" — every action is allowed (the default, backward
 	// compatible). When non-nil, a command (or redirect) whose capability
 	// class is absent is treated as if it does not exist.
-	allowedActions map[cmds.Action]bool
+	allowedActions   map[cmds.Action]bool
+	actionAuthorizer func(cmds.Action) bool
 	// conflictPolicyFn resolves the write-conflict policy for a resolved path.
 	// nil means "use the default" (vfs.PolicyHash). The server sets this to a
 	// per-docset resolver; standalone shells get the default.
@@ -62,11 +63,17 @@ func (s *Shell) SetAllowedActions(actions []cmds.Action) {
 // ActionAllowed reports whether the session may perform the capability class.
 // An unrestricted shell (allowedActions == nil) permits everything.
 func (s *Shell) ActionAllowed(a cmds.Action) bool {
+	if s.actionAuthorizer != nil && !s.actionAuthorizer(a) {
+		return false
+	}
 	if s.allowedActions == nil {
 		return true
 	}
 	return s.allowedActions[a]
 }
+
+// SetActionAuthorizer installs a per-invocation narrowing check.
+func (s *Shell) SetActionAuthorizer(fn func(cmds.Action) bool) { s.actionAuthorizer = fn }
 
 // SetConflictPolicyFn installs a resolver that maps a resolved path to its
 // write-conflict policy. Passing nil restores the default (vfs.PolicyHash).


### PR DESCRIPTION
## Summary

- add top-level role definitions and resource-centric docset ACLs with additive grants and deny precedence
- resolve current identity roles and home ownership at runtime through a file-backed `AuthorizationStore`
- reserve `guest` for keyless access, keep home directories implicitly read/write for their owners, and respect nested docset boundaries
- snapshot authorization for reads while reauthorizing writes and capabilities when invoked
- add CLI commands for managing roles, identity assignments, docset grants/denials, and role capabilities
- keep legacy identity grant fields parseable but non-authoritative when RBAC is enforced

## Security behavior

- authorization fails closed if dynamic role resolution fails or returns unknown roles
- policy identity must match the authenticated principal
- unknown/empty token scopes fail closed
- recursive deletion cannot cross into nested docsets

## Testing

- `go test ./...`
- `go test -race ./pkg/openlore ./cmd/openlore`