### PR TITLE
fix(oauth): accept canonical root resource URI

### DIFF
--- a/pkg/openlore/authorize.go
+++ b/pkg/openlore/authorize.go
@@ -99,7 +99,7 @@ func (s *Server) authorizeHandler(w http.ResponseWriter, r *http.Request) {
 	// If a resource indicator (RFC 8707) is present it must name this instance's
 	// audience — the only resource OpenLore mints tokens for.
 	resource := q.Get("resource")
-	if resource != "" && s.config.Tokens != nil && resource != s.config.Tokens.Audience {
+	if resource != "" && s.config.Tokens != nil && !sameResourceIdentifier(resource, s.config.Tokens.Audience) {
 		http.Error(w, "resource does not match this server's audience", http.StatusBadRequest)
 		return
 	}
@@ -118,6 +118,35 @@ func (s *Server) authorizeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	id := s.authorizeReqs.put(req)
 	s.renderAuthorizeChoice(w, id)
+}
+
+// sameResourceIdentifier treats the two valid spellings of an origin URL as
+// equivalent: https://example.com and https://example.com/. OAuth clients such
+// as Claude canonicalize an advertised origin to the latter form. Paths other
+// than the root remain exact so this does not broaden a resource's boundary.
+func sameResourceIdentifier(a, b string) bool {
+	if a == b {
+		return true
+	}
+	au, err := url.Parse(a)
+	if err != nil || au.Scheme == "" || au.Host == "" || au.Opaque != "" || au.User != nil {
+		return false
+	}
+	bu, err := url.Parse(b)
+	if err != nil || bu.Scheme == "" || bu.Host == "" || bu.Opaque != "" || bu.User != nil {
+		return false
+	}
+	if au.Scheme != bu.Scheme || au.Host != bu.Host || au.RawQuery != bu.RawQuery || au.Fragment != bu.Fragment {
+		return false
+	}
+	ap, bp := au.EscapedPath(), bu.EscapedPath()
+	if ap == "" {
+		ap = "/"
+	}
+	if bp == "" {
+		bp = "/"
+	}
+	return ap == bp
 }
 
 // authorizePublicHandler serves POST /authorize/public: the "continue with

--- a/pkg/openlore/authorize_test.go
+++ b/pkg/openlore/authorize_test.go
@@ -66,6 +66,38 @@ func TestAuthorize_RendersChoicePageWithRequestID(t *testing.T) {
 	}
 }
 
+func TestAuthorize_AcceptsRootSlashResourceCanonicalization(t *testing.T) {
+	s := newTokenTestServer(t, true, "allow")
+	_, challenge := pkcePair()
+
+	rec, authz := runAuthorize(t, s, url.Values{
+		"response_type":         {"code"},
+		"redirect_uri":          {"http://127.0.0.1:52123/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"resource":              {s.config.Tokens.Audience + "/"},
+	})
+	if rec.Code != http.StatusOK || authz == "" {
+		t.Fatalf("status = %d, authz = %q; want accepted canonical resource; body=%s", rec.Code, authz, rec.Body.String())
+	}
+}
+
+func TestAuthorize_RejectsDifferentResourcePath(t *testing.T) {
+	s := newTokenTestServer(t, true, "allow")
+	_, challenge := pkcePair()
+
+	rec, _ := runAuthorize(t, s, url.Values{
+		"response_type":         {"code"},
+		"redirect_uri":          {"http://127.0.0.1:52123/callback"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"resource":              {s.config.Tokens.Audience + "/other"},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for a different resource path", rec.Code)
+	}
+}
+
 // TestAuthorize_PublicChoiceMintsAnonymousToken exercises the "continue with
 // public access" button: POST /authorize/public → redirect with code → token
 // exchange yields an anonymous, read-only token (§8.4).

--- a/pkg/openlore/tokenendpoint.go
+++ b/pkg/openlore/tokenendpoint.go
@@ -157,7 +157,7 @@ func (t *tokenEndpoint) handleAuthorizationCode(w http.ResponseWriter, r *http.R
 	}
 	// A resource indicator on the token request must match the one bound at
 	// /authorize (RFC 8707).
-	if reqResource := r.Form.Get("resource"); reqResource != "" && c.Resource != "" && reqResource != c.Resource {
+	if reqResource := r.Form.Get("resource"); reqResource != "" && c.Resource != "" && !sameResourceIdentifier(reqResource, c.Resource) {
 		oauthError(w, http.StatusBadRequest, "invalid_target", "resource mismatch")
 		return
 	}

--- a/pkg/openlore/tokenendpoint_test.go
+++ b/pkg/openlore/tokenendpoint_test.go
@@ -52,6 +52,24 @@ func TestTokenEndpoint_AuthorizationCodeGrant(t *testing.T) {
 	}
 }
 
+func TestTokenEndpoint_AcceptsEquivalentRootResource(t *testing.T) {
+	s := newTokenTestServer(t, true, "allow")
+	code := s.authCodes.Issue(authCode{
+		Subject:  "alice",
+		Scope:    ScopeFull,
+		Resource: s.config.Tokens.Audience + "/",
+	})
+
+	rec, _ := postForm(t, s.tokens, url.Values{
+		"grant_type": {"authorization_code"},
+		"code":       {code},
+		"resource":   {s.config.Tokens.Audience},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestTokenEndpoint_CodeIsSingleUse(t *testing.T) {
 	s := newTokenTestServer(t, true, "allow")
 	code, _ := s.IssueAuthCode("alice", ScopeFull)


### PR DESCRIPTION
## Summary
- accept `https://host` and `https://host/` as equivalent OAuth resource identifiers
- preserve exact matching for all non-root paths
- apply the comparison during both authorization and token exchange

Claude canonicalizes the protected resource origin to a trailing-slash URL, while OpenLore's configured audience and metadata currently use the no-slash form.

## Testing
- `go test ./...`