### PR TITLE
feat(okf): add lore validate bundle linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,15 +389,15 @@ registration. A plugin implements one or more provider interfaces:
 | `ReadMiddlewareProvider` | before-read middleware |
 | `PostCommitProvider` | post-commit middleware |
 | `GrantTypeProvider` | named grant types (e.g. `publish`) |
-| `CommandProvider` | `lore` subcommands (`LoreCommands() []cmds.LoreSub`) |
+| `ValidatorProvider` | checks run by the core `lore validate` command |
 | `MetaExtenderProvider` | fields added to `lore meta` records |
 | `PluginInfoProvider` | plugin name + version (`Info() PluginInfo`), logged at boot |
 
 Built-in plugins (`shellexec`, `inbox`, `okf`) are wired from config; consumers
 add their own via `Server.RegisterPlugin`. A plugin can extend the introspection
-surface without the `lore` dispatcher knowing about it: `CommandProvider` adds
-whole subcommands, and `MetaExtenderProvider` enriches an existing command's
-output (the okf plugin uses it to annotate `lore meta` — see below).
+surface without owning commands: `ValidatorProvider` extends the core-owned
+`lore validate` command, and `MetaExtenderProvider` enriches the core-owned
+`lore meta` command (the okf plugin provides both — see below).
 
 Every built-in plugin reports a name and semantic version via
 `PluginInfoProvider`, recorded in the server's boot logs as it registers, so it
@@ -465,9 +465,10 @@ if err := okf.Validate(path, content); err != nil {
 
 ### `lore validate` — bundle linter
 
-When the OKF plugin is enabled, `lore validate [bundle]` scans the bundle
-directory (the current directory by default) and prints every finding in a
-grep-friendly format:
+`lore validate [bundle]` is a core command. It scans the bundle directory (the
+current directory by default), runs validators contributed by enabled plugins,
+and prints every finding in a grep-friendly format. The built-in OKF plugin
+contributes the initial validator:
 
 ```text
 tables/orders.md:1:1: error [okf/concept] frontmatter is missing the required non-empty 'type' field

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ OpenLore is built on [Wish](https://github.com/charmbracelet/wish) from Charmbra
 | `lore` | Introspection dispatcher (run `lore` for subcommands) |
 | `lore docsets` | List the docsets you can access, their grants, paths, and attributes |
 | `lore meta` | Emit each document's frontmatter as NDJSON, cwd-scoped (see [Plugins](#plugins)) |
+| `lore validate [bundle]` | Lint an OKF bundle, local links, and aliased-path portability |
 
 `lore docsets` prints an aligned, greppable table:
 
@@ -414,10 +415,10 @@ The `okf` version tracks the OKF spec revision it validates (OKF v0.1).
 
 The built-in **Open Knowledge Format** plugin validates knowledge documents on
 write against [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md).
-OKF is a directory of markdown files with YAML frontmatter; a document is
+OKF is a directory of markdown files with YAML frontmatter; a bundle is
 conformant when every non-reserved `.md` file opens with a parseable frontmatter
-block containing a non-empty `type` field. Reserved files (`index.md`,
-`log.md`) are validated leniently.
+block containing a non-empty `type` field and reserved files (`index.md`,
+`log.md`) follow their OKF structure.
 
 Enable it **per docset** in `lore.json` by adding an `okf` block to a docset —
 so OKF scoping reads the same display roots as the docset's paths and grants and
@@ -461,6 +462,33 @@ if err := okf.Validate(path, content); err != nil {
     // not OKF-conformant
 }
 ```
+
+### `lore validate` — bundle linter
+
+When the OKF plugin is enabled, `lore validate [bundle]` scans the bundle
+directory (the current directory by default) and prints every finding in a
+grep-friendly format:
+
+```text
+tables/orders.md:1:1: error [okf/concept] frontmatter is missing the required non-empty 'type' field
+metrics/revenue.md:12:19: error [openlore/broken-link] local link "../tables/missing.md" does not resolve
+metrics/revenue.md:15:8: warning [openlore/alias-target] link targets aliased docset path /wiki; it may resolve differently on another machine
+2 errors, 1 warning
+```
+
+The checks are deliberately separated:
+
+- `okf/*` errors are mandatory OKF v0.1 bundle-conformance rules and are
+  implemented by `pkg/okf.ValidateBundle`.
+- `openlore/broken-link` and `openlore/link-outside-bundle` are OpenLore
+  operational errors. OKF itself requires consumers to tolerate broken links.
+- `openlore/alias-referrer` and `openlore/alias-target` are portability
+  warnings. A docset alias can resolve under a different checkout path on
+  another machine, so links should use the canonical docset path instead.
+
+Only bundle-local Markdown links are resolved. URL links are left to their
+protocol-specific tooling rather than fetched by the server. The command exits
+non-zero when it finds errors; warnings alone do not fail validation.
 
 ### `lore meta` — frontmatter reader
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/pkg/sftp v1.13.10
+	github.com/yuin/goldmark v1.8.4
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
+github.com/yuin/goldmark v1.8.4/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=

--- a/pkg/okf/bundle.go
+++ b/pkg/okf/bundle.go
@@ -1,0 +1,280 @@
+package okf
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// Severity is the impact of a validation diagnostic.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Diagnostic is one linter-style validation finding.
+type Diagnostic struct {
+	Path     string
+	Line     int
+	Column   int
+	Severity Severity
+	Rule     string
+	Message  string
+}
+
+// File is one file in a knowledge bundle. Path is relative to the bundle root.
+type File struct {
+	Path    string
+	Content []byte
+}
+
+// Link is a standard Markdown link found in an OKF document.
+type Link struct {
+	Destination string
+	Line        int
+	Column      int
+}
+
+// ValidateBundle checks the mandatory OKF v0.1 conformance rules for every
+// Markdown file in a bundle. It intentionally does not reject broken links:
+// OKF §5.3 requires consumers to tolerate them. OpenLore checks link
+// resolvability separately as an operational requirement.
+func ValidateBundle(files []File) []Diagnostic {
+	var diagnostics []Diagnostic
+	for _, file := range files {
+		name := strings.TrimPrefix(path.Clean("/"+file.Path), "/")
+		if path.Ext(name) != ".md" {
+			continue
+		}
+
+		if !IsReserved(name) {
+			if err := Validate(name, file.Content); err != nil {
+				diagnostics = append(diagnostics, diagnostic(name, 1, "okf/concept", err.Error()))
+			}
+			continue
+		}
+
+		switch path.Base(name) {
+		case IndexFile:
+			diagnostics = append(diagnostics, validateIndex(name, file.Content)...)
+		case LogFile:
+			diagnostics = append(diagnostics, validateLog(name, file.Content)...)
+		}
+	}
+	sortDiagnostics(diagnostics)
+	return diagnostics
+}
+
+func validateIndex(name string, content []byte) []Diagnostic {
+	if !utf8Valid(content) {
+		return []Diagnostic{diagnostic(name, 1, "okf/utf8", "file is not valid UTF-8")}
+	}
+	meta, body, hasFM, err := ParseFrontmatter(content)
+	if err != nil {
+		return []Diagnostic{diagnostic(name, 1, "okf/frontmatter", err.Error())}
+	}
+	if !hasFM && hasOpeningDelimiter(content) {
+		return []Diagnostic{diagnostic(name, 1, "okf/frontmatter", "YAML frontmatter block has no closing '---' delimiter")}
+	}
+	var diagnostics []Diagnostic
+	if hasFM {
+		if name != IndexFile {
+			diagnostics = append(diagnostics, diagnostic(name, 1, "okf/index-frontmatter", "frontmatter is permitted only in the bundle-root index.md"))
+		} else {
+			version, ok := meta["okf_version"].(string)
+			if !ok || strings.TrimSpace(version) == "" {
+				diagnostics = append(diagnostics, diagnostic(name, 1, "okf/index-frontmatter", "bundle-root index.md frontmatter must declare a non-empty 'okf_version'"))
+			}
+		}
+	} else {
+		body = content
+	}
+	if len(markdownHeadings(body)) == 0 {
+		diagnostics = append(diagnostics, diagnostic(name, firstContentLine(content), "okf/index-structure", "index.md must contain at least one Markdown section heading"))
+	}
+	return diagnostics
+}
+
+func validateLog(name string, content []byte) []Diagnostic {
+	if !utf8Valid(content) {
+		return []Diagnostic{diagnostic(name, 1, "okf/utf8", "file is not valid UTF-8")}
+	}
+	_, body, hasFM, err := ParseFrontmatter(content)
+	if err != nil {
+		return []Diagnostic{diagnostic(name, 1, "okf/frontmatter", err.Error())}
+	}
+	if !hasFM && hasOpeningDelimiter(content) {
+		return []Diagnostic{diagnostic(name, 1, "okf/frontmatter", "YAML frontmatter block has no closing '---' delimiter")}
+	}
+
+	var diagnostics []Diagnostic
+	if hasFM {
+		diagnostics = append(diagnostics, diagnostic(name, 1, "okf/log-frontmatter", "log.md must not contain YAML frontmatter"))
+	} else {
+		body = content
+	}
+	var previous time.Time
+	groupHeadings := 0
+	for _, heading := range markdownHeadings(body) {
+		if heading.Level != 2 {
+			continue
+		}
+		groupHeadings++
+		date := strings.TrimSpace(heading.Text)
+		parsed, err := time.Parse("2006-01-02", date)
+		if err != nil || parsed.Format("2006-01-02") != date {
+			diagnostics = append(diagnostics, diagnostic(name, heading.Line, "okf/log-date", "log.md date headings must use ISO 8601 YYYY-MM-DD form"))
+			continue
+		}
+		if !previous.IsZero() && parsed.After(previous) {
+			diagnostics = append(diagnostics, diagnostic(name, heading.Line, "okf/log-order", "log.md date groups must be newest first"))
+		}
+		previous = parsed
+	}
+	if groupHeadings == 0 {
+		diagnostics = append(diagnostics, diagnostic(name, firstContentLine(content), "okf/log-structure", "log.md must contain at least one ISO 8601 date group"))
+	}
+	return diagnostics
+}
+
+// Links returns standard Markdown links from a document body. Frontmatter,
+// images, code spans, and code blocks are excluded by the CommonMark parser.
+// Destinations with URL schemes are included so callers can decide which
+// schemes they know how to check.
+func Links(content []byte) []Link {
+	_, body, hasFM, err := ParseFrontmatter(content)
+	lineOffset := 0
+	if err != nil || !hasFM {
+		body = content
+	} else {
+		lineOffset = bytes.Count(content[:len(content)-len(body)], []byte("\n"))
+	}
+	doc := goldmark.DefaultParser().Parse(text.NewReader(body))
+	var links []Link
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		link, ok := node.(*ast.Link)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		offset := nodeOffset(link)
+		line, column := lineColumn(body, offset)
+		links = append(links, Link{Destination: string(link.Destination), Line: line + lineOffset, Column: column})
+		return ast.WalkContinue, nil
+	})
+	return links
+}
+
+// LocalLinkPath returns the path component of a link that should resolve
+// inside a bundle. External URLs, anchors, and empty destinations return false.
+func LocalLinkPath(destination string) (string, bool) {
+	destination = strings.TrimSpace(destination)
+	if destination == "" || strings.HasPrefix(destination, "#") {
+		return "", false
+	}
+	u, err := url.Parse(destination)
+	if err != nil || u.Scheme != "" || u.Host != "" || strings.HasPrefix(destination, "//") {
+		return "", false
+	}
+	p, err := url.PathUnescape(u.Path)
+	if err != nil || p == "" {
+		return "", false
+	}
+	return p, true
+}
+
+func diagnostic(name string, line int, rule, message string) Diagnostic {
+	return Diagnostic{Path: name, Line: line, Column: 1, Severity: SeverityError, Rule: rule, Message: message}
+}
+
+func sortDiagnostics(diagnostics []Diagnostic) {
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Path != diagnostics[j].Path {
+			return diagnostics[i].Path < diagnostics[j].Path
+		}
+		if diagnostics[i].Line != diagnostics[j].Line {
+			return diagnostics[i].Line < diagnostics[j].Line
+		}
+		return diagnostics[i].Column < diagnostics[j].Column
+	})
+}
+
+func hasOpeningDelimiter(content []byte) bool {
+	_, ok := trimOpeningDelim(content)
+	return ok
+}
+
+func utf8Valid(content []byte) bool {
+	return utf8.Valid(content)
+}
+
+type markdownHeading struct {
+	Level int
+	Text  string
+	Line  int
+}
+
+func markdownHeadings(content []byte) []markdownHeading {
+	doc := goldmark.DefaultParser().Parse(text.NewReader(content))
+	var headings []markdownHeading
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		heading, ok := node.(*ast.Heading)
+		if !entering || !ok {
+			return ast.WalkContinue, nil
+		}
+		offset := nodeOffset(heading)
+		line, _ := lineColumn(content, offset)
+		headings = append(headings, markdownHeading{Level: heading.Level, Text: string(heading.Text(content)), Line: line})
+		return ast.WalkContinue, nil
+	})
+	return headings
+}
+
+func nodeOffset(node ast.Node) int {
+	if node.Type() == ast.TypeBlock {
+		if lines := node.Lines(); lines != nil && lines.Len() > 0 {
+			return lines.At(0).Start
+		}
+	}
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		if textNode, ok := child.(*ast.Text); ok {
+			return textNode.Segment.Start
+		}
+	}
+	return 0
+}
+
+func lineColumn(source []byte, offset int) (line, column int) {
+	if offset < 0 || offset > len(source) {
+		offset = 0
+	}
+	line = bytes.Count(source[:offset], []byte("\n")) + 1
+	lastNewline := bytes.LastIndexByte(source[:offset], '\n')
+	return line, offset - lastNewline
+}
+
+func firstContentLine(content []byte) int {
+	_, body, ok := SplitFrontmatter(content)
+	if !ok {
+		return 1
+	}
+	return bytes.Count(content[:len(content)-len(body)], []byte("\n")) + 1
+}
+
+// FormatDiagnostic renders a diagnostic in a grep-friendly compiler format.
+func FormatDiagnostic(d Diagnostic) string {
+	return fmt.Sprintf("%s:%d:%d: %s [%s] %s", d.Path, d.Line, d.Column, d.Severity, d.Rule, d.Message)
+}

