### PR TITLE
feat(mcp): allow requiring OAuth independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,12 @@ TLS-terminating proxy this is `https://your-host/mcp`). Configure it via
 mcp:
   enabled: true   # on by default; set false to disable
   path: /mcp      # path on the HTTP server
+  require_auth: true # force OAuth login instead of anonymous access
 ```
+
+Omit `require_auth` to inherit the SSH posture from `allow_keyless`. Set it to
+`true` to make OAuth-native clients open the browser login flow while retaining
+keyless SSH access, or `false` to permit anonymous MCP when SSH requires a key.
 
 Or with flags: `--mcp-path /custom` to change the path. The endpoint requires
 the HTTP server (`--http-port`) to be enabled.

--- a/assets/config/openlore.yml
+++ b/assets/config/openlore.yml
@@ -36,6 +36,7 @@ max_jobs: 8
 mcp:
   enabled: true
   path: /mcp
+  require_auth: true
 
 passkeys:
   enabled: true
@@ -51,8 +52,8 @@ passkeys:
 # instance mints/verifies tokens), so it lives here, not in lore.json. Enabling
 # it mounts the OAuth flow (/authorize, /oauth/token), Dynamic Client
 # Registration (/register), and discovery (/.well-known/oauth-*), so OAuth-native
-# MCP clients (Claude Desktop, Cowork) can log in — while posture (public vs
-# token-required) still derives from lore.json's allow_keyless/unknown_identity.
+# MCP clients (Claude Desktop, Cowork) can log in. MCP's require_auth setting
+# overrides the default posture inherited from lore.json's allow_keyless.
 # The ES256 signing key is generated on first boot under <data_dir>/auth/.
 tokens:
   issuer: https://openlore.sh

--- a/assets/lore/mcp.md
+++ b/assets/lore/mcp.md
@@ -31,7 +31,13 @@ Configure it in `openlore.yml`:
 mcp:
   enabled: true   # on by default; set false to disable
   path: /mcp      # path on the HTTP server
+  require_auth: true # force OAuth login instead of anonymous access
 ```
