### PR TITLE
Preserve Markdown frontmatter formatting

### DIFF
--- a/internal/passkeys/browser.go
+++ b/internal/passkeys/browser.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/aakarim/go-openlore/pkg/okf"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
@@ -129,14 +130,24 @@ func isMarkdown(filePath string) bool {
 }
 
 func renderMarkdown(w http.ResponseWriter, source []byte) error {
+	frontmatter, markdown, hasFrontmatter := okf.SplitFrontmatter(source)
+	if !hasFrontmatter {
+		markdown = source
+	}
+
 	var rendered bytes.Buffer
 	md := goldmark.New(goldmark.WithExtensions(extension.GFM))
-	if err := md.Convert(source, &rendered); err != nil {
+	if err := md.Convert(markdown, &rendered); err != nil {
 		return err
 	}
 
+	var formattedFrontmatter string
+	if hasFrontmatter {
+		formattedFrontmatter = `<section class="frontmatter" aria-label="Frontmatter"><div class="frontmatter-title">Frontmatter</div><pre><code>` + html.EscapeString(strings.TrimSpace(string(frontmatter))) + `</code></pre></section>`
+	}
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := fmt.Fprintf(w, `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><base target="_top"><meta name="viewport" content="width=device-width, initial-scale=1"><style>:root{color-scheme:light dark}*{box-sizing:border-box}body{max-width:860px;margin:0 auto;padding:2.5rem 2rem;font:16px/1.65 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1f2328;background:#fff}h1,h2{border-bottom:1px solid #d0d7de;padding-bottom:.3em}h1,h2,h3,h4,h5,h6{line-height:1.25;margin:1.5em 0 .65em}h1:first-child{margin-top:0}a{color:#0969da}pre{overflow:auto;padding:1rem;border-radius:6px;background:#f6f8fa}code{font:85%% SFMono-Regular,Consolas,'Liberation Mono',monospace;background:#eff1f3;padding:.2em .4em;border-radius:4px}pre code{background:transparent;padding:0}blockquote{margin-left:0;padding-left:1em;border-left:4px solid #d0d7de;color:#59636e}img{max-width:100%%}table{border-collapse:collapse;display:block;overflow:auto}th,td{padding:.4rem .8rem;border:1px solid #d0d7de}tr:nth-child(2n){background:#f6f8fa}hr{border:0;border-top:1px solid #d0d7de}@media(prefers-color-scheme:dark){body{color:#e6edf3;background:#0d1117}a{color:#58a6ff}h1,h2,hr{border-color:#30363d}pre,code,tr:nth-child(2n){background:#161b22}blockquote{border-color:#3d444d;color:#9198a1}th,td{border-color:#3d444d}}</style></head><body>%s</body></html>`, rendered.String())
+	_, err := fmt.Fprintf(w, `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><base target="_top"><meta name="viewport" content="width=device-width, initial-scale=1"><style>:root{color-scheme:light dark}*{box-sizing:border-box}body{max-width:860px;margin:0 auto;padding:2.5rem 2rem;font:16px/1.65 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1f2328;background:#fff}h1,h2{border-bottom:1px solid #d0d7de;padding-bottom:.3em}h1,h2,h3,h4,h5,h6{line-height:1.25;margin:1.5em 0 .65em}h1:first-child{margin-top:0}a{color:#0969da}pre{overflow:auto;padding:1rem;border-radius:6px;background:#f6f8fa}code{font:85%% SFMono-Regular,Consolas,'Liberation Mono',monospace;background:#eff1f3;padding:.2em .4em;border-radius:4px}pre code{background:transparent;padding:0}.frontmatter{margin:0 0 2rem;border:1px solid #d0d7de;border-radius:6px;overflow:hidden}.frontmatter-title{padding:.45rem .8rem;border-bottom:1px solid #d0d7de;background:#f6f8fa;color:#59636e;font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em}.frontmatter pre{margin:0;border-radius:0}blockquote{margin-left:0;padding-left:1em;border-left:4px solid #d0d7de;color:#59636e}img{max-width:100%%}table{border-collapse:collapse;display:block;overflow:auto}th,td{padding:.4rem .8rem;border:1px solid #d0d7de}tr:nth-child(2n){background:#f6f8fa}hr{border:0;border-top:1px solid #d0d7de}@media(prefers-color-scheme:dark){body{color:#e6edf3;background:#0d1117}a{color:#58a6ff}h1,h2,hr{border-color:#30363d}pre,code,tr:nth-child(2n),.frontmatter-title{background:#161b22}.frontmatter,.frontmatter-title{border-color:#30363d}.frontmatter-title,blockquote{color:#9198a1}blockquote{border-color:#3d444d}th,td{border-color:#3d444d}}</style></head><body>%s%s</body></html>`, formattedFrontmatter, rendered.String())
 	return err
 }
 

--- a/internal/passkeys/browser.go
+++ b/internal/passkeys/browser.go
@@ -1,6 +1,7 @@
 package passkeys
 
 import (
+	"bytes"
 	"fmt"
 	"html"
 	"mime"
@@ -11,6 +12,8 @@ import (
 	"strings"
 
 	"github.com/aakarim/go-openlore/pkg/vfs"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
 )
 
 // LoreBrowserHandler serves an authenticated web browser over the filesystem.
@@ -67,6 +70,16 @@ func (p *Passkeys) LoreBrowserHandler(fsForIdentity func(identity string) vfs.Fi
 			http.NotFound(w, r)
 			return
 		}
+		if r.URL.Query().Get("raw") != "1" {
+			p.renderFile(w, r, lorePath, fsPath)
+			return
+		}
+		if isMarkdown(fsPath) {
+			if err := renderMarkdown(w, data); err != nil {
+				http.Error(w, "failed to render markdown", http.StatusInternalServerError)
+			}
+			return
+		}
 		ctype := mime.TypeByExtension(path.Ext(fsPath))
 		if ctype == "" {
 			ctype = "text/plain; charset=utf-8"
@@ -74,6 +87,57 @@ func (p *Passkeys) LoreBrowserHandler(fsForIdentity func(identity string) vfs.Fi
 		w.Header().Set("Content-Type", ctype)
 		w.Write(data)
 	})
+}
+
+func (p *Passkeys) renderFile(w http.ResponseWriter, r *http.Request, lorePath, fsPath string) {
+	parentURL := lorePath + path.Dir(fsPath)
+	if path.Dir(fsPath) == "/" {
+		parentURL += "/"
+	}
+
+	var crumbs strings.Builder
+	fmt.Fprintf(&crumbs, `<a href="%s/">Lore</a>`, html.EscapeString(strings.TrimRight(lorePath, "/")))
+	parts := strings.Split(strings.Trim(fsPath, "/"), "/")
+	for i, part := range parts {
+		crumbs.WriteString(`<span class="separator">/</span>`)
+		if i == len(parts)-1 {
+			fmt.Fprintf(&crumbs, `<span aria-current="page">%s</span>`, html.EscapeString(part))
+			continue
+		}
+		crumbPath := "/" + strings.Join(parts[:i+1], "/")
+		fmt.Fprintf(&crumbs, `<a href="%s%s/">%s</a>`, html.EscapeString(lorePath), html.EscapeString(crumbPath), html.EscapeString(part))
+	}
+
+	iframeURL := r.URL.EscapedPath() + "?raw=1"
+	name := path.Base(fsPath)
+	var b strings.Builder
+	b.WriteString(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">`)
+	b.WriteString(`<meta name="viewport" content="width=device-width, initial-scale=1">`)
+	fmt.Fprintf(&b, "<title>%s — OpenLore</title>", html.EscapeString(name))
+	b.WriteString(`<style>*{box-sizing:border-box}html,body{height:100%;margin:0}body{display:flex;flex-direction:column;background:#0d1117;color:#c9d1d9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif}.bar{height:3rem;flex:none;display:flex;align-items:center;gap:.65rem;padding:0 .85rem;border-bottom:1px solid #30363d;background:#161b22}.breadcrumbs{display:flex;align-items:center;gap:.5rem;min-width:0;overflow:hidden;white-space:nowrap;font-size:.9rem}.breadcrumbs a{color:#58a6ff;text-decoration:none}.breadcrumbs a:hover{text-decoration:underline}.breadcrumbs span[aria-current=page]{overflow:hidden;text-overflow:ellipsis;color:#c9d1d9}.separator{color:#6e7681}.close{display:grid;place-items:center;width:2rem;height:2rem;margin-left:auto;flex:none;border-radius:6px;color:#8b949e;text-decoration:none;font-size:1.35rem;line-height:1}.close:hover{background:#30363d;color:#f0f6fc}iframe{width:100%;flex:1;border:0;background:#fff}</style></head><body>`)
+	fmt.Fprintf(&b, `<nav class="bar" aria-label="File navigation"><div class="breadcrumbs">%s</div><a class="close" href="%s" aria-label="Close file and return to folder" title="Close">×</a></nav>`, crumbs.String(), html.EscapeString(parentURL))
+	fmt.Fprintf(&b, `<iframe src="%s" title="%s"></iframe>`, html.EscapeString(iframeURL), html.EscapeString(name))
+	b.WriteString(`</body></html>`)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(b.String()))
+}
+
+func isMarkdown(filePath string) bool {
+	ext := strings.ToLower(path.Ext(filePath))
+	return ext == ".md" || ext == ".markdown"
+}
+
+func renderMarkdown(w http.ResponseWriter, source []byte) error {
+	var rendered bytes.Buffer
+	md := goldmark.New(goldmark.WithExtensions(extension.GFM))
+	if err := md.Convert(source, &rendered); err != nil {
+		return err
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, err := fmt.Fprintf(w, `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><base target="_top"><meta name="viewport" content="width=device-width, initial-scale=1"><style>:root{color-scheme:light dark}*{box-sizing:border-box}body{max-width:860px;margin:0 auto;padding:2.5rem 2rem;font:16px/1.65 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1f2328;background:#fff}h1,h2{border-bottom:1px solid #d0d7de;padding-bottom:.3em}h1,h2,h3,h4,h5,h6{line-height:1.25;margin:1.5em 0 .65em}h1:first-child{margin-top:0}a{color:#0969da}pre{overflow:auto;padding:1rem;border-radius:6px;background:#f6f8fa}code{font:85%% SFMono-Regular,Consolas,'Liberation Mono',monospace;background:#eff1f3;padding:.2em .4em;border-radius:4px}pre code{background:transparent;padding:0}blockquote{margin-left:0;padding-left:1em;border-left:4px solid #d0d7de;color:#59636e}img{max-width:100%%}table{border-collapse:collapse;display:block;overflow:auto}th,td{padding:.4rem .8rem;border:1px solid #d0d7de}tr:nth-child(2n){background:#f6f8fa}hr{border:0;border-top:1px solid #d0d7de}@media(prefers-color-scheme:dark){body{color:#e6edf3;background:#0d1117}a{color:#58a6ff}h1,h2,hr{border-color:#30363d}pre,code,tr:nth-child(2n){background:#161b22}blockquote{border-color:#3d444d;color:#9198a1}th,td{border-color:#3d444d}}</style></head><body>%s</body></html>`, rendered.String())
+	return err
 }
 
 func (p *Passkeys) renderDir(w http.ResponseWriter, fsys vfs.FileSystem, lorePath, fsPath string) {

--- a/internal/passkeys/browser_test.go
+++ b/internal/passkeys/browser_test.go
@@ -29,17 +29,26 @@ func TestRenderFileIncludesBreadcrumbsIframeAndParentCloseLink(t *testing.T) {
 
 func TestRenderMarkdownFormatsGFMAndDoesNotRenderRawHTML(t *testing.T) {
 	rec := httptest.NewRecorder()
-	source := []byte("# Guide\n\n| A | B |\n| - | - |\n| one | two |\n\n<script>alert('no')</script>\n")
+	source := []byte("---\ntype: guide\ntags:\n  - setup\n  - web\n---\n# Guide\n\n| A | B |\n| - | - |\n| one | two |\n\n<script>alert('no')</script>\n")
 
 	if err := renderMarkdown(rec, source); err != nil {
 		t.Fatalf("renderMarkdown: %v", err)
 	}
 
 	body := rec.Body.String()
-	for _, want := range []string{"<h1>Guide</h1>", "<table>", `<base target="_top">`} {
+	for _, want := range []string{
+		"<h1>Guide</h1>",
+		"<table>",
+		`<base target="_top">`,
+		`<section class="frontmatter"`,
+		"type: guide\ntags:\n  - setup\n  - web",
+	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("rendered markdown missing %q", want)
 		}
+	}
+	if strings.Contains(body, "<hr>") {
+		t.Fatal("frontmatter delimiters must not be rendered as Markdown")
 	}
 	if strings.Contains(body, "<script>") {
 		t.Fatal("raw HTML must not be rendered into the markdown document")

--- a/internal/passkeys/browser_test.go
+++ b/internal/passkeys/browser_test.go
@@ -1,0 +1,50 @@
+package passkeys
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRenderFileIncludesBreadcrumbsIframeAndParentCloseLink(t *testing.T) {
+	pk := &Passkeys{}
+	req := httptest.NewRequest("GET", "/lore/guides/setup.md", nil)
+	rec := httptest.NewRecorder()
+
+	pk.renderFile(rec, req, "/lore", "/guides/setup.md")
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		`href="/lore/"`,
+		`href="/lore/guides/"`,
+		`aria-current="page">setup.md`,
+		`href="/lore/guides" aria-label="Close file and return to folder"`,
+		`src="/lore/guides/setup.md?raw=1"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("file view missing %q", want)
+		}
+	}
+}
+
+func TestRenderMarkdownFormatsGFMAndDoesNotRenderRawHTML(t *testing.T) {
+	rec := httptest.NewRecorder()
+	source := []byte("# Guide\n\n| A | B |\n| - | - |\n| one | two |\n\n<script>alert('no')</script>\n")
+
+	if err := renderMarkdown(rec, source); err != nil {
+		t.Fatalf("renderMarkdown: %v", err)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{"<h1>Guide</h1>", "<table>", `<base target="_top">`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered markdown missing %q", want)
+		}
+	}
+	if strings.Contains(body, "<script>") {
+		t.Fatal("raw HTML must not be rendered into the markdown document")
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- split YAML frontmatter from the Markdown body before rendering
- display frontmatter in a dedicated preformatted metadata panel
- keep nested YAML and list indentation intact
- prevent frontmatter delimiters from rendering as Markdown horizontal rules

## Verification

- ?   	github.com/aakarim/go-openlore/assets	[no test files]
ok  	github.com/aakarim/go-openlore/cmd/openlore	(cached)
ok  	github.com/aakarim/go-openlore/internal/config	(cached)
?   	github.com/aakarim/go-openlore/internal/httpserver	[no test files]
ok  	github.com/aakarim/go-openlore/internal/legal	(cached)
?   	github.com/aakarim/go-openlore/internal/metrics	[no test files]
ok  	github.com/aakarim/go-openlore/internal/passkeys	(cached)
?   	github.com/aakarim/go-openlore/internal/skills	[no test files]
ok  	github.com/aakarim/go-openlore/pkg/agentskills	(cached)
ok  	github.com/aakarim/go-openlore/pkg/okf	(cached)
ok  	github.com/aakarim/go-openlore/pkg/openlore	(cached)
ok  	github.com/aakarim/go-openlore/pkg/openlore/meta	(cached)
?   	github.com/aakarim/go-openlore/pkg/openlore/plugin	[no test files]
?   	github.com/aakarim/go-openlore/pkg/openlore/validation	[no test files]
?   	github.com/aakarim/go-openlore/pkg/shell	[no test files]
ok  	github.com/aakarim/go-openlore/pkg/shell/cmds	(cached)
ok  	github.com/aakarim/go-openlore/pkg/shell/parser	(cached)
ok  	github.com/aakarim/go-openlore/pkg/vfs	(cached)
- 