--- a/pkg/okf/bundle_test.go
+++ b/pkg/okf/bundle_test.go
@@ -1,0 +1,102 @@
+package okf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateBundle_ReportsEveryMandatoryError(t *testing.T) {
+	files := []File{
+		{Path: "bad.md", Content: []byte("# missing frontmatter\n")},
+		{Path: "nested/index.md", Content: []byte("---\ntype: Index\n---\n# Nested\n")},
+		{Path: "log.md", Content: []byte("# Updates\n\n## July 14\n- changed\n")},
+		{Path: "good.md", Content: []byte("---\ntype: Note\n---\n[missing](nope.md)\n")},
+	}
+
+	got := ValidateBundle(files)
+	if len(got) != 3 {
+		t.Fatalf("got %d diagnostics, want 3: %+v", len(got), got)
+	}
+	wantRules := []string{"okf/concept", "okf/log-date", "okf/index-frontmatter"}
+	for _, rule := range wantRules {
+		found := false
+		for _, diagnostic := range got {
+			if diagnostic.Rule == rule {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing rule %q in %+v", rule, got)
+		}
+	}
+	for _, diagnostic := range got {
+		if strings.Contains(diagnostic.Message, "nope.md") {
+			t.Fatalf("broken links are not OKF conformance errors: %+v", diagnostic)
+		}
+	}
+}
+
+func TestValidateBundle_RootIndexVersionIsValid(t *testing.T) {
+	files := []File{{Path: "index.md", Content: []byte("---\nokf_version: \"0.1\"\n---\n# Contents\n")}}
+	if got := ValidateBundle(files); len(got) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", got)
+	}
+}
+
+func TestValidateBundle_ReservedStructure(t *testing.T) {
+	t.Run("index accepts any markdown heading level", func(t *testing.T) {
+		files := []File{{Path: "index.md", Content: []byte("## Tables\n\n- [Orders](orders.md)\n")}}
+		if got := ValidateBundle(files); len(got) != 0 {
+			t.Fatalf("unexpected diagnostics: %+v", got)
+		}
+	})
+	t.Run("empty index fails", func(t *testing.T) {
+		if got := ValidateBundle([]File{{Path: "index.md"}}); len(got) != 1 || got[0].Rule != "okf/index-structure" {
+			t.Fatalf("diagnostics = %+v", got)
+		}
+	})
+	t.Run("log dates must be newest first", func(t *testing.T) {
+		content := []byte("# Updates\n\n## 2026-01-01\n- old\n\n## 2026-02-01\n- new\n")
+		got := ValidateBundle([]File{{Path: "log.md", Content: content}})
+		if len(got) != 1 || got[0].Rule != "okf/log-order" {
+			t.Fatalf("diagnostics = %+v", got)
+		}
+	})
+}
+
+func TestLinks_FindsLocalLinksOutsideCodeFences(t *testing.T) {
+	content := []byte("[relative](../tables/orders.md#schema) and [absolute](/index.md)\n```md\n[example](missing.md)\n```\n[web](https://example.com)\n")
+	links := Links(content)
+	if len(links) != 3 {
+		t.Fatalf("got %d links, want 3: %+v", len(links), links)
+	}
+	if got, ok := LocalLinkPath(links[0].Destination); !ok || got != "../tables/orders.md" {
+		t.Fatalf("first local link = %q, %v", got, ok)
+	}
+	if _, ok := LocalLinkPath(links[2].Destination); ok {
+		t.Fatal("external URL must not be treated as a bundle-local path")
+	}
+}
+
+func TestLinks_UsesCommonMarkAndOnlyDocumentBodyLinks(t *testing.T) {
+	content := []byte(`---
+type: Note
+description: "[not a body link](frontmatter.md)"
+---
+` + "`[inline code](code.md)` ![image](image.png)\n" + `
+[balanced](a_(old).md)
+[reference][target]
+
+[target]: referenced.md
+`)
+	links := Links(content)
+	if len(links) != 2 {
+		t.Fatalf("got %d links, want 2: %+v", len(links), links)
+	}
+	if links[0].Destination != "a_(old).md" || links[1].Destination != "referenced.md" {
+		t.Fatalf("destinations = %+v", links)
+	}
+	if links[0].Line != 7 {
+		t.Fatalf("balanced link line = %d, want 7", links[0].Line)
+	}
+}