+
+`require_auth` is optional. When omitted, MCP inherits the SSH posture from
+`allow_keyless`; set it to `true` to make OAuth-native clients such as Claude
+open the browser login flow even while keyless SSH remains enabled. Set it to
+`false` to allow anonymous MCP access even when SSH requires a key.
 
 Or with flags: `--mcp-path /custom` to change the path. The endpoint requires
 the HTTP server (`http_port`) to be enabled.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,10 @@ type Config struct {
 	// Default true. The endpoint is mounted at MCPPath on the HTTP server.
 	MCPEnabled bool
 	MCPPath    string
+	// MCPRequireAuth overrides the SSH-derived authentication posture for the
+	// MCP endpoint. Nil inherits !AllowKeyless; true forces OAuth so clients
+	// such as Claude open the browser login flow.
+	MCPRequireAuth *bool
 	// APIEnabled controls whether the plain JSON HTTP API (backed by the MCP
 	// server) runs. Default true. It is mounted at APIPath on the HTTP server.
 	APIEnabled   bool
@@ -365,8 +369,9 @@ type fileConfig struct {
 }
 
 type mcpYAML struct {
-	Enabled *bool  `yaml:"enabled"`
-	Path    string `yaml:"path"`
+	Enabled     *bool  `yaml:"enabled"`
+	Path        string `yaml:"path"`
+	RequireAuth *bool  `yaml:"require_auth"`
 }
 
 type apiYAML struct {
@@ -430,6 +435,9 @@ func New(opts ...Option) (Config, error) {
 
 	if cfg.configFileLoaded && cfg.embeddedConfigUsed {
 		return Config{}, errors.New("conflict: cannot use both a config file and embedded config")
+	}
+	if cfg.MCPEnabled && cfg.MCPRequireAuth != nil && *cfg.MCPRequireAuth && cfg.Tokens == nil {
+		return Config{}, errors.New("mcp.require_auth requires tokens to be configured")
 	}
 
 	return cfg, nil
@@ -848,6 +856,18 @@ func applyMCPConfig(cfg *Config, m *mcpYAML) {
 	if m.Path != "" {
 		cfg.MCPPath = m.Path
 	}
+	if m.RequireAuth != nil {
+		cfg.MCPRequireAuth = m.RequireAuth
+	}
+}
+
+// MCPAuthRequired resolves the MCP-specific override. When it is omitted, MCP
+// retains the historical behavior of mirroring the SSH keyless posture.
+func (cfg Config) MCPAuthRequired() bool {
+	if cfg.MCPRequireAuth != nil {
+		return *cfg.MCPRequireAuth
+	}
+	return !cfg.AllowKeyless
 }
 
 // WithMCPPath sets the path the MCP-over-HTTP endpoint is mounted at on the

--- a/internal/config/mcp_test.go
+++ b/internal/config/mcp_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMCPRequireAuthOverridesKeylessPosture(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "openlore.yml")
+	contents := []byte(`
+mcp:
+  require_auth: true
+tokens:
+  issuer: https://openlore.test
+  audience: https://openlore.test
+`)
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := New(WithConfigFile(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.AllowKeyless {
+		t.Fatal("MCP override must not change the SSH keyless posture")
+	}
+	if !cfg.MCPAuthRequired() {
+		t.Fatal("MCPAuthRequired() = false, want true")
+	}
+}
+
+func TestMCPRequireAuthDefaultsToKeylessPosture(t *testing.T) {
+	cfg, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MCPAuthRequired() {
+		t.Fatal("MCPAuthRequired() = true for default keyless config, want false")
+	}
+
+	cfg, err = New(WithAllowKeyless(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.MCPAuthRequired() {
+		t.Fatal("MCPAuthRequired() = false when keyless is disabled, want true")
+	}
+}
+
+func TestMCPRequireAuthRequiresTokenIssuer(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "openlore.yml")
+	if err := os.WriteFile(path, []byte("mcp:\n  require_auth: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New(WithConfigFile(path)); err == nil {
+		t.Fatal("expected mcp.require_auth without tokens to be rejected")
+	}
+}

--- a/openlore.sh/docs/mcp.md
+++ b/openlore.sh/docs/mcp.md
@@ -31,7 +31,13 @@ Configure it in `openlore.yml`:
 mcp:
   enabled: true   # on by default; set false to disable
   path: /mcp      # path on the HTTP server
+  require_auth: true # force OAuth login instead of anonymous access
 ```
+
+`require_auth` is optional. When omitted, MCP inherits the SSH posture from
+`allow_keyless`; set it to `true` to make OAuth-native clients such as Claude
+open the browser login flow even while keyless SSH remains enabled. Set it to
+`false` to allow anonymous MCP access even when SSH requires a key.
 
 Or with flags: `--mcp-path /custom` to change the path. The endpoint requires
 the HTTP server (`http_port`) to be enabled.

--- a/openlore.sh/openlore.yml
+++ b/openlore.sh/openlore.yml
@@ -36,6 +36,7 @@ max_jobs: 8
 mcp:
   enabled: true
   path: /mcp
+  require_auth: true
 
 passkeys:
   enabled: true
@@ -51,8 +52,8 @@ passkeys:
 # instance mints/verifies tokens), so it lives here, not in lore.json. Enabling
 # it mounts the OAuth flow (/authorize, /oauth/token), Dynamic Client
 # Registration (/register), and discovery (/.well-known/oauth-*), so OAuth-native
-# MCP clients (Claude Desktop, Cowork) can log in — while posture (public vs
-# token-required) still derives from lore.json's allow_keyless/unknown_identity.
+# MCP clients (Claude Desktop, Cowork) can log in. MCP's require_auth setting
+# overrides the default posture inherited from lore.json's allow_keyless.
 # The ES256 signing key is generated on first boot under <data_dir>/auth/.
 tokens:
   issuer: https://openlore.sh

--- a/openlore.yml.example
+++ b/openlore.yml.example
@@ -38,6 +38,9 @@ metrics_port: 3000
 mcp:
   enabled: true
   path: /mcp
+  # Force OAuth login even when lore.json allows keyless/anonymous access.
+  # Omit this setting to inherit the SSH posture from allow_keyless.
+  require_auth: true
 
 # ── JSON HTTP API ─────────────────────────────────────
 #
@@ -132,8 +135,8 @@ host_key_path: .ssh/openlore_ed25519
 # infrastructure — how this instance mints and verifies tokens — so it
 # lives here, not in lore.json (which is access policy). When omitted,
 # the MCP/HTTP endpoints serve anonymous callers (Phase 0). Posture
-# (public vs token-required) still derives from lore.json's
-# allow_keyless / unknown_identity.
+# (public vs token-required) derives from lore.json's allow_keyless by default;
+# mcp.require_auth can override it for the MCP endpoint.
 #
 # The ES256 signing key is generated on first boot under <data_dir>/auth/.
 # Public keys are published at /.well-known/jwks.json. Passkey login mints

--- a/pkg/openlore/auth_middleware.go
+++ b/pkg/openlore/auth_middleware.go
@@ -6,23 +6,23 @@ import (
 	"strings"
 )
 
-// authMiddleware wraps the /mcp and /api handlers with posture-aware bearer
-// verification. Posture is derived from SSH (§4): no separate switch.
+// authMiddleware wraps an HTTP handler with posture-aware bearer verification.
+// The caller supplies whether a token is required so transports may override
+// the SSH-derived default.
 //
 //   - No issuer configured → no-op; callers resolve to anonymous (Phase 0).
-//   - allow_keyless (optional-token) → verify a token if present (reject if
-//     invalid); if absent, proceed anonymously.
-//   - !allow_keyless (required-token) → a valid token is required; missing or
-//     invalid → 401. Unknown identity under `unknown_identity: deny` → 403.
+//   - Optional-token posture → verify a token if present (reject if invalid);
+//     if absent, proceed anonymously.
+//   - Required-token posture → a valid token is required; missing or invalid
+//     returns 401. Unknown identity under `unknown_identity: deny` returns 403.
 //
 // A verified token is resolved to an Identity and stored on the request context
 // via contextWithIdentity, so the shared shellForContext scopes the tool call
 // exactly as an SSH session (docs/mcp-bearer-auth.md §4, §6).
-func (s *Server) authMiddleware(next http.Handler) http.Handler {
+func (s *Server) authMiddleware(next http.Handler, required bool) http.Handler {
 	if s.issuer == nil {
 		return next
 	}
-	required := !s.config.AllowKeyless
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := bearerToken(r)

--- a/pkg/openlore/auth_middleware_test.go
+++ b/pkg/openlore/auth_middleware_test.go
@@ -100,7 +100,7 @@ func mint(t *testing.T, s *Server, sub, scope string) string {
 
 func TestAuthMiddleware_KeylessNoTokenIsAnonymous(t *testing.T) {
 	s := newTokenTestServer(t, true, "allow")
-	h := s.authMiddleware(s.identityEcho())
+	h := s.authMiddleware(s.identityEcho(), false)
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mcp", nil))
@@ -113,9 +113,24 @@ func TestAuthMiddleware_KeylessNoTokenIsAnonymous(t *testing.T) {
 	}
 }
 
+func TestAuthMiddleware_RequiredOverrideChallengesKeylessCaller(t *testing.T) {
+	s := newTokenTestServer(t, true, "allow")
+	h := s.authMiddleware(s.identityEcho(), true)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mcp", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if challenge := rec.Header().Get("WWW-Authenticate"); !strings.Contains(challenge, "resource_metadata=") {
+		t.Fatalf("WWW-Authenticate = %q, want OAuth resource metadata challenge", challenge)
+	}
+}
+
 func TestAuthMiddleware_ValidTokenResolvesIdentity(t *testing.T) {
 	s := newTokenTestServer(t, true, "allow")
-	h := s.authMiddleware(s.identityEcho())
+	h := s.authMiddleware(s.identityEcho(), false)
 
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer "+mint(t, s, "alice", ScopeFull))
@@ -132,7 +147,7 @@ func TestAuthMiddleware_ValidTokenResolvesIdentity(t *testing.T) {
 
 func TestAuthMiddleware_InvalidTokenRejectedEvenKeyless(t *testing.T) {
 	s := newTokenTestServer(t, true, "allow")
-	h := s.authMiddleware(s.identityEcho())
+	h := s.authMiddleware(s.identityEcho(), false)
 
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer not-a-real-token")
@@ -146,7 +161,7 @@ func TestAuthMiddleware_InvalidTokenRejectedEvenKeyless(t *testing.T) {
 
 func TestAuthMiddleware_RequiredPostureRejectsMissingToken(t *testing.T) {
 	s := newTokenTestServer(t, false, "deny")
-	h := s.authMiddleware(s.identityEcho())
+	h := s.authMiddleware(s.identityEcho(), true)
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mcp", nil))
@@ -167,7 +182,7 @@ func TestAuthMiddleware_RequiredPostureRejectsMissingToken(t *testing.T) {
 
 func TestAuthMiddleware_UnknownSubDenyIs403(t *testing.T) {
 	s := newTokenTestServer(t, false, "deny")
-	h := s.authMiddleware(s.identityEcho())
+	h := s.authMiddleware(s.identityEcho(), true)
 
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer "+mint(t, s, "nobody", ScopeFull))
@@ -181,7 +196,7 @@ func TestAuthMiddleware_UnknownSubDenyIs403(t *testing.T) {
 
 func TestAuthMiddleware_AnonymousTokenResolvesToDefault(t *testing.T) {
 	s := newTokenTestServer(t, true, "allow")
-	h := s.authMiddleware(s.identityEcho())
+	h := s.authMiddleware(s.identityEcho(), false)
 
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
 	req.Header.Set("Authorization", "Bearer "+mint(t, s, anonymousSubject, ScopeFull))

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -1316,7 +1316,7 @@ func (s *Server) ListenAndServe() error {
 				// Posture-aware bearer auth (§4): identity from a verified token
 				// (or anonymous) is placed on the request context, which the
 				// Streamable transport carries into the tool handler.
-				h := s.authMiddleware(mcpHandler)
+				h := s.authMiddleware(mcpHandler, s.config.MCPAuthRequired())
 				httpCfg.ExtraHandlers[mcpPath] = h
 				httpCfg.ExtraHandlers[mcpPath+"/"] = h
 				s.logger.Info("MCP endpoint mounted", "path", mcpPath, "http_port", s.config.HTTPPort)
@@ -1328,7 +1328,7 @@ func (s *Server) ListenAndServe() error {
 			if s.config.APIEnabled && s.config.APIPath != "" {
 				apiPath := "/" + strings.Trim(s.config.APIPath, "/")
 				api := NewMCPHTTPAPI(mcpServer)
-				httpCfg.ExtraHandlers[apiPath+"/"] = s.authMiddleware(api.Handler(apiPath))
+				httpCfg.ExtraHandlers[apiPath+"/"] = s.authMiddleware(api.Handler(apiPath), !s.config.AllowKeyless)
 				s.logger.Info("HTTP API mounted", "path", apiPath, "http_port", s.config.HTTPPort)
 			}
 


### PR DESCRIPTION
## Summary
- add an optional `mcp.require_auth` override for the SSH-derived authentication posture
- force OAuth discovery/browser login for the hosted OpenLore MCP endpoint while retaining keyless SSH
- reject `require_auth: true` when token issuance is not configured
- document true, false, and inherited behavior

## Testing
- `go test ./...`