### PR TITLE
feat: add Agent Skills docset plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,36 @@ lore meta | jq -r 'select(.type=="Metric").path' | xargs cat # drill into metric
 Read-scoping comes for free: the walk goes through the session filesystem, so
 `lore meta` only ever sees what the identity can already read.
 
+**Agent Skills.** Setting `"agent_skills": true` on a docset treats every
+canonical path in that docset as an [Agent Skills](https://agentskills.io/)
+collection. Each immediate child directory is a skill and must contain an
+exactly named `SKILL.md` with valid Agent Skills frontmatter. Writes are checked
+both at admission and immediately before the serialized commit. To keep a
+parseable `SKILL.md` as ordinary documentation, set
+`metadata.agent_skill: disable`; aliases remain alternate spellings and are not
+scanned as additional collections.
+
+```json
+{
+  "docsets": {
+    "skills": {
+      "paths": ["/skills"],
+      "aliases": ["/agent-skills"],
+      "agent_skills": true
+    }
+  }
+}
+```
+
+Enabled, accessible collections can be queried without scanning unrelated
+documents. Results use absolute canonical mounted paths; the accepted filter
+names are `agent_skills`, `agent_skill`, `skills`, and `skill`:
+
+```bash
+lore meta --filter agent_skills
+lore meta --filter skills /skills/deploy
+```
+
 **OKF annotation.** When the okf plugin is active, it enriches `lore meta`
 records (via `MetaExtenderProvider`) with an `okf` field — but only for
 documents where OKF actually applies (the owning docset has `okf` and the path

--- a/cmd/openlore/main.go
+++ b/cmd/openlore/main.go
@@ -507,7 +507,10 @@ func main() {
 	// The inbox plugin contributes the `publish` grant (read whole docset, no
 	// deletes, create/edit only within the docset's inbox). Registered by
 	// default so lore.json may use `"grant": "publish"`.
-	srv.RegisterPlugin(openlore.NewInboxPlugin())
+	if err := srv.RegisterPlugin(openlore.NewInboxPlugin()); err != nil {
+		slog.Error("failed to register inbox plugin", "error", err)
+		os.Exit(1)
+	}
 
 	cmds.VersionString = assets.Version()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,6 +197,8 @@ type JWKSSpec struct {
 // DocsetSpec defines a named set of path mappings.
 type DocsetSpec struct {
 	Paths []PathMapping `json:"paths"`
+	// AgentSkills treats each canonical path as an Agent Skills collection.
+	AgentSkills bool `json:"agent_skills,omitempty"`
 	// Aliases are alternate display roots for the first path. They expose the
 	// same content while the first path remains canonical for home, inbox,
 	// policy, hooks, and changesets.

--- a/pkg/agentskills/validate.go
+++ b/pkg/agentskills/validate.go
@@ -1,0 +1,76 @@
+// Package agentskills validates the agentskills.io SKILL.md format.
+package agentskills
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/aakarim/go-openlore/pkg/okf"
+)
+
+var nameRE = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+// Result describes a parseable skill. Disabled skills deliberately bypass all
+// strict field validation after the exact opt-out has been observed.
+type Result struct{ Disabled bool }
+
+// Validate validates content for the skill directory dirName.
+func Validate(dirName string, content []byte) (Result, error) {
+	fm, _, ok, err := okf.ParseFrontmatter(content)
+	if err != nil {
+		return Result{}, err
+	}
+	if !ok || fm == nil {
+		return Result{}, fmt.Errorf("SKILL.md requires YAML frontmatter mapping")
+	}
+	if raw, ok := fm["metadata"]; ok {
+		if m, ok := raw.(map[string]any); ok && m["agent_skill"] == "disable" {
+			return Result{Disabled: true}, nil
+		}
+	}
+	allowed := map[string]bool{"name": true, "description": true, "license": true, "compatibility": true, "metadata": true, "allowed-tools": true}
+	for k := range fm {
+		if !allowed[k] {
+			return Result{}, fmt.Errorf("unknown frontmatter field %q", k)
+		}
+	}
+	name, ok := fm["name"].(string)
+	if !ok || len(name) < 1 || len(name) > 64 || !nameRE.MatchString(name) {
+		return Result{}, fmt.Errorf("name must be 1-64 characters matching [a-z0-9]+(?:-[a-z0-9]+)*")
+	}
+	if name != path.Base(dirName) {
+		return Result{}, fmt.Errorf("name %q must match parent directory %q", name, path.Base(dirName))
+	}
+	desc, ok := fm["description"].(string)
+	if !ok || strings.TrimSpace(desc) == "" || utf8.RuneCountInString(desc) > 1024 {
+		return Result{}, fmt.Errorf("description must be a nonblank string of at most 1024 characters")
+	}
+	for _, k := range []string{"license", "allowed-tools"} {
+		if v, exists := fm[k]; exists {
+			if _, ok := v.(string); !ok {
+				return Result{}, fmt.Errorf("%s must be a string", k)
+			}
+		}
+	}
+	if v, exists := fm["compatibility"]; exists {
+		s, ok := v.(string)
+		if !ok || s == "" || utf8.RuneCountInString(s) > 500 {
+			return Result{}, fmt.Errorf("compatibility must be a nonempty string of at most 500 characters")
+		}
+	}
+	if v, exists := fm["metadata"]; exists {
+		m, ok := v.(map[string]any)
+		if !ok {
+			return Result{}, fmt.Errorf("metadata must be a string-to-string mapping")
+		}
+		for k, x := range m {
+			if _, ok := x.(string); !ok {
+				return Result{}, fmt.Errorf("metadata.%s must be a string", k)
+			}
+		}
+	}
+	return Result{}, nil
+}

--- a/pkg/agentskills/validate_test.go
+++ b/pkg/agentskills/validate_test.go
@@ -1,0 +1,58 @@
+package agentskills
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	valid := []byte("---\nname: my-skill\ndescription: Does useful work\nmetadata:\n  owner: team\n---\nanything\n")
+	if _, err := Validate("my-skill", valid); err != nil {
+		t.Fatal(err)
+	}
+	bad := []byte("---\nname: other\ndescription: ok\nextra: no\n---\n")
+	if _, err := Validate("my-skill", bad); err == nil {
+		t.Fatal("expected strict validation error")
+	}
+}
+
+func TestValidateStrictFieldsAndRuneLimits(t *testing.T) {
+	base := func(extra string) []byte {
+		return []byte("---\nname: my-skill\ndescription: useful\n" + extra + "---\n")
+	}
+	tests := []struct {
+		name string
+		body []byte
+		bad  bool
+	}{
+		{"description multibyte boundary", []byte("---\nname: my-skill\ndescription: " + strings.Repeat("界", 1024) + "\n---\n"), false},
+		{"description over boundary", []byte("---\nname: my-skill\ndescription: " + strings.Repeat("界", 1025) + "\n---\n"), true},
+		{"compatibility multibyte boundary", base("compatibility: " + strings.Repeat("界", 500) + "\n"), false},
+		{"compatibility over boundary", base("compatibility: " + strings.Repeat("界", 501) + "\n"), true},
+		{"unknown field", base("surprise: true\n"), true},
+		{"non-string license", base("license: 7\n"), true},
+		{"non-string tools", base("allowed-tools: [cat]\n"), true},
+		{"non-map metadata", base("metadata: owner\n"), true},
+		{"non-string metadata value", base("metadata:\n  owner: 7\n"), true},
+		{"directory mismatch", []byte("---\nname: other\ndescription: useful\n---\n"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Validate("my-skill", tt.body)
+			if (err != nil) != tt.bad {
+				t.Fatalf("error = %v, bad = %v", err, tt.bad)
+			}
+		})
+	}
+}
+
+func TestValidateDisableBeforeStrictValidation(t *testing.T) {
+	b := []byte("---\nmetadata:\n  agent_skill: disable\nunknown: allowed-for-disabled\n---\n")
+	r, err := Validate("anything", b)
+	if err != nil || !r.Disabled {
+		t.Fatalf("result=%+v err=%v", r, err)
+	}
+	if _, err := Validate("anything", []byte("not frontmatter")); err == nil {
+		t.Fatal("opt-out must remain parseable")
+	}
+}

--- a/pkg/openlore/agent_skills_plugin.go
+++ b/pkg/openlore/agent_skills_plugin.go
@@ -1,0 +1,175 @@
+package openlore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path"
+	"strings"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/agentskills"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type agentSkillsPlugin struct {
+	docsets      map[string]config.DocsetSpec
+	fs           vfs.FileSystem
+	canonicalize func(string) string
+	logger       *slog.Logger
+}
+
+func anyDocsetHasAgentSkills(ds map[string]config.DocsetSpec) bool {
+	for _, d := range ds {
+		if d.AgentSkills {
+			return true
+		}
+	}
+	return false
+}
+
+func newAgentSkills(ds map[string]config.DocsetSpec, fsys vfs.FileSystem, canonicalize func(string) string, logger *slog.Logger) *agentSkillsPlugin {
+	return &agentSkillsPlugin{docsets: ds, fs: fsys, canonicalize: canonicalize, logger: logger}
+}
+
+func (p *agentSkillsPlugin) canonical(pth string) string {
+	if p.canonicalize != nil {
+		return vfs.CleanPath(p.canonicalize(pth))
+	}
+	if c, ok := p.fs.(vfs.PathCanonicalizer); ok {
+		return vfs.CleanPath(c.CanonicalPath(pth))
+	}
+	return vfs.CleanPath(pth)
+}
+
+func (p *agentSkillsPlugin) roots() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, ds := range p.docsets {
+		if ds.AgentSkills {
+			for _, pm := range ds.Paths {
+				r := p.canonical(displayPath(pm))
+				if !seen[r] {
+					seen[r] = true
+					out = append(out, r)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func candidate(root, target string) (string, bool) {
+	root, target = vfs.CleanPath(root), vfs.CleanPath(target)
+	if !pathWithinRoot(root, target) || target == root {
+		return "", false
+	}
+	rel := strings.TrimPrefix(strings.TrimPrefix(target, root), "/")
+	first := strings.Split(rel, "/")[0]
+	if first == "" || !strings.Contains(rel, "/") {
+		return "", false
+	}
+	return path.Join(root, first), true
+}
+
+// validateMutation projects only SKILL.md, the sole constrained resource.
+func (p *agentSkillsPlugin) validateMutation(cs vfs.ChangeSet) error {
+	if cs.Action == vfs.ChangeActionMkdir || cs.Action == vfs.ChangeActionMkdirAll {
+		return nil
+	}
+	for _, root := range p.roots() {
+		dir, ok := candidate(root, cs.Target)
+		if !ok {
+			continue
+		}
+		// Removing the whole immediate-child directory is explicitly allowed.
+		if (cs.Action == vfs.ChangeActionRemove || cs.Action == vfs.ChangeActionRemoveAll) && vfs.CleanPath(cs.Target) == dir {
+			continue
+		}
+		skill := path.Join(dir, "SKILL.md")
+		var content []byte
+		if cs.Action == vfs.ChangeActionWrite && vfs.CleanPath(cs.Target) == skill && cs.Write != nil {
+			content = cs.Write.Bytes
+		} else {
+			// Any operation that removes SKILL.md projects it missing.
+			if (cs.Action == vfs.ChangeActionRemove || cs.Action == vfs.ChangeActionRemoveAll) && pathWithinRoot(vfs.CleanPath(cs.Target), skill) {
+				return fmt.Errorf("agent_skills: %s: SKILL.md is required", dir)
+			}
+			b, err := p.fs.ReadFile(skill)
+			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return fmt.Errorf("agent_skills: %s: SKILL.md is required", dir)
+				}
+				if p.logger != nil {
+					p.logger.Error("agent skill validation read failed", "target", cs.Target, "action", cs.Action, "root", root, "err", err)
+				}
+				return fmt.Errorf("agent_skills: %s: unable to validate SKILL.md", dir)
+			}
+			content = b
+		}
+		if _, err := agentskills.Validate(path.Base(dir), content); err != nil {
+			return fmt.Errorf("agent_skills: %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func (p *agentSkillsPlugin) WriteMiddleware() []WriteMiddleware {
+	return []WriteMiddleware{func(next WriteHandler) WriteHandler {
+		return func(ctx context.Context, op WriteOp) (WriteResult, error) {
+			if err := p.validateMutation(op.ChangeSet); err != nil {
+				return WriteResult{}, err
+			}
+			return next(ctx, op)
+		}
+	}}
+}
+
+func (p *agentSkillsPlugin) MetaExtenders() []meta.Extender {
+	return []meta.Extender{func(abs string, content []byte, _ map[string]any) map[string]any {
+		abs = p.canonical(abs)
+		for _, root := range p.roots() {
+			dir, ok := candidate(root, abs)
+			if !ok || abs != path.Join(dir, "SKILL.md") {
+				continue
+			}
+			r, err := agentskills.Validate(path.Base(dir), content)
+			if r.Disabled {
+				return nil
+			}
+			if err != nil {
+				return map[string]any{"agent_skill": false, "agent_skill_error": err.Error()}
+			}
+			return map[string]any{"agent_skill": true}
+		}
+		return nil
+	}}
+}
+
+func (p *agentSkillsPlugin) MetaFilters() []meta.Filter {
+	return []meta.Filter{{Name: "agent_skills", Aliases: []string{"agent_skill", "skills", "skill"}, Roots: p.roots(), AbsolutePaths: true, Selector: func(abs string, r meta.Record) bool {
+		if metadata, ok := r.Fields["metadata"].(map[string]any); ok && metadata["agent_skill"] == "disable" {
+			return false
+		}
+		abs = p.canonical(abs)
+		for _, root := range p.roots() {
+			dir, ok := candidate(root, abs)
+			if ok && abs == path.Join(dir, "SKILL.md") {
+				trusted, _ := r.Fields["agent_skill"].(bool)
+				return trusted
+			}
+		}
+		return false
+	}}}
+}
+
+func (*agentSkillsPlugin) Info() PluginInfo {
+	return PluginInfo{Name: "agent_skills", Version: "1.0.0"}
+}
+
+var _ WriteMiddlewareProvider = (*agentSkillsPlugin)(nil)
+var _ MetaExtenderProvider = (*agentSkillsPlugin)(nil)
+var _ MetaFilterProvider = (*agentSkillsPlugin)(nil)

--- a/pkg/openlore/agent_skills_plugin_test.go
+++ b/pkg/openlore/agent_skills_plugin_test.go
@@ -1,0 +1,211 @@
+package openlore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+func skillBytes(name string) []byte {
+	return []byte("---\nname: " + name + "\ndescription: useful\n---\n")
+}
+
+func TestAgentSkillsAdmissionRootFilesAndNestedRoots(t *testing.T) {
+	docsets := map[string]config.DocsetSpec{
+		"outer": {Paths: []config.PathMapping{{Source: "/skills", Display: "/skills"}}, AgentSkills: true},
+		"inner": {Paths: []config.PathMapping{{Source: "/skills/team", Display: "/skills/team"}}, AgentSkills: true},
+	}
+	p := newAgentSkills(docsets, failingReadFS{err: os.ErrNotExist}, nil, slog.Default())
+	rootFile := vfs.ChangeSet{Target: "/skills/README.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("docs")}}
+	if err := p.validateMutation(rootFile); err != nil {
+		t.Fatalf("outer root-level file must be ignored: %v", err)
+	}
+	// It is root-level for the inner collection, but supporting content in the
+	// outer collection's immediate child, so the outer SKILL.md is required.
+	innerRootFile := rootFile
+	innerRootFile.Target = "/skills/team/README.md"
+	if err := p.validateMutation(innerRootFile); err == nil || !strings.Contains(err.Error(), "/skills/team") {
+		t.Fatalf("nested root must retain enabled ancestor evaluation: %v", err)
+	}
+}
+
+func TestAgentSkillsAnnotationsAndAuthoritativePreApply(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "skills", "valid"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "skills", "valid", "SKILL.md"), skillBytes("valid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := NewDirFS(root, config.FilesConfig{})
+	if err := dir.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	docsets := map[string]config.DocsetSpec{"skills": {Paths: []config.PathMapping{{Source: "/skills", Display: "/skills"}}, AgentSkills: true}}
+	p := newAgentSkills(docsets, dir, nil, slog.Default())
+	ext := p.MetaExtenders()[0]
+	if got := ext("/skills/valid/SKILL.md", skillBytes("valid"), nil); got["agent_skill"] != true {
+		t.Fatalf("valid annotation = %v", got)
+	}
+	if got := ext("/skills/valid/SKILL.md", skillBytes("wrong"), nil); got["agent_skill"] != false {
+		t.Fatalf("invalid annotation = %v", got)
+	}
+	disabled := []byte("---\nmetadata:\n  agent_skill: disable\n---\n")
+	if got := ext("/skills/valid/SKILL.md", disabled, nil); got != nil {
+		t.Fatalf("disabled annotation = %v", got)
+	}
+	forgedDisabled := meta.Record{Fields: map[string]any{
+		"agent_skill": true,
+		"metadata":    map[string]any{"agent_skill": "disable"},
+	}}
+	if p.MetaFilters()[0].Selector("/skills/valid/SKILL.md", forgedDisabled) {
+		t.Fatal("disabled skill forged its way into filtered discovery")
+	}
+
+	l := newWriteLog(dir, nil, slog.Default(), 1)
+	l.SetPreApply(p.validateMutation)
+	defer l.Close(context.Background())
+	bad := vfs.ChangeSet{Target: "/skills/bad/SKILL.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: skillBytes("wrong")}}
+	if _, err := l.Submit(context.Background(), Actor{}, bad); err == nil {
+		t.Fatal("direct/deferred commit bypass must reject invalid skill")
+	}
+	removeSkill := vfs.ChangeSet{Target: "/skills/valid/SKILL.md", Action: vfs.ChangeActionRemove}
+	if _, err := l.Submit(context.Background(), Actor{}, removeSkill); err == nil {
+		t.Fatal("SKILL.md deletion must be rejected")
+	}
+	removeDir := vfs.ChangeSet{Target: "/skills/valid", Action: vfs.ChangeActionRemoveAll, RemoveAll: &vfs.RemoveAllChange{}}
+	if _, err := l.Submit(context.Background(), Actor{}, removeDir); err != nil {
+		t.Fatalf("whole skill directory deletion: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(root, "skills", "disabled"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	disabledPath := filepath.Join(root, "skills", "disabled", "SKILL.md")
+	if err := os.WriteFile(disabledPath, disabled, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removeDisabledSkill := vfs.ChangeSet{Target: "/skills/disabled/SKILL.md", Action: vfs.ChangeActionRemove}
+	if _, err := l.Submit(context.Background(), Actor{}, removeDisabledSkill); err == nil {
+		t.Fatal("disabled SKILL.md deletion must be rejected")
+	}
+	removeDisabledDir := vfs.ChangeSet{Target: "/skills/disabled", Action: vfs.ChangeActionRemoveAll, RemoveAll: &vfs.RemoveAllChange{}}
+	if _, err := l.Submit(context.Background(), Actor{}, removeDisabledDir); err != nil {
+		t.Fatalf("whole disabled skill directory deletion: %v", err)
+	}
+}
+
+type errorReadFS struct{ error }
+
+func (f errorReadFS) Stat(string) (*vfs.FileInfo, error)     { return nil, f.error }
+func (f errorReadFS) ReadDir(string) ([]vfs.FileInfo, error) { return nil, f.error }
+func (f errorReadFS) ReadFile(string) ([]byte, error)        { return nil, f.error }
+
+func TestAgentSkillsReadErrorIsLoggedButNotLeaked(t *testing.T) {
+	secret := errors.New("backend password=secret")
+	var logs bytes.Buffer
+	p := newAgentSkills(map[string]config.DocsetSpec{"s": {Paths: []config.PathMapping{{Source: "/skills", Display: "/skills"}}, AgentSkills: true}}, errorReadFS{secret}, nil, slog.New(slog.NewTextHandler(&logs, nil)))
+	cs := vfs.ChangeSet{Target: "/skills/a/note.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("x")}}
+	err := p.validateMutation(cs)
+	if err == nil || strings.Contains(err.Error(), "password") || !strings.Contains(err.Error(), "unable to validate") {
+		t.Fatalf("public error = %v", err)
+	}
+	if !strings.Contains(logs.String(), "password=secret") || strings.Contains(logs.String(), "x\"") {
+		t.Fatalf("log missing backend error or leaked content: %s", logs.String())
+	}
+}
+
+func TestAgentSkillsMetaCanonicalizesAliases(t *testing.T) {
+	docsets := map[string]config.DocsetSpec{
+		"skills": {
+			Paths:       []config.PathMapping{{Source: "/skills", Display: "/skills"}},
+			Aliases:     []string{"/agent-skills"},
+			AgentSkills: true,
+		},
+	}
+	canonical := func(p string) string {
+		p = vfs.CleanPath(p)
+		if p == "/agent-skills" || strings.HasPrefix(p, "/agent-skills/") {
+			return "/skills" + strings.TrimPrefix(p, "/agent-skills")
+		}
+		return p
+	}
+	p := newAgentSkills(docsets, failingReadFS{err: os.ErrNotExist}, canonical, slog.Default())
+	got := p.MetaExtenders()[0]("/agent-skills/deploy/SKILL.md", skillBytes("deploy"), nil)
+	if got["agent_skill"] != true {
+		t.Fatalf("alias metadata annotation = %v", got)
+	}
+}
+
+func TestSessionMetaFiltersRequireGrantOnFilterDocset(t *testing.T) {
+	docsets := map[string]config.DocsetSpec{
+		"skills": {Paths: []config.PathMapping{{Source: "/skills", Display: "/skills"}}, AgentSkills: true},
+		"nested": {Paths: []config.PathMapping{{Source: "/skills/team", Display: "/skills/team"}}},
+	}
+	s := &Server{auth: &config.AuthConfig{Docsets: docsets}, grants: newGrantRegistry()}
+	p := newAgentSkills(docsets, failingReadFS{err: os.ErrNotExist}, s.canonicalPath, slog.Default())
+	if err := s.registerPlugin(p); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.sessionMetaFilters(Identity{Grants: map[string]string{"nested": "ro"}}); len(got) != 0 {
+		t.Fatalf("nested ordinary grant exposed ancestor filter: %+v", got)
+	}
+	got := s.sessionMetaFilters(Identity{Grants: map[string]string{"skills": "ro"}})
+	if len(got) != 1 || len(got[0].Roots) != 1 || got[0].Roots[0] != "/skills" {
+		t.Fatalf("direct skills grant did not bind filter: %+v", got)
+	}
+}
+
+func TestSessionDocsetsMarksAgentSkillsCanonicalAndAliasRows(t *testing.T) {
+	docsets := map[string]config.DocsetSpec{
+		"skills": {
+			Paths:       []config.PathMapping{{Source: "/skills", Display: "/skills"}},
+			Aliases:     []string{"/agent-skills"},
+			AgentSkills: true,
+		},
+	}
+	s := &Server{
+		auth:         &config.AuthConfig{Docsets: docsets},
+		grants:       newGrantRegistry(),
+		authEnforced: true,
+		config:       config.Config{Readonly: true},
+	}
+	rows := s.sessionDocsets(Identity{Grants: map[string]string{"skills": "ro"}})
+	if len(rows) != 2 || !rows[0].AgentSkills || !rows[1].AgentSkills {
+		t.Fatalf("agent skills attributes missing from canonical/alias rows: %+v", rows)
+	}
+}
+
+type filterPlugin []meta.Filter
+
+func (p filterPlugin) MetaFilters() []meta.Filter { return p }
+
+func TestRegisterPluginRejectsFilterNameAliasCollisions(t *testing.T) {
+	permutations := []struct{ first, second meta.Filter }{
+		{meta.Filter{Name: "one"}, meta.Filter{Name: "one"}},
+		{meta.Filter{Name: "one", Aliases: []string{"alias"}}, meta.Filter{Name: "alias"}},
+		{meta.Filter{Name: "one"}, meta.Filter{Name: "two", Aliases: []string{"one"}}},
+		{meta.Filter{Name: "one", Aliases: []string{"alias"}}, meta.Filter{Name: "two", Aliases: []string{"alias"}}},
+	}
+	for _, tt := range permutations {
+		s := &Server{grants: newGrantRegistry()}
+		if err := s.registerPlugin(filterPlugin{tt.first}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.registerPlugin(filterPlugin{tt.second}); err == nil {
+			t.Fatalf("collision accepted: %+v then %+v", tt.first, tt.second)
+		}
+	}
+	if s := (&Server{grants: newGrantRegistry()}); s.registerPlugin(filterPlugin{{Name: "one", Aliases: []string{"one"}}}) == nil {
+		t.Fatal("same-filter collision accepted")
+	}
+}

--- a/pkg/openlore/authz_test.go
+++ b/pkg/openlore/authz_test.go
@@ -25,7 +25,9 @@ func grantTestServer() *Server {
 			},
 		},
 	}
-	s.registerPlugin(NewInboxPlugin())
+	if err := s.registerPlugin(NewInboxPlugin()); err != nil {
+		panic(err)
+	}
 	s.authorizationStore = &mutableAuthorizationStore{}
 	return s
 }
@@ -119,7 +121,9 @@ func TestValidateGrants(t *testing.T) {
 	}
 
 	// Register the inbox plugin → publish becomes valid.
-	s.registerPlugin(NewInboxPlugin())
+	if err := s.registerPlugin(NewInboxPlugin()); err != nil {
+		t.Fatal(err)
+	}
 	if err := s.validateGrants(); err != nil {
 		t.Fatalf("publish should validate once the inbox plugin is registered: %v", err)
 	}

--- a/pkg/openlore/commands.go
+++ b/pkg/openlore/commands.go
@@ -23,3 +23,5 @@ type CommandProvider interface {
 type MetaExtenderProvider interface {
 	MetaExtenders() []meta.Extender
 }
+
+type MetaFilterProvider interface{ MetaFilters() []meta.Filter }

--- a/pkg/openlore/docsets_test.go
+++ b/pkg/openlore/docsets_test.go
@@ -43,7 +43,9 @@ func enforcedDocsetServer() *Server {
 		},
 	}
 	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
-	s.registerPlugin(NewInboxPlugin())
+	if err := s.registerPlugin(NewInboxPlugin()); err != nil {
+		panic(err)
+	}
 	return s
 }
 

--- a/pkg/openlore/meta/meta.go
+++ b/pkg/openlore/meta/meta.go
@@ -25,6 +25,15 @@ import (
 // agrees with write-side enforcement.
 type Extender func(absPath string, content []byte, frontmatter map[string]any) map[string]any
 
+// Filter is a plugin-provided, session-bound metadata query.
+type Filter struct {
+	Name          string
+	Aliases       []string
+	Roots         []string
+	AbsolutePaths bool
+	Selector      func(absPath string, record Record) bool
+}
+
 // Record is one scanned document: its path relative to the scan root and the
 // merged field map (frontmatter plus any extender-contributed fields). Path is
 // kept separate so callers decide how to surface it.

--- a/pkg/openlore/okf_plugin_test.go
+++ b/pkg/openlore/okf_plugin_test.go
@@ -306,7 +306,9 @@ func TestRegisterPlugin_WiresOKFIntoLoreMeta(t *testing.T) {
 		"wiki": docset("/wiki", &config.OKFDocsetConfig{}),
 	}
 	s := &Server{grants: newGrantRegistry()}
-	s.registerPlugin(newOKF(docsets, nil)) // must collect the meta extender
+	if err := s.registerPlugin(newOKF(docsets, nil)); err != nil { // must collect the meta extender
+		t.Fatal(err)
+	}
 
 	sh := shell.NewShell(NewDirFS(dir, config.FilesConfig{}))
 	sh.SetMetaExtenders(s.metaExtenders)

--- a/pkg/openlore/plugin_info_test.go
+++ b/pkg/openlore/plugin_info_test.go
@@ -32,8 +32,12 @@ func TestRegisterPlugin_LogsNameAndVersion(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 	s := &Server{grants: newGrantRegistry(), logger: logger}
 
-	s.registerPlugin(newOKF(map[string]config.DocsetSpec{}, logger))
-	s.registerPlugin(NewInboxPlugin())
+	if err := s.registerPlugin(newOKF(map[string]config.DocsetSpec{}, logger)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.registerPlugin(NewInboxPlugin()); err != nil {
+		t.Fatal(err)
+	}
 
 	out := buf.String()
 	for _, want := range []string{`name=okf`, `version=0.1.0`, `name=inbox`, `version=1.0.0`} {
@@ -47,5 +51,7 @@ func TestRegisterPlugin_LogsNameAndVersion(t *testing.T) {
 // panic during registration.
 func TestRegisterPlugin_NilLoggerDoesNotPanic(t *testing.T) {
 	s := &Server{grants: newGrantRegistry()}
-	s.registerPlugin(NewInboxPlugin()) // must not panic
+	if err := s.registerPlugin(NewInboxPlugin()); err != nil { // must not panic
+		t.Fatal(err)
+	}
 }

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -85,6 +85,7 @@ type Server struct {
 	// metaExtenders are the `lore meta` extenders contributed by plugins,
 	// installed per session in buildSessionShell.
 	metaExtenders []meta.Extender
+	metaFilters   []meta.Filter
 
 	// postCommitMW is the post-commit middleware contributed by plugins, run at
 	// the applier after a durable commit (feed emit, post_write hooks) in
@@ -157,16 +158,15 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		motd:    cfg.MOTD,
 	}
 
-	// Built-in shellexec plugin: external commands as middleware on the
-	// read/write paths (pre_read, pre_commit, post_write). Registered here,
-	// before the write log is built, so its post-commit middleware is composed
-	// into the applier's chain.
+	// Construct shellexec now, but register built-ins after auth/docsets are
+	// loaded so Agent Skills admission can be the outermost write middleware.
+	var shellPlugin *shellexecPlugin
 	if !cfg.Shellexec.IsEmpty() {
 		plug, err := newShellexec(cfg.Shellexec, cfg.DataDir, ShellRunner{}, logger)
 		if err != nil {
 			return nil, fmt.Errorf("configuring shellexec plugin: %w", err)
 		}
-		s.registerPlugin(plug)
+		shellPlugin = plug
 	}
 
 	// Load auth config
@@ -216,8 +216,22 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 	// write log is built — because it resolves the effective OKF config per write
 	// from the docset that owns the target path. Only registered when at least
 	// one docset carries OKF config.
+	var agentSkills *agentSkillsPlugin
+	if anyDocsetHasAgentSkills(s.auth.Docsets) {
+		agentSkills = newAgentSkills(s.auth.Docsets, s.merge, s.canonicalPath, logger)
+		if err := s.registerPlugin(agentSkills); err != nil {
+			return nil, err
+		}
+	}
 	if anyDocsetHasOKF(s.auth.Docsets) {
-		s.registerPlugin(newOKF(s.auth.Docsets, logger))
+		if err := s.registerPlugin(newOKF(s.auth.Docsets, logger)); err != nil {
+			return nil, err
+		}
+	}
+	if shellPlugin != nil {
+		if err := s.registerPlugin(shellPlugin); err != nil {
+			return nil, err
+		}
 	}
 
 	// Set up root directory. A caller-supplied rootFS wins (installed before the
@@ -256,6 +270,9 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		// so it is the sole writer and gives globally ordered writes/removes. The
 		// applier runs the post-commit chain after each durable commit.
 		s.writeLog = newWriteLog(s.merge, s.postCommitChain(), logger, 0)
+		if agentSkills != nil {
+			s.writeLog.SetPreApply(agentSkills.validateMutation)
+		}
 
 		// Async external work (Part D): the `spawn` command runs a command in a
 		// bounded goroutine and writes its stdout back through the captured
@@ -622,11 +639,14 @@ func (s *Server) shellHandler(next ssh.Handler) ssh.Handler {
 // post-commit provider registered after construction still fires on commits.
 //
 // Call it before serving; it is not safe to call concurrently with live traffic.
-func (s *Server) RegisterPlugin(p any) {
-	s.registerPlugin(p)
+func (s *Server) RegisterPlugin(p any) error {
+	if err := s.registerPlugin(p); err != nil {
+		return err
+	}
 	if s.writeLog != nil {
 		s.writeLog.SetPostCommit(s.postCommitChain())
 	}
+	return nil
 }
 
 // CommitChangeSet appends an already-authorized ChangeSet directly to the ordered
@@ -663,7 +683,24 @@ func (s *Server) canonicalChangeSet(cs vfs.ChangeSet) vfs.ChangeSet {
 // NewServer before the write log is built: read/write middleware are read
 // per-session at buildSessionShell time, but the post-commit chain is composed
 // once when newWriteLog is constructed.
-func (s *Server) registerPlugin(p any) {
+func (s *Server) registerPlugin(p any) error {
+	if fp, ok := p.(MetaFilterProvider); ok {
+		claimed := map[string]bool{}
+		for _, existing := range s.metaFilters {
+			claimed[existing.Name] = true
+			for _, alias := range existing.Aliases {
+				claimed[alias] = true
+			}
+		}
+		for _, f := range fp.MetaFilters() {
+			for _, name := range append([]string{f.Name}, f.Aliases...) {
+				if name == "" || claimed[name] {
+					return fmt.Errorf("metadata filter name or alias %q is already registered", name)
+				}
+				claimed[name] = true
+			}
+		}
+	}
 	if wp, ok := p.(WriteMiddlewareProvider); ok {
 		s.writeMW = append(s.writeMW, wp.WriteMiddleware()...)
 	}
@@ -686,6 +723,9 @@ func (s *Server) registerPlugin(p any) {
 	if mp, ok := p.(MetaExtenderProvider); ok {
 		s.metaExtenders = append(s.metaExtenders, mp.MetaExtenders()...)
 	}
+	if fp, ok := p.(MetaFilterProvider); ok {
+		s.metaFilters = append(s.metaFilters, fp.MetaFilters()...)
+	}
 	// Record the plugin's identity + version in the boot logs. Logged per
 	// registration so it captures plugins registered after NewServer (e.g. the
 	// inbox plugin, wired by the CLI via RegisterPlugin) too.
@@ -693,6 +733,7 @@ func (s *Server) registerPlugin(p any) {
 		info := ip.Info()
 		s.logger.Info("plugin registered", "name", info.Name, "version", info.Version)
 	}
+	return nil
 }
 
 // writeChain composes the admission (pre-commit) middleware around a terminal
@@ -858,6 +899,7 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 	// Per-session docset views for `lore docsets` and publish inboxes for
 	// `publish`. Computed once here, where the access authority lives.
 	sh.SetDocsets(s.sessionDocsets(id))
+	sh.SetMetaFilters(s.sessionMetaFilters(id))
 	sh.SetPublishTargets(s.sessionPublishTargets(id))
 	sh.SetMetaExtenders(s.metaExtenders)
 
@@ -897,12 +939,13 @@ func (s *Server) sessionDocsets(id Identity) []cmds.DocsetInfo {
 		}
 		for i, pm := range ds.Paths {
 			out = append(out, cmds.DocsetInfo{
-				Name:     name,
-				Paths:    []string{displayPath(pm)},
-				Grant:    grantName,
-				Writable: writable[name],
-				Home:     i == 0 && name == id.HomeDocset,
-				Inbox:    inboxPath(ds) != "",
+				Name:        name,
+				Paths:       []string{displayPath(pm)},
+				Grant:       grantName,
+				Writable:    writable[name],
+				Home:        i == 0 && name == id.HomeDocset,
+				Inbox:       inboxPath(ds) != "",
+				AgentSkills: ds.AgentSkills,
 			})
 		}
 		target := primaryDisplayPath(ds)
@@ -913,10 +956,47 @@ func (s *Server) sessionDocsets(id Identity) []cmds.DocsetInfo {
 				AliasTarget: target,
 				Grant:       grantName,
 				Writable:    writable[name],
+				AgentSkills: ds.AgentSkills,
 			})
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func (s *Server) sessionMetaFilters(id Identity) []meta.Filter {
+	var out []meta.Filter
+	for _, f := range s.metaFilters {
+		nf := f
+		nf.Roots = nil
+		seen := map[string]bool{}
+		for docsetName, grantName := range id.Grants {
+			ds, ok := s.auth.Docsets[docsetName]
+			if !ok {
+				continue
+			}
+			grant, ok := s.grants.get(grantName)
+			if !ok {
+				continue
+			}
+			for _, pm := range ds.Paths {
+				docRoot := s.canonicalPath(displayPath(pm))
+				for _, providerRoot := range f.Roots {
+					providerRoot = s.canonicalPath(providerRoot)
+					// Filters are bound to docset roots, not merely intersecting
+					// descendants. A grant on a nested ordinary docset must not
+					// expose a filter contributed by its skills-enabled ancestor.
+					if providerRoot == docRoot && !seen[providerRoot] && grant.CanRead(ds, providerRoot) {
+						seen[providerRoot] = true
+						nf.Roots = append(nf.Roots, providerRoot)
+					}
+				}
+			}
+		}
+		if len(nf.Roots) > 0 {
+			out = append(out, nf)
+		}
+	}
 	return out
 }
 

--- a/pkg/openlore/server_seams_test.go
+++ b/pkg/openlore/server_seams_test.go
@@ -84,7 +84,9 @@ func TestRegisterPlugin_WriteMiddlewareGatesLaterWrite(t *testing.T) {
 	s := newSeamServer(t, fs)
 
 	// Registered AFTER construction — must take effect on the composed chain.
-	s.RegisterPlugin(deferMWProvider{gatedPrefix: "/gated", ref: "held-1"})
+	if err := s.RegisterPlugin(deferMWProvider{gatedPrefix: "/gated", ref: "held-1"}); err != nil {
+		t.Fatal(err)
+	}
 
 	chain := s.writeChain()
 
@@ -113,7 +115,9 @@ func TestRegisterPlugin_PostCommitFiresAfterConstruction(t *testing.T) {
 	s := newSeamServer(t, fs)
 
 	rec := &recordPostCommit{}
-	s.RegisterPlugin(rec) // post-commit provider registered after the log was built
+	if err := s.RegisterPlugin(rec); err != nil { // post-commit provider registered after the log was built
+		t.Fatal(err)
+	}
 
 	_, err := s.CommitChangeSet(context.Background(), Actor{ID: "alice", Extra: map[string]string{"approver": "bob"}}, writeCS("/x"))
 	if err != nil {
@@ -136,7 +140,9 @@ func TestCommitChangeSet_SkipsAdmission(t *testing.T) {
 	s := newSeamServer(t, fs)
 
 	// A middleware that defers EVERY write. Admission (writeChain) would park.
-	s.RegisterPlugin(deferMWProvider{gatedPrefix: "/", ref: "held"})
+	if err := s.RegisterPlugin(deferMWProvider{gatedPrefix: "/", ref: "held"}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Sanity: admission defers.
 	if _, err := s.writeChain()(context.Background(), WriteOp{ChangeSet: writeCS("/x"), Actor: Actor{ID: "a"}}); err == nil {

--- a/pkg/openlore/writelog.go
+++ b/pkg/openlore/writelog.go
@@ -49,6 +49,7 @@ type writeLog struct {
 
 	mu         sync.RWMutex      // guards closed + postCommit + serializes sends against Close
 	postCommit PostCommitHandler // optional; runs at the applier after a durable commit
+	preApply   func(vfs.ChangeSet) error
 	closed     bool
 	ch         chan logEntry
 
@@ -89,7 +90,17 @@ func newWriteLog(substrate vfs.WritableFS, postCommit PostCommitHandler, logger 
 func (l *writeLog) run() {
 	defer close(l.done)
 	for e := range l.ch {
-		h, err := vfs.CommitChangeSet(l.substrate, e.cs)
+		var h string
+		var err error
+		l.mu.RLock()
+		pre := l.preApply
+		l.mu.RUnlock()
+		if pre != nil {
+			err = pre(e.cs)
+		}
+		if err == nil {
+			h, err = vfs.CommitChangeSet(l.substrate, e.cs)
+		}
 		e.reply <- applyResult{hash: h, err: err}
 		if err != nil {
 			continue
@@ -105,6 +116,12 @@ func (l *writeLog) run() {
 				"target", e.cs.Target, "action", e.cs.Action, "err", perr)
 		}
 	}
+}
+
+func (l *writeLog) SetPreApply(h func(vfs.ChangeSet) error) {
+	l.mu.Lock()
+	l.preApply = h
+	l.mu.Unlock()
 }
 
 // SetPostCommit replaces the post-commit handler run by the applier after each

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -41,6 +41,7 @@ type CmdContext interface {
 	// meta` records. The host installs these once per session; a standalone
 	// shell returns nil.
 	MetaExtenders() []meta.Extender
+	MetaFilters() []meta.Filter
 }
 
 // DocsetInfo describes one docset a session can access. It is the per-session
@@ -65,7 +66,8 @@ type DocsetInfo struct {
 	// Inbox reports whether the docset declares an inbox folder (used by the
 	// publish grant). It says nothing about the inbox path or size — that lives
 	// in PublishTarget.
-	Inbox bool
+	Inbox       bool
+	AgentSkills bool
 }
 
 // PublishTarget is a writable inbox: its logical docset name (the first path

--- a/pkg/shell/cmds/lore.go
+++ b/pkg/shell/cmds/lore.go
@@ -97,6 +97,9 @@ func cmdLoreDocsets(ctx CmdContext, args []string, w io.Writer, errW io.Writer, 
 		if d.Inbox {
 			attrs = append(attrs, "inbox")
 		}
+		if d.AgentSkills {
+			attrs = append(attrs, "agent-skills")
+		}
 		if d.AliasTarget != "" {
 			attrs = append(attrs, "alias")
 		}

--- a/pkg/shell/cmds/lore_meta.go
+++ b/pkg/shell/cmds/lore_meta.go
@@ -140,6 +140,7 @@ func runMetaFilter(ctx CmdContext, name, narrow string, pathSet bool, w, errW io
 			}
 			obj["path"] = resultPath
 			if err := enc.Encode(obj); err != nil {
+				fmt.Fprintf(errW, "lore meta: %s\n", err)
 				return 1
 			}
 		}

--- a/pkg/shell/cmds/lore_meta.go
+++ b/pkg/shell/cmds/lore_meta.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path"
 	"strings"
 
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
 // cmdLoreMeta is the `lore meta` command adapter. It is shell plumbing only: it
@@ -16,12 +18,28 @@ import (
 // `path` merged in. All the real work lives in pkg/meta.
 func cmdLoreMeta(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	root := ctx.Cwd()
-	for _, a := range args {
+	filterName := ""
+	pathSet := false
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--filter" {
+			if i+1 >= len(args) {
+				fmt.Fprintln(errW, "lore meta: --filter requires a name")
+				return 1
+			}
+			i++
+			filterName = args[i]
+			continue
+		}
 		if strings.HasPrefix(a, "-") {
 			fmt.Fprintf(errW, "lore meta: unknown flag %q\n", a)
 			return 1
 		}
 		root = ctx.Resolve(a)
+		pathSet = true
+	}
+	if filterName != "" {
+		return runMetaFilter(ctx, filterName, root, pathSet, w, errW)
 	}
 
 	records, err := meta.Scan(ctx.FS(), root, ctx.MetaExtenders()...)
@@ -43,6 +61,95 @@ func cmdLoreMeta(ctx CmdContext, args []string, w io.Writer, errW io.Writer, std
 		}
 	}
 	return 0
+}
+
+func runMetaFilter(ctx CmdContext, name, narrow string, pathSet bool, w, errW io.Writer) int {
+	var filter *meta.Filter
+	for _, f := range ctx.MetaFilters() {
+		if f.Name == name {
+			x := f
+			filter = &x
+			break
+		}
+		for _, a := range f.Aliases {
+			if a == name {
+				x := f
+				filter = &x
+				break
+			}
+		}
+		if filter != nil {
+			break
+		}
+	}
+	if filter == nil {
+		fmt.Fprintf(errW, "lore meta: unknown filter %q\n", name)
+		return 1
+	}
+	canonical := func(p string) string { return vfs.CleanPath(p) }
+	if c, ok := ctx.FS().(vfs.PathCanonicalizer); ok {
+		canonical = func(p string) string { return vfs.CleanPath(c.CanonicalPath(p)) }
+	}
+	if pathSet {
+		narrow = canonical(narrow)
+	}
+	seenRoots, seenResults := map[string]bool{}, map[string]bool{}
+	enc := json.NewEncoder(w)
+	for _, bound := range filter.Roots {
+		bound = canonical(bound)
+		scan := ""
+		if !pathSet {
+			scan = bound
+		} else if within(bound, narrow) {
+			scan = vfs.CleanPath(narrow)
+		} else if within(narrow, bound) {
+			scan = bound
+		} else {
+			continue
+		}
+		if seenRoots[scan] {
+			continue
+		}
+		seenRoots[scan] = true
+		info, err := ctx.FS().Stat(scan)
+		if err != nil {
+			fmt.Fprintf(errW, "lore meta: %s\n", err)
+			return 1
+		}
+		recs, err := meta.Scan(ctx.FS(), scan, ctx.MetaExtenders()...)
+		if err != nil {
+			fmt.Fprintf(errW, "lore meta: %s\n", err)
+			return 1
+		}
+		for _, r := range recs {
+			abs := canonical(path.Join(scan, r.Path))
+			if !info.Dir {
+				abs = canonical(scan)
+			}
+			if seenResults[abs] || !filter.Selector(abs, r) {
+				continue
+			}
+			seenResults[abs] = true
+			resultPath := r.Path
+			if filter.AbsolutePaths {
+				resultPath = abs
+			}
+			obj := make(map[string]any, len(r.Fields)+1)
+			for k, v := range r.Fields {
+				obj[k] = v
+			}
+			obj["path"] = resultPath
+			if err := enc.Encode(obj); err != nil {
+				return 1
+			}
+		}
+	}
+	return 0
+}
+
+func within(root, p string) bool {
+	root, p = vfs.CleanPath(root), vfs.CleanPath(p)
+	return root == "/" || p == root || strings.HasPrefix(p, root+"/")
 }
 
 func init() {

--- a/pkg/shell/cmds/lore_meta_test.go
+++ b/pkg/shell/cmds/lore_meta_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
+	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
 // The `lore meta` command lives here (shell plumbing); its scanning business
@@ -113,6 +114,58 @@ func TestLoreMetaCommand_AppliesSessionExtenders(t *testing.T) {
 				t.Fatalf("extender leaked onto %v", r["path"])
 			}
 		}
+	}
+}
+
+type canonicalMetaFS struct{ *mapFS }
+
+func (f canonicalMetaFS) CanonicalPath(p string) string {
+	p = vfs.CleanPath(p)
+	if p == "/alias" || strings.HasPrefix(p, "/alias/") {
+		return "/docs" + strings.TrimPrefix(p, "/alias")
+	}
+	return p
+}
+
+func TestLoreMetaFilterAliasesNarrowingAndAbsoluteCanonicalPaths(t *testing.T) {
+	fs := canonicalMetaFS{metaTreeFS()}
+	sh := shell.NewShell(fs)
+	sh.SetMetaFilters([]meta.Filter{{
+		Name:          "agent_skills",
+		Aliases:       []string{"agent_skill", "skills", "skill"},
+		Roots:         []string{"/docs"},
+		AbsolutePaths: true,
+		Selector: func(abs string, r meta.Record) bool {
+			return r.Fields["type"] == "Note"
+		},
+	}})
+	for _, alias := range []string{"agent_skills", "agent_skill", "skills", "skill"} {
+		out, errOut, code := runMeta(t, sh, "/", "lore meta --filter "+alias+" /alias/sub")
+		if code != 0 {
+			t.Fatalf("%s: exit=%d stderr=%s", alias, code, errOut)
+		}
+		recs := parseNDJSON(t, out)
+		if len(recs) != 1 || recs[0]["path"] != "/docs/sub/nested.md" {
+			t.Fatalf("%s: canonical narrowed results = %v", alias, recs)
+		}
+	}
+}
+
+func TestLoreMetaFilterExactFilePath(t *testing.T) {
+	sh := shell.NewShell(metaTreeFS())
+	sh.SetMetaFilters([]meta.Filter{{
+		Name:          "notes",
+		Roots:         []string{"/docs"},
+		AbsolutePaths: true,
+		Selector:      func(abs string, _ meta.Record) bool { return abs == "/docs/metric.md" },
+	}})
+	out, errOut, code := runMeta(t, sh, "/", "lore meta --filter notes /docs/metric.md")
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, errOut)
+	}
+	recs := parseNDJSON(t, out)
+	if len(recs) != 1 || recs[0]["path"] != "/docs/metric.md" {
+		t.Fatalf("exact-file filtered result = %v", recs)
 	}
 }
 

--- a/pkg/shell/cmds/lore_meta_test.go
+++ b/pkg/shell/cmds/lore_meta_test.go
@@ -3,6 +3,7 @@ package cmds_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -166,6 +167,28 @@ func TestLoreMetaFilterExactFilePath(t *testing.T) {
 	recs := parseNDJSON(t, out)
 	if len(recs) != 1 || recs[0]["path"] != "/docs/metric.md" {
 		t.Fatalf("exact-file filtered result = %v", recs)
+	}
+}
+
+type errorWriter struct{ err error }
+
+func (w errorWriter) Write([]byte) (int, error) { return 0, w.err }
+
+func TestLoreMetaFilterReportsEncodingFailure(t *testing.T) {
+	sh := shell.NewShell(metaTreeFS())
+	sh.SetMetaFilters([]meta.Filter{{
+		Name:     "all",
+		Roots:    []string{"/docs"},
+		Selector: func(string, meta.Record) bool { return true },
+	}})
+	var errOut bytes.Buffer
+	writeErr := errors.New("output unavailable")
+	code := sh.ExecPipeline("lore meta --filter all", errorWriter{err: writeErr}, &errOut, nil)
+	if code != 1 {
+		t.Fatalf("exit=%d, want 1", code)
+	}
+	if !strings.Contains(errOut.String(), writeErr.Error()) {
+		t.Fatalf("stderr missing encoding error: %q", errOut.String())
 	}
 }
 

--- a/pkg/shell/cmds/lore_test.go
+++ b/pkg/shell/cmds/lore_test.go
@@ -46,7 +46,7 @@ func TestLoreDocsets_Table(t *testing.T) {
 	docsets := []cmds.DocsetInfo{
 		{Name: "public", Paths: []string{"/docs/public"}, Grant: "ro"},
 		{Name: "public", Paths: []string{"/public"}, AliasTarget: "/docs/public", Grant: "ro"},
-		{Name: "backend", Paths: []string{"/docs/backend", "/docs/api"}, Grant: "rw", Writable: true},
+		{Name: "backend", Paths: []string{"/docs/backend", "/docs/api"}, Grant: "rw", Writable: true, AgentSkills: true},
 		{Name: "home", Paths: []string{"/home/backend"}, Grant: "rw", Writable: true, Home: true, Inbox: true},
 	}
 	out, _, code := runLore(t, docsets, "lore docsets")
@@ -70,7 +70,7 @@ func TestLoreDocsets_Table(t *testing.T) {
 	}
 	assertRow(lines[1], "public", "ro", "-", "/docs/public", "-")
 	assertRow(lines[2], "public", "ro", "alias", "/public", "/docs/public")
-	assertRow(lines[3], "backend", "rw", "-", "/docs/backend,/docs/api", "-")
+	assertRow(lines[3], "backend", "rw", "agent-skills", "/docs/backend,/docs/api", "-")
 	assertRow(lines[4], "home", "rw", "home,inbox", "/home/backend", "-")
 }
 

--- a/pkg/shell/cmds/spawn.go
+++ b/pkg/shell/cmds/spawn.go
@@ -158,5 +158,6 @@ func (c *frozenContext) WriteConflictPolicy(string) vfs.WriteConflictPolicy {
 func (c *frozenContext) Docsets() []DocsetInfo           { return nil }
 func (c *frozenContext) PublishTargets() []PublishTarget { return nil }
 func (c *frozenContext) MetaExtenders() []meta.Extender  { return nil }
+func (c *frozenContext) MetaFilters() []meta.Filter      { return nil }
 
 var _ CmdContext = (*frozenContext)(nil)

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -37,6 +37,7 @@ type Shell struct {
 	// metaExtenders are the plugin-contributed extenders applied by `lore meta`,
 	// installed by the host per session. nil for a standalone shell.
 	metaExtenders []meta.Extender
+	metaFilters   []meta.Filter
 }
 
 // NewShell creates a new Shell backed by the given vfs.FileSystem.
@@ -102,6 +103,8 @@ func (s *Shell) SetMetaExtenders(e []meta.Extender) { s.metaExtenders = e }
 // MetaExtenders reports the per-session `lore meta` extenders. Implements
 // CmdContext.
 func (s *Shell) MetaExtenders() []meta.Extender { return s.metaExtenders }
+func (s *Shell) SetMetaFilters(f []meta.Filter) { s.metaFilters = f }
+func (s *Shell) MetaFilters() []meta.Filter     { return s.metaFilters }
 
 // --- CmdContext interface implementation ---
 


### PR DESCRIPTION
## Summary

- add an opt-in `agent_skills` docset plugin following the Agent Skills specification
- validate whole skills on writes/removals at admission and serialized commit time
- expose skills through `lore docsets` attributes and plugin-provided `lore meta --filter` discovery
- support canonical filters `agent_skills`, `agent_skill`, `skills`, and `skill`
- preserve the existing runtime `skills.json` shell-command system

## Configuration

```json
{
  "docsets": {
    "skills": {
      "paths": ["/skills"],
      "agent_skills": true
    }
  }
}
```

Use `metadata.agent_skill: disable` in a parseable `SKILL.md` to opt a directory out of validation and discovery.

## Notable API change

`Server.RegisterPlugin` now returns an error so metadata-filter name and alias collisions fail deterministically.

## Validation

- `git diff --check`
- `go test ./...`