--- a/pkg/okf/okf.go
+++ b/pkg/okf/okf.go
@@ -84,6 +84,9 @@ func validateConcept(content []byte) error {
 func validateReserved(content []byte) error {
 	fm, _, ok := SplitFrontmatter(content)
 	if !ok {
+		if _, hasOpen := trimOpeningDelim(content); hasOpen {
+			return fmt.Errorf("YAML frontmatter block has no closing '---' delimiter")
+		}
 		return nil
 	}
 	_, err := parseFrontmatter(fm)

--- a/pkg/okf/okf_test.go
+++ b/pkg/okf/okf_test.go
@@ -91,8 +91,8 @@ no closing delimiter
 			wantErr: true,
 		},
 		{
-			name: "crlf line endings",
-			path: "tables/orders.md",
+			name:    "crlf line endings",
+			path:    "tables/orders.md",
 			content: "---\r\ntype: BigQuery Table\r\n---\r\nbody\r\n",
 			wantErr: false,
 		},
@@ -181,6 +181,12 @@ func TestValidate_NonUTF8(t *testing.T) {
 	content := []byte{'-', '-', '-', '\n', 't', 'y', 'p', 'e', ':', ' ', 0xff, 0xfe, '\n', '-', '-', '-', '\n'}
 	if err := Validate("x.md", content); err == nil {
 		t.Fatal("expected error for non-UTF-8 content")
+	}
+}
+
+func TestValidate_ReservedFileWithUnclosedFrontmatter(t *testing.T) {
+	if err := Validate("index.md", []byte("---\nokf_version: 0.1\n")); err == nil {
+		t.Fatal("expected unclosed reserved-file frontmatter to fail")
 	}
 }
 

--- a/pkg/openlore/commands.go
+++ b/pkg/openlore/commands.go
@@ -6,10 +6,10 @@ import (
 )
 
 // CommandProvider is implemented by a plugin that contributes `lore`
-// subcommands. registerPlugin detects it and registers each returned command
-// with the lore dispatcher (cmds.RegisterLoreSub), so a plugin can extend the
-// `lore` introspection surface without the dispatcher knowing about it. Core
-// subcommands (docsets, meta) register themselves the same way.
+// subcommands. registerPlugin detects it and installs each returned command on
+// shells created by that server, so a plugin can extend the `lore`
+// introspection surface without leaking state across servers. Core subcommands
+// (docsets, meta) use the package registry.
 type CommandProvider interface {
 	LoreCommands() []cmds.LoreSub
 }

--- a/pkg/openlore/commands.go
+++ b/pkg/openlore/commands.go
@@ -2,17 +2,8 @@ package openlore
 
 import (
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
-	"github.com/aakarim/go-openlore/pkg/shell/cmds"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 )
-
-// CommandProvider is implemented by a plugin that contributes `lore`
-// subcommands. registerPlugin detects it and installs each returned command on
-// shells created by that server, so a plugin can extend the `lore`
-// introspection surface without leaking state across servers. Core subcommands
-// (docsets, meta) use the package registry.
-type CommandProvider interface {
-	LoreCommands() []cmds.LoreSub
-}
 
 // MetaExtenderProvider is implemented by a plugin that enriches `lore meta`
 // records. registerPlugin detects it and collects each extender onto the server,
@@ -25,3 +16,8 @@ type MetaExtenderProvider interface {
 }
 
 type MetaFilterProvider interface{ MetaFilters() []meta.Filter }
+
+// ValidatorProvider is implemented by a plugin that contributes checks to the
+// core `lore validate` command. registerPlugin collects validators onto the
+// server, which installs them per session in buildSessionShell.
+type ValidatorProvider interface{ Validators() []validation.Validator }

--- a/pkg/openlore/okf_plugin.go
+++ b/pkg/openlore/okf_plugin.go
@@ -3,12 +3,16 @@ package openlore
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"path"
+	"sort"
+	"strings"
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/okf"
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -152,6 +156,177 @@ func (p *okfPlugin) MetaExtenders() []meta.Extender {
 	}
 }
 
+// LoreCommands implements CommandProvider. Validation is read-only and runs on
+// the session filesystem, so it cannot inspect documents outside the caller's
+// grants. OKF conformance comes from pkg/okf; link and alias checks are
+// OpenLore operational diagnostics layered on top.
+func (p *okfPlugin) LoreCommands() []cmds.LoreSub {
+	return []cmds.LoreSub{{
+		Name:    "validate",
+		Summary: "Lint an OKF bundle, its local links, and path portability",
+		Run:     runValidate,
+	}}
+}
+
+func runValidate(ctx cmds.CmdContext, args []string, w io.Writer, errW io.Writer, _ io.Reader) int {
+	root := ctx.Cwd()
+	if len(args) > 1 {
+		fmt.Fprintln(errW, "Usage: lore validate [bundle]")
+		return 1
+	}
+	if len(args) == 1 {
+		if strings.HasPrefix(args[0], "-") {
+			fmt.Fprintf(errW, "lore validate: unknown flag %q\n", args[0])
+			return 1
+		}
+		root = ctx.Resolve(args[0])
+	}
+	root = vfs.CleanPath(root)
+	info, err := ctx.FS().Stat(root)
+	if err != nil {
+		fmt.Fprintf(errW, "lore validate: %s\n", err)
+		return 1
+	}
+	if !info.Dir {
+		fmt.Fprintf(errW, "lore validate: %s is not a bundle directory\n", root)
+		return 1
+	}
+
+	type scannedFile struct {
+		absolute string
+		relative string
+		content  []byte
+	}
+	var scanned []scannedFile
+	err = vfs.WalkDir(ctx.FS(), root, func(filePath string, info *vfs.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info == nil || info.Dir || path.Ext(info.FileName) != ".md" {
+			return nil
+		}
+		content, err := ctx.FS().ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		scanned = append(scanned, scannedFile{
+			absolute: vfs.CleanPath(filePath),
+			relative: relativeBundlePath(root, filePath),
+			content:  content,
+		})
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(errW, "lore validate: %s\n", err)
+		return 1
+	}
+
+	files := make([]okf.File, 0, len(scanned))
+	for _, file := range scanned {
+		files = append(files, okf.File{Path: file.relative, Content: file.content})
+	}
+	diagnostics := okf.ValidateBundle(files)
+	aliasRoots := accessibleAliasRoots(ctx.Docsets())
+	for _, file := range scanned {
+		for _, link := range okf.Links(file.content) {
+			local, ok := okf.LocalLinkPath(link.Destination)
+			if !ok {
+				continue
+			}
+			target := path.Join(path.Dir(file.absolute), local)
+			if strings.HasPrefix(local, "/") {
+				target = path.Join(root, strings.TrimPrefix(local, "/"))
+			}
+			target = vfs.CleanPath(target)
+			if !pathWithinRoot(root, target) {
+				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityError,
+					"openlore/link-outside-bundle", fmt.Sprintf("local link %q resolves outside the bundle", link.Destination)))
+			} else if _, err := ctx.FS().Stat(target); err != nil {
+				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityError,
+					"openlore/broken-link", fmt.Sprintf("local link %q does not resolve", link.Destination)))
+			}
+			if aliasRoot(file.absolute, aliasRoots) != "" {
+				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityWarning,
+					"openlore/alias-referrer", "link originates from an aliased docset path; use a stable checkout path"))
+			}
+			if alias := aliasRoot(target, aliasRoots); alias != "" {
+				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityWarning,
+					"openlore/alias-target", fmt.Sprintf("link targets aliased docset path %s; it may resolve differently on another machine", alias)))
+			}
+		}
+	}
+
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Path != diagnostics[j].Path {
+			return diagnostics[i].Path < diagnostics[j].Path
+		}
+		if diagnostics[i].Line != diagnostics[j].Line {
+			return diagnostics[i].Line < diagnostics[j].Line
+		}
+		if diagnostics[i].Column != diagnostics[j].Column {
+			return diagnostics[i].Column < diagnostics[j].Column
+		}
+		return diagnostics[i].Rule < diagnostics[j].Rule
+	})
+	errors, warnings := 0, 0
+	for _, diagnostic := range diagnostics {
+		fmt.Fprintln(w, okf.FormatDiagnostic(diagnostic))
+		if diagnostic.Severity == okf.SeverityError {
+			errors++
+		} else {
+			warnings++
+		}
+	}
+	fmt.Fprintf(w, "%d %s, %d %s\n", errors, countLabel(errors, "error"), warnings, countLabel(warnings, "warning"))
+	if errors > 0 {
+		return 1
+	}
+	return 0
+}
+
+func countLabel(count int, singular string) string {
+	if count == 1 {
+		return singular
+	}
+	return singular + "s"
+}
+
+func accessibleAliasRoots(docsets []cmds.DocsetInfo) []string {
+	var roots []string
+	for _, docset := range docsets {
+		if docset.AliasTarget != "" {
+			roots = append(roots, docset.Paths...)
+		}
+	}
+	sort.Slice(roots, func(i, j int) bool { return len(roots[i]) > len(roots[j]) })
+	return roots
+}
+
+func relativeBundlePath(root, filePath string) string {
+	root = vfs.CleanPath(root)
+	filePath = vfs.CleanPath(filePath)
+	if root == "/" {
+		return strings.TrimPrefix(filePath, "/")
+	}
+	return strings.TrimPrefix(filePath, root+"/")
+}
+
+func aliasRoot(filePath string, roots []string) string {
+	for _, root := range roots {
+		if pathWithinRoot(root, filePath) {
+			return root
+		}
+	}
+	return ""
+}
+
+func openLoreDiagnostic(filePath string, link okf.Link, severity okf.Severity, rule, message string) okf.Diagnostic {
+	return okf.Diagnostic{
+		Path: filePath, Line: link.Line, Column: link.Column,
+		Severity: severity, Rule: rule, Message: message,
+	}
+}
+
 // Info implements PluginInfoProvider. The version tracks the OKF spec revision
 // the validator targets (OKF v0.1).
 func (p *okfPlugin) Info() PluginInfo {
@@ -161,5 +336,6 @@ func (p *okfPlugin) Info() PluginInfo {
 var (
 	_ WriteMiddlewareProvider = (*okfPlugin)(nil)
 	_ MetaExtenderProvider    = (*okfPlugin)(nil)
+	_ CommandProvider         = (*okfPlugin)(nil)
 	_ PluginInfoProvider      = (*okfPlugin)(nil)
 )

--- a/pkg/openlore/okf_plugin.go
+++ b/pkg/openlore/okf_plugin.go
@@ -3,7 +3,6 @@ package openlore
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"path"
 	"sort"
@@ -12,7 +11,7 @@ import (
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/okf"
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
-	"github.com/aakarim/go-openlore/pkg/shell/cmds"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -156,159 +155,63 @@ func (p *okfPlugin) MetaExtenders() []meta.Extender {
 	}
 }
 
-// LoreCommands implements CommandProvider. Validation is read-only and runs on
-// the session filesystem, so it cannot inspect documents outside the caller's
-// grants. OKF conformance comes from pkg/okf; link and alias checks are
-// OpenLore operational diagnostics layered on top.
-func (p *okfPlugin) LoreCommands() []cmds.LoreSub {
-	return []cmds.LoreSub{{
-		Name:    "validate",
-		Summary: "Lint an OKF bundle, its local links, and path portability",
-		Run:     runValidate,
+// Validators implements ValidatorProvider. The command and filesystem scan are
+// owned by core; the plugin contributes OKF conformance plus OpenLore's
+// operational link and alias-portability checks.
+func (p *okfPlugin) Validators() []validation.Validator {
+	aliasRoots := p.aliasRoots()
+	return []validation.Validator{func(bundle validation.Bundle) []validation.Diagnostic {
+		files := make([]okf.File, 0, len(bundle.Files))
+		for _, file := range bundle.Files {
+			files = append(files, okf.File{Path: file.Path, Content: file.Content})
+		}
+		okfDiagnostics := okf.ValidateBundle(files)
+		diagnostics := make([]validation.Diagnostic, 0, len(okfDiagnostics))
+		for _, diagnostic := range okfDiagnostics {
+			diagnostics = append(diagnostics, fromOKFDiagnostic(diagnostic))
+		}
+		for _, file := range bundle.Files {
+			if path.Ext(file.Path) != ".md" {
+				continue
+			}
+			for _, link := range okf.Links(file.Content) {
+				local, ok := okf.LocalLinkPath(link.Destination)
+				if !ok {
+					continue
+				}
+				target := path.Join(path.Dir(file.AbsolutePath), local)
+				if strings.HasPrefix(local, "/") {
+					target = path.Join(bundle.Root, strings.TrimPrefix(local, "/"))
+				}
+				target = vfs.CleanPath(target)
+				if !pathWithinRoot(bundle.Root, target) {
+					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityError,
+						"openlore/link-outside-bundle", fmt.Sprintf("local link %q resolves outside the bundle", link.Destination)))
+				} else if _, err := bundle.FS.Stat(target); err != nil {
+					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityError,
+						"openlore/broken-link", fmt.Sprintf("local link %q does not resolve", link.Destination)))
+				}
+				if aliasRoot(file.AbsolutePath, aliasRoots) != "" {
+					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityWarning,
+						"openlore/alias-referrer", "link originates from an aliased docset path; use a stable checkout path"))
+				}
+				if alias := aliasRoot(target, aliasRoots); alias != "" {
+					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityWarning,
+						"openlore/alias-target", fmt.Sprintf("link targets aliased docset path %s; it may resolve differently on another machine", alias)))
+				}
+			}
+		}
+		return diagnostics
 	}}
 }
 
-func runValidate(ctx cmds.CmdContext, args []string, w io.Writer, errW io.Writer, _ io.Reader) int {
-	root := ctx.Cwd()
-	if len(args) > 1 {
-		fmt.Fprintln(errW, "Usage: lore validate [bundle]")
-		return 1
-	}
-	if len(args) == 1 {
-		if strings.HasPrefix(args[0], "-") {
-			fmt.Fprintf(errW, "lore validate: unknown flag %q\n", args[0])
-			return 1
-		}
-		root = ctx.Resolve(args[0])
-	}
-	root = vfs.CleanPath(root)
-	info, err := ctx.FS().Stat(root)
-	if err != nil {
-		fmt.Fprintf(errW, "lore validate: %s\n", err)
-		return 1
-	}
-	if !info.Dir {
-		fmt.Fprintf(errW, "lore validate: %s is not a bundle directory\n", root)
-		return 1
-	}
-
-	type scannedFile struct {
-		absolute string
-		relative string
-		content  []byte
-	}
-	var scanned []scannedFile
-	err = vfs.WalkDir(ctx.FS(), root, func(filePath string, info *vfs.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if info == nil || info.Dir || path.Ext(info.FileName) != ".md" {
-			return nil
-		}
-		content, err := ctx.FS().ReadFile(filePath)
-		if err != nil {
-			return err
-		}
-		scanned = append(scanned, scannedFile{
-			absolute: vfs.CleanPath(filePath),
-			relative: relativeBundlePath(root, filePath),
-			content:  content,
-		})
-		return nil
-	})
-	if err != nil {
-		fmt.Fprintf(errW, "lore validate: %s\n", err)
-		return 1
-	}
-
-	files := make([]okf.File, 0, len(scanned))
-	for _, file := range scanned {
-		files = append(files, okf.File{Path: file.relative, Content: file.content})
-	}
-	diagnostics := okf.ValidateBundle(files)
-	aliasRoots := accessibleAliasRoots(ctx.Docsets())
-	for _, file := range scanned {
-		for _, link := range okf.Links(file.content) {
-			local, ok := okf.LocalLinkPath(link.Destination)
-			if !ok {
-				continue
-			}
-			target := path.Join(path.Dir(file.absolute), local)
-			if strings.HasPrefix(local, "/") {
-				target = path.Join(root, strings.TrimPrefix(local, "/"))
-			}
-			target = vfs.CleanPath(target)
-			if !pathWithinRoot(root, target) {
-				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityError,
-					"openlore/link-outside-bundle", fmt.Sprintf("local link %q resolves outside the bundle", link.Destination)))
-			} else if _, err := ctx.FS().Stat(target); err != nil {
-				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityError,
-					"openlore/broken-link", fmt.Sprintf("local link %q does not resolve", link.Destination)))
-			}
-			if aliasRoot(file.absolute, aliasRoots) != "" {
-				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityWarning,
-					"openlore/alias-referrer", "link originates from an aliased docset path; use a stable checkout path"))
-			}
-			if alias := aliasRoot(target, aliasRoots); alias != "" {
-				diagnostics = append(diagnostics, openLoreDiagnostic(file.relative, link, okf.SeverityWarning,
-					"openlore/alias-target", fmt.Sprintf("link targets aliased docset path %s; it may resolve differently on another machine", alias)))
-			}
-		}
-	}
-
-	sort.SliceStable(diagnostics, func(i, j int) bool {
-		if diagnostics[i].Path != diagnostics[j].Path {
-			return diagnostics[i].Path < diagnostics[j].Path
-		}
-		if diagnostics[i].Line != diagnostics[j].Line {
-			return diagnostics[i].Line < diagnostics[j].Line
-		}
-		if diagnostics[i].Column != diagnostics[j].Column {
-			return diagnostics[i].Column < diagnostics[j].Column
-		}
-		return diagnostics[i].Rule < diagnostics[j].Rule
-	})
-	errors, warnings := 0, 0
-	for _, diagnostic := range diagnostics {
-		fmt.Fprintln(w, okf.FormatDiagnostic(diagnostic))
-		if diagnostic.Severity == okf.SeverityError {
-			errors++
-		} else {
-			warnings++
-		}
-	}
-	fmt.Fprintf(w, "%d %s, %d %s\n", errors, countLabel(errors, "error"), warnings, countLabel(warnings, "warning"))
-	if errors > 0 {
-		return 1
-	}
-	return 0
-}
-
-func countLabel(count int, singular string) string {
-	if count == 1 {
-		return singular
-	}
-	return singular + "s"
-}
-
-func accessibleAliasRoots(docsets []cmds.DocsetInfo) []string {
+func (p *okfPlugin) aliasRoots() []string {
 	var roots []string
-	for _, docset := range docsets {
-		if docset.AliasTarget != "" {
-			roots = append(roots, docset.Paths...)
-		}
+	for _, docset := range p.docsets {
+		roots = append(roots, docset.Aliases...)
 	}
 	sort.Slice(roots, func(i, j int) bool { return len(roots[i]) > len(roots[j]) })
 	return roots
-}
-
-func relativeBundlePath(root, filePath string) string {
-	root = vfs.CleanPath(root)
-	filePath = vfs.CleanPath(filePath)
-	if root == "/" {
-		return strings.TrimPrefix(filePath, "/")
-	}
-	return strings.TrimPrefix(filePath, root+"/")
 }
 
 func aliasRoot(filePath string, roots []string) string {
@@ -320,10 +223,17 @@ func aliasRoot(filePath string, roots []string) string {
 	return ""
 }
 
-func openLoreDiagnostic(filePath string, link okf.Link, severity okf.Severity, rule, message string) okf.Diagnostic {
-	return okf.Diagnostic{
+func openLoreDiagnostic(filePath string, link okf.Link, severity validation.Severity, rule, message string) validation.Diagnostic {
+	return validation.Diagnostic{
 		Path: filePath, Line: link.Line, Column: link.Column,
 		Severity: severity, Rule: rule, Message: message,
+	}
+}
+
+func fromOKFDiagnostic(diagnostic okf.Diagnostic) validation.Diagnostic {
+	return validation.Diagnostic{
+		Path: diagnostic.Path, Line: diagnostic.Line, Column: diagnostic.Column,
+		Severity: validation.Severity(diagnostic.Severity), Rule: diagnostic.Rule, Message: diagnostic.Message,
 	}
 }
 
@@ -336,6 +246,6 @@ func (p *okfPlugin) Info() PluginInfo {
 var (
 	_ WriteMiddlewareProvider = (*okfPlugin)(nil)
 	_ MetaExtenderProvider    = (*okfPlugin)(nil)
-	_ CommandProvider         = (*okfPlugin)(nil)
+	_ ValidatorProvider       = (*okfPlugin)(nil)
 	_ PluginInfoProvider      = (*okfPlugin)(nil)
 )

--- a/pkg/openlore/okf_plugin_test.go
+++ b/pkg/openlore/okf_plugin_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/shell"
-	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -367,12 +366,18 @@ func TestOKFPlugin_ValidateCommandListsAllErrorsAndAliasWarnings(t *testing.T) {
 	write("target.md", validDoc)
 	write("invalid.md", invalidDoc)
 
+	docsets := docsWithOKF()
+	docset := docsets["docs"]
+	docset.Paths = []config.PathMapping{{Source: "/wiki", Display: "/wiki"}}
+	docset.Aliases = []string{"/docs"}
+	docsets["docs"] = docset
+	plugin := pluginWith(docsets)
 	sh := shell.NewShell(NewDirFS(dir, config.FilesConfig{}))
 	sh.SetCwd("/docs")
-	sh.SetDocsets([]cmds.DocsetInfo{{Name: "wiki", Paths: []string{"/docs"}, AliasTarget: "/wiki", Grant: "ro"}})
+	sh.SetValidators(plugin.Validators())
 
 	var out, errOut bytes.Buffer
-	code := runValidate(sh, nil, &out, &errOut, nil)
+	code := sh.ExecPipeline("lore validate", &out, &errOut, nil)
 	if code != 1 {
 		t.Fatalf("exit=%d, want 1; stdout=%s stderr=%s", code, out.String(), errOut.String())
 	}
@@ -396,9 +401,10 @@ func TestOKFPlugin_ValidateCommandSucceedsForPortableBundle(t *testing.T) {
 	}
 	sh := shell.NewShell(NewDirFS(dir, config.FilesConfig{}))
 	sh.SetCwd("/")
+	sh.SetValidators(pluginWith(docsWithOKF()).Validators())
 
 	var out, errOut bytes.Buffer
-	if code := runValidate(sh, nil, &out, &errOut, nil); code != 0 {
+	if code := sh.ExecPipeline("lore validate", &out, &errOut, nil); code != 0 {
 		t.Fatalf("exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
 	}
 	if out.String() != "0 errors, 0 warnings\n" {
@@ -406,18 +412,20 @@ func TestOKFPlugin_ValidateCommandSucceedsForPortableBundle(t *testing.T) {
 	}
 }
 
-func TestRegisterPlugin_ValidateCommandIsSessionLocal(t *testing.T) {
+func TestRegisterPlugin_ValidateCommandIsCoreAndValidatorsAreSessionLocal(t *testing.T) {
 	withOKF := &Server{}
 	if err := withOKF.registerPlugin(pluginWith(docsWithOKF())); err != nil {
 		t.Fatal(err)
 	}
-	withoutOKF := &Server{}
 
-	fsys := NewDirFS(t.TempDir(), config.FilesConfig{})
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "invalid.md"), []byte(invalidDoc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewDirFS(dir, config.FilesConfig{})
 	withShell := shell.NewShell(fsys)
-	withShell.SetLoreCommands(withOKF.loreCommands)
+	withShell.SetValidators(withOKF.validators)
 	withoutShell := shell.NewShell(fsys)
-	withoutShell.SetLoreCommands(withoutOKF.loreCommands)
 
 	var withOut, withoutOut, errOut bytes.Buffer
 	if code := withShell.ExecPipeline("lore", &withOut, &errOut, nil); code != 0 {
@@ -426,10 +434,18 @@ func TestRegisterPlugin_ValidateCommandIsSessionLocal(t *testing.T) {
 	if code := withoutShell.ExecPipeline("lore", &withoutOut, &errOut, nil); code != 0 {
 		t.Fatalf("lore without plugin exit=%d: %s", code, errOut.String())
 	}
-	if !strings.Contains(withOut.String(), "validate") {
-		t.Fatalf("plugin session missing validate command:\n%s", withOut.String())
+	if !strings.Contains(withOut.String(), "validate") || !strings.Contains(withoutOut.String(), "validate") {
+		t.Fatalf("core validate command missing: with plugin:\n%s\nwithout plugin:\n%s", withOut.String(), withoutOut.String())
 	}
-	if strings.Contains(withoutOut.String(), "validate") {
-		t.Fatalf("validate leaked into session without plugin:\n%s", withoutOut.String())
+	withOut.Reset()
+	withoutOut.Reset()
+	if code := withShell.ExecPipeline("lore validate", &withOut, &errOut, nil); code != 1 {
+		t.Fatalf("with plugin exit=%d, want 1: %s", code, withOut.String())
+	}
+	if code := withoutShell.ExecPipeline("lore validate", &withoutOut, &errOut, nil); code != 0 {
+		t.Fatalf("without plugin exit=%d, want 0: %s", code, withoutOut.String())
+	}
+	if !strings.Contains(withOut.String(), "okf/concept") || withoutOut.String() != "0 errors, 0 warnings\n" {
+		t.Fatalf("validators not session-local: with=%q without=%q", withOut.String(), withoutOut.String())
 	}
 }

--- a/pkg/openlore/okf_plugin_test.go
+++ b/pkg/openlore/okf_plugin_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/shell"
+	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -349,5 +350,86 @@ func TestAnyDocsetHasOKF(t *testing.T) {
 	}
 	if !anyDocsetHasOKF(docsWithOKF()) {
 		t.Fatal("a docset carries OKF; expected true")
+	}
+}
+
+func TestOKFPlugin_ValidateCommandListsAllErrorsAndAliasWarnings(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, "docs", name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("good.md", "---\ntype: Note\n---\n[target](target.md) [missing](missing.md)\n")
+	write("target.md", validDoc)
+	write("invalid.md", invalidDoc)
+
+	sh := shell.NewShell(NewDirFS(dir, config.FilesConfig{}))
+	sh.SetCwd("/docs")
+	sh.SetDocsets([]cmds.DocsetInfo{{Name: "wiki", Paths: []string{"/docs"}, AliasTarget: "/wiki", Grant: "ro"}})
+
+	var out, errOut bytes.Buffer
+	code := runValidate(sh, nil, &out, &errOut, nil)
+	if code != 1 {
+		t.Fatalf("exit=%d, want 1; stdout=%s stderr=%s", code, out.String(), errOut.String())
+	}
+	for _, want := range []string{
+		"invalid.md:1:1: error [okf/concept]",
+		"error [openlore/broken-link]",
+		"warning [openlore/alias-referrer]",
+		"warning [openlore/alias-target]",
+		"2 errors, 4 warnings",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestOKFPlugin_ValidateCommandSucceedsForPortableBundle(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte(validDoc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sh := shell.NewShell(NewDirFS(dir, config.FilesConfig{}))
+	sh.SetCwd("/")
+
+	var out, errOut bytes.Buffer
+	if code := runValidate(sh, nil, &out, &errOut, nil); code != 0 {
+		t.Fatalf("exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
+	}
+	if out.String() != "0 errors, 0 warnings\n" {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestRegisterPlugin_ValidateCommandIsSessionLocal(t *testing.T) {
+	withOKF := &Server{}
+	if err := withOKF.registerPlugin(pluginWith(docsWithOKF())); err != nil {
+		t.Fatal(err)
+	}
+	withoutOKF := &Server{}
+
+	fsys := NewDirFS(t.TempDir(), config.FilesConfig{})
+	withShell := shell.NewShell(fsys)
+	withShell.SetLoreCommands(withOKF.loreCommands)
+	withoutShell := shell.NewShell(fsys)
+	withoutShell.SetLoreCommands(withoutOKF.loreCommands)
+
+	var withOut, withoutOut, errOut bytes.Buffer
+	if code := withShell.ExecPipeline("lore", &withOut, &errOut, nil); code != 0 {
+		t.Fatalf("lore with plugin exit=%d: %s", code, errOut.String())
+	}
+	if code := withoutShell.ExecPipeline("lore", &withoutOut, &errOut, nil); code != 0 {
+		t.Fatalf("lore without plugin exit=%d: %s", code, errOut.String())
+	}
+	if !strings.Contains(withOut.String(), "validate") {
+		t.Fatalf("plugin session missing validate command:\n%s", withOut.String())
+	}
+	if strings.Contains(withoutOut.String(), "validate") {
+		t.Fatalf("validate leaked into session without plugin:\n%s", withoutOut.String())
 	}
 }

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -86,6 +86,9 @@ type Server struct {
 	// installed per session in buildSessionShell.
 	metaExtenders []meta.Extender
 	metaFilters   []meta.Filter
+	// loreCommands are plugin-contributed `lore` subcommands, installed per
+	// session so multiple servers in one process cannot overwrite each other.
+	loreCommands []cmds.LoreSub
 
 	// postCommitMW is the post-commit middleware contributed by plugins, run at
 	// the applier after a durable commit (feed emit, post_write hooks) in
@@ -712,9 +715,7 @@ func (s *Server) registerPlugin(p any) error {
 		}
 	}
 	if cp, ok := p.(CommandProvider); ok {
-		for _, c := range cp.LoreCommands() {
-			cmds.RegisterLoreSub(c)
-		}
+		s.loreCommands = append(s.loreCommands, cp.LoreCommands()...)
 	}
 	if mp, ok := p.(MetaExtenderProvider); ok {
 		s.metaExtenders = append(s.metaExtenders, mp.MetaExtenders()...)
@@ -910,6 +911,7 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 	sh.SetMetaFilters(s.sessionMetaFilters(id))
 	sh.SetPublishTargets(s.sessionPublishTargets(id))
 	sh.SetMetaExtenders(s.metaExtenders)
+	sh.SetLoreCommands(s.loreCommands)
 
 	// Set identity info as environment variables
 	if id.IdentityName != "" {

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aakarim/go-openlore/internal/passkeys"
 	"github.com/aakarim/go-openlore/internal/skills"
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"
@@ -86,9 +87,7 @@ type Server struct {
 	// installed per session in buildSessionShell.
 	metaExtenders []meta.Extender
 	metaFilters   []meta.Filter
-	// loreCommands are plugin-contributed `lore` subcommands, installed per
-	// session so multiple servers in one process cannot overwrite each other.
-	loreCommands []cmds.LoreSub
+	validators    []validation.Validator
 
 	// postCommitMW is the post-commit middleware contributed by plugins, run at
 	// the applier after a durable commit (feed emit, post_write hooks) in
@@ -714,14 +713,14 @@ func (s *Server) registerPlugin(p any) error {
 			s.grants.register(g)
 		}
 	}
-	if cp, ok := p.(CommandProvider); ok {
-		s.loreCommands = append(s.loreCommands, cp.LoreCommands()...)
-	}
 	if mp, ok := p.(MetaExtenderProvider); ok {
 		s.metaExtenders = append(s.metaExtenders, mp.MetaExtenders()...)
 	}
 	if fp, ok := p.(MetaFilterProvider); ok {
 		s.metaFilters = append(s.metaFilters, fp.MetaFilters()...)
+	}
+	if vp, ok := p.(ValidatorProvider); ok {
+		s.validators = append(s.validators, vp.Validators()...)
 	}
 	// Record the plugin's identity + version in the boot logs. Logged per
 	// registration so it captures plugins registered after NewServer (e.g. the
@@ -911,7 +910,7 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 	sh.SetMetaFilters(s.sessionMetaFilters(id))
 	sh.SetPublishTargets(s.sessionPublishTargets(id))
 	sh.SetMetaExtenders(s.metaExtenders)
-	sh.SetLoreCommands(s.loreCommands)
+	sh.SetValidators(s.validators)
 
 	// Set identity info as environment variables
 	if id.IdentityName != "" {

--- a/pkg/openlore/validation/validation.go
+++ b/pkg/openlore/validation/validation.go
@@ -1,0 +1,103 @@
+// Package validation holds the generic bundle-linting mechanism behind
+// `lore validate`. Core owns scanning and diagnostics; plugins contribute the
+// policy through Validator functions.
+package validation
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+type Diagnostic struct {
+	Path     string
+	Line     int
+	Column   int
+	Severity Severity
+	Rule     string
+	Message  string
+}
+
+type File struct {
+	AbsolutePath string
+	Path         string
+	Content      []byte
+}
+
+type Bundle struct {
+	Root  string
+	FS    vfs.FileSystem
+	Files []File
+}
+
+type Validator func(Bundle) []Diagnostic
+
+func Scan(fsys vfs.FileSystem, root string, validators ...Validator) ([]Diagnostic, error) {
+	root = vfs.CleanPath(root)
+	bundle := Bundle{Root: root, FS: fsys}
+	err := vfs.WalkDir(fsys, root, func(filePath string, info *vfs.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info == nil || info.Dir {
+			return nil
+		}
+		content, err := fsys.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+		bundle.Files = append(bundle.Files, File{
+			AbsolutePath: vfs.CleanPath(filePath),
+			Path:         relativePath(root, filePath),
+			Content:      content,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var diagnostics []Diagnostic
+	for _, validator := range validators {
+		diagnostics = append(diagnostics, validator(bundle)...)
+	}
+	sort.SliceStable(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Path != diagnostics[j].Path {
+			return diagnostics[i].Path < diagnostics[j].Path
+		}
+		if diagnostics[i].Line != diagnostics[j].Line {
+			return diagnostics[i].Line < diagnostics[j].Line
+		}
+		if diagnostics[i].Column != diagnostics[j].Column {
+			return diagnostics[i].Column < diagnostics[j].Column
+		}
+		return diagnostics[i].Rule < diagnostics[j].Rule
+	})
+	return diagnostics, nil
+}
+
+func FormatDiagnostic(d Diagnostic) string {
+	return fmt.Sprintf("%s:%d:%d: %s [%s] %s", d.Path, d.Line, d.Column, d.Severity, d.Rule, d.Message)
+}
+
+func relativePath(root, filePath string) string {
+	root = vfs.CleanPath(root)
+	filePath = vfs.CleanPath(filePath)
+	if root == "/" {
+		return strings.TrimPrefix(filePath, "/")
+	}
+	if filePath == root {
+		return path.Base(filePath)
+	}
+	return strings.TrimPrefix(filePath, root+"/")
+}

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -42,6 +42,10 @@ type CmdContext interface {
 	// shell returns nil.
 	MetaExtenders() []meta.Extender
 	MetaFilters() []meta.Filter
+	// LoreCommands reports plugin-contributed lore subcommands installed for
+	// this session. Commands are session-local so one server cannot overwrite
+	// another server's plugin state in the process-wide core registry.
+	LoreCommands() []LoreSub
 }
 
 // DocsetInfo describes one docset a session can access. It is the per-session

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -42,10 +43,8 @@ type CmdContext interface {
 	// shell returns nil.
 	MetaExtenders() []meta.Extender
 	MetaFilters() []meta.Filter
-	// LoreCommands reports plugin-contributed lore subcommands installed for
-	// this session. Commands are session-local so one server cannot overwrite
-	// another server's plugin state in the process-wide core registry.
-	LoreCommands() []LoreSub
+	// Validators reports plugin-contributed checks used by `lore validate`.
+	Validators() []validation.Validator
 }
 
 // DocsetInfo describes one docset a session can access. It is the per-session

--- a/pkg/shell/cmds/lore.go
+++ b/pkg/shell/cmds/lore.go
@@ -7,10 +7,7 @@ import (
 	"strings"
 )
 
-// LoreSub is a registered `lore` subcommand. Core subcommands (docsets, meta)
-// register themselves in init; plugins contribute session-local entries via
-// the host, so the introspection surface is extensible without reshaping the
-// `lore` dispatcher.
+// LoreSub is a registered core `lore` subcommand.
 type LoreSub struct {
 	// Name is the subcommand word, e.g. "meta" in `lore meta`.
 	Name string
@@ -24,46 +21,33 @@ type LoreSub struct {
 // loreSubs is the registry of `lore` subcommands, keyed by name.
 var loreSubs = map[string]LoreSub{}
 
-// RegisterLoreSub adds (or replaces) a process-wide core `lore` subcommand.
-// Plugin commands should be installed on a session through CmdContext instead.
+// RegisterLoreSub adds (or replaces) a core `lore` subcommand.
 func RegisterLoreSub(sub LoreSub) {
 	loreSubs[sub.Name] = sub
 }
 
 // CmdLore is the `lore` introspection dispatcher. Bare `lore` prints usage and
 // exits 0; an unknown subcommand errors to stderr and exits 1. Subcommands are
-// resolved from the core registry plus the current session's plugin commands.
+// resolved from the loreSubs registry.
 func CmdLore(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	if len(args) == 0 {
-		printLoreUsage(ctx, w)
+		printLoreUsage(w)
 		return 0
 	}
-	if sub, ok := availableLoreSubs(ctx)[args[0]]; ok {
+	if sub, ok := loreSubs[args[0]]; ok {
 		return sub.Run(ctx, args[1:], w, errW, stdin)
 	}
 	fmt.Fprintf(errW, "lore: unknown command %q\n", args[0])
-	printLoreUsage(ctx, errW)
+	printLoreUsage(errW)
 	return 1
 }
 
-func availableLoreSubs(ctx CmdContext) map[string]LoreSub {
-	subs := make(map[string]LoreSub, len(loreSubs)+len(ctx.LoreCommands()))
-	for name, sub := range loreSubs {
-		subs[name] = sub
-	}
-	for _, sub := range ctx.LoreCommands() {
-		subs[sub.Name] = sub
-	}
-	return subs
-}
-
-func printLoreUsage(ctx CmdContext, w io.Writer) {
+func printLoreUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: lore <command>")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Commands:")
-	available := availableLoreSubs(ctx)
-	subs := make([]LoreSub, 0, len(available))
-	for _, s := range available {
+	subs := make([]LoreSub, 0, len(loreSubs))
+	for _, s := range loreSubs {
 		subs = append(subs, s)
 	}
 	sort.Slice(subs, func(i, j int) bool { return subs[i].Name < subs[j].Name })

--- a/pkg/shell/cmds/lore.go
+++ b/pkg/shell/cmds/lore.go
@@ -8,9 +8,9 @@ import (
 )
 
 // LoreSub is a registered `lore` subcommand. Core subcommands (docsets, meta)
-// register themselves in init; plugins contribute more via the host
-// (openlore.CommandProvider → RegisterLoreSub), so the introspection surface is
-// extensible without reshaping the `lore` dispatcher.
+// register themselves in init; plugins contribute session-local entries via
+// the host, so the introspection surface is extensible without reshaping the
+// `lore` dispatcher.
 type LoreSub struct {
 	// Name is the subcommand word, e.g. "meta" in `lore meta`.
 	Name string
@@ -24,34 +24,46 @@ type LoreSub struct {
 // loreSubs is the registry of `lore` subcommands, keyed by name.
 var loreSubs = map[string]LoreSub{}
 
-// RegisterLoreSub adds (or replaces) a `lore` subcommand. Called from init for
-// core subcommands and by the host when a plugin contributes commands.
+// RegisterLoreSub adds (or replaces) a process-wide core `lore` subcommand.
+// Plugin commands should be installed on a session through CmdContext instead.
 func RegisterLoreSub(sub LoreSub) {
 	loreSubs[sub.Name] = sub
 }
 
 // CmdLore is the `lore` introspection dispatcher. Bare `lore` prints usage and
 // exits 0; an unknown subcommand errors to stderr and exits 1. Subcommands are
-// resolved from the loreSubs registry, so plugins can extend the surface.
+// resolved from the core registry plus the current session's plugin commands.
 func CmdLore(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	if len(args) == 0 {
-		printLoreUsage(w)
+		printLoreUsage(ctx, w)
 		return 0
 	}
-	if sub, ok := loreSubs[args[0]]; ok {
+	if sub, ok := availableLoreSubs(ctx)[args[0]]; ok {
 		return sub.Run(ctx, args[1:], w, errW, stdin)
 	}
 	fmt.Fprintf(errW, "lore: unknown command %q\n", args[0])
-	printLoreUsage(errW)
+	printLoreUsage(ctx, errW)
 	return 1
 }
 
-func printLoreUsage(w io.Writer) {
+func availableLoreSubs(ctx CmdContext) map[string]LoreSub {
+	subs := make(map[string]LoreSub, len(loreSubs)+len(ctx.LoreCommands()))
+	for name, sub := range loreSubs {
+		subs[name] = sub
+	}
+	for _, sub := range ctx.LoreCommands() {
+		subs[sub.Name] = sub
+	}
+	return subs
+}
+
+func printLoreUsage(ctx CmdContext, w io.Writer) {
 	fmt.Fprintln(w, "Usage: lore <command>")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Commands:")
-	subs := make([]LoreSub, 0, len(loreSubs))
-	for _, s := range loreSubs {
+	available := availableLoreSubs(ctx)
+	subs := make([]LoreSub, 0, len(available))
+	for _, s := range available {
 		subs = append(subs, s)
 	}
 	sort.Slice(subs, func(i, j int) bool { return subs[i].Name < subs[j].Name })

--- a/pkg/shell/cmds/lore_validate.go
+++ b/pkg/shell/cmds/lore_validate.go
@@ -1,0 +1,70 @@
+package cmds
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+func cmdLoreValidate(ctx CmdContext, args []string, w io.Writer, errW io.Writer, _ io.Reader) int {
+	root := ctx.Cwd()
+	if len(args) > 1 {
+		fmt.Fprintln(errW, "Usage: lore validate [bundle]")
+		return 1
+	}
+	if len(args) == 1 {
+		if strings.HasPrefix(args[0], "-") {
+			fmt.Fprintf(errW, "lore validate: unknown flag %q\n", args[0])
+			return 1
+		}
+		root = ctx.Resolve(args[0])
+	}
+	root = vfs.CleanPath(root)
+	info, err := ctx.FS().Stat(root)
+	if err != nil {
+		fmt.Fprintf(errW, "lore validate: %s\n", err)
+		return 1
+	}
+	if !info.Dir {
+		fmt.Fprintf(errW, "lore validate: %s is not a bundle directory\n", root)
+		return 1
+	}
+
+	diagnostics, err := validation.Scan(ctx.FS(), root, ctx.Validators()...)
+	if err != nil {
+		fmt.Fprintf(errW, "lore validate: %s\n", err)
+		return 1
+	}
+	errors, warnings := 0, 0
+	for _, diagnostic := range diagnostics {
+		fmt.Fprintln(w, validation.FormatDiagnostic(diagnostic))
+		if diagnostic.Severity == validation.SeverityError {
+			errors++
+		} else {
+			warnings++
+		}
+	}
+	fmt.Fprintf(w, "%d %s, %d %s\n", errors, countLabel(errors, "error"), warnings, countLabel(warnings, "warning"))
+	if errors > 0 {
+		return 1
+	}
+	return 0
+}
+
+func countLabel(count int, singular string) string {
+	if count == 1 {
+		return singular
+	}
+	return singular + "s"
+}
+
+func init() {
+	RegisterLoreSub(LoreSub{
+		Name:    "validate",
+		Summary: "Lint a bundle with plugin-provided validators",
+		Run:     cmdLoreValidate,
+	})
+}

--- a/pkg/shell/cmds/spawn.go
+++ b/pkg/shell/cmds/spawn.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -155,10 +156,10 @@ func (c *frozenContext) ActionAllowed(Action) bool { return true }
 func (c *frozenContext) WriteConflictPolicy(string) vfs.WriteConflictPolicy {
 	return c.policy
 }
-func (c *frozenContext) Docsets() []DocsetInfo           { return nil }
-func (c *frozenContext) PublishTargets() []PublishTarget { return nil }
-func (c *frozenContext) MetaExtenders() []meta.Extender  { return nil }
-func (c *frozenContext) MetaFilters() []meta.Filter      { return nil }
-func (c *frozenContext) LoreCommands() []LoreSub         { return nil }
+func (c *frozenContext) Docsets() []DocsetInfo              { return nil }
+func (c *frozenContext) PublishTargets() []PublishTarget    { return nil }
+func (c *frozenContext) MetaExtenders() []meta.Extender     { return nil }
+func (c *frozenContext) MetaFilters() []meta.Filter         { return nil }
+func (c *frozenContext) Validators() []validation.Validator { return nil }
 
 var _ CmdContext = (*frozenContext)(nil)

--- a/pkg/shell/cmds/spawn.go
+++ b/pkg/shell/cmds/spawn.go
@@ -159,5 +159,6 @@ func (c *frozenContext) Docsets() []DocsetInfo           { return nil }
 func (c *frozenContext) PublishTargets() []PublishTarget { return nil }
 func (c *frozenContext) MetaExtenders() []meta.Extender  { return nil }
 func (c *frozenContext) MetaFilters() []meta.Filter      { return nil }
+func (c *frozenContext) LoreCommands() []LoreSub         { return nil }
 
 var _ CmdContext = (*frozenContext)(nil)

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -39,6 +39,9 @@ type Shell struct {
 	// installed by the host per session. nil for a standalone shell.
 	metaExtenders []meta.Extender
 	metaFilters   []meta.Filter
+	// loreCommands are plugin-contributed lore subcommands installed by the
+	// host per session. Core subcommands remain in the package registry.
+	loreCommands []cmds.LoreSub
 }
 
 // NewShell creates a new Shell backed by the given vfs.FileSystem.
@@ -112,6 +115,12 @@ func (s *Shell) SetMetaExtenders(e []meta.Extender) { s.metaExtenders = e }
 func (s *Shell) MetaExtenders() []meta.Extender { return s.metaExtenders }
 func (s *Shell) SetMetaFilters(f []meta.Filter) { s.metaFilters = f }
 func (s *Shell) MetaFilters() []meta.Filter     { return s.metaFilters }
+
+// SetLoreCommands installs plugin-contributed lore subcommands for this shell.
+func (s *Shell) SetLoreCommands(commands []cmds.LoreSub) { s.loreCommands = commands }
+
+// LoreCommands reports this shell's plugin-contributed lore subcommands.
+func (s *Shell) LoreCommands() []cmds.LoreSub { return s.loreCommands }
 
 // --- CmdContext interface implementation ---
 

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/shell/parser"
 	"github.com/aakarim/go-openlore/pkg/vfs"
@@ -39,9 +40,8 @@ type Shell struct {
 	// installed by the host per session. nil for a standalone shell.
 	metaExtenders []meta.Extender
 	metaFilters   []meta.Filter
-	// loreCommands are plugin-contributed lore subcommands installed by the
-	// host per session. Core subcommands remain in the package registry.
-	loreCommands []cmds.LoreSub
+	// validators are plugin-contributed checks applied by `lore validate`.
+	validators []validation.Validator
 }
 
 // NewShell creates a new Shell backed by the given vfs.FileSystem.
@@ -116,11 +116,11 @@ func (s *Shell) MetaExtenders() []meta.Extender { return s.metaExtenders }
 func (s *Shell) SetMetaFilters(f []meta.Filter) { s.metaFilters = f }
 func (s *Shell) MetaFilters() []meta.Filter     { return s.metaFilters }
 
-// SetLoreCommands installs plugin-contributed lore subcommands for this shell.
-func (s *Shell) SetLoreCommands(commands []cmds.LoreSub) { s.loreCommands = commands }
+// SetValidators installs plugin-contributed checks for `lore validate`.
+func (s *Shell) SetValidators(validators []validation.Validator) { s.validators = validators }
 
-// LoreCommands reports this shell's plugin-contributed lore subcommands.
-func (s *Shell) LoreCommands() []cmds.LoreSub { return s.loreCommands }
+// Validators reports this shell's plugin-contributed validation checks.
+func (s *Shell) Validators() []validation.Validator { return s.validators }
 
 // --- CmdContext interface implementation ---
 


### PR DESCRIPTION
## Summary

- add core-owned `lore validate [bundle]` with linter-style diagnostics and non-zero exits on errors
- let plugins extend validation through session-scoped `ValidatorProvider` checks, following the `lore meta` extension model
- keep mandatory OKF v0.1 bundle conformance in `pkg/okf`, separate from OpenLore link and portability checks
- validate bundle-local Markdown links and warn when referring or target paths use docset aliases

## Validation

- `go test ./...`
- `git diff --check`