### PR TITLE
Mount admin configuration under /opt/openlore

### DIFF
--- a/docs/configuration-and-identity.md
+++ b/docs/configuration-and-identity.md
@@ -111,6 +111,13 @@ Docsets grant exact role names:
 Multiple roles contribute grants independently. Any matching docset deny wins.
 Capability allows form a union across roles, while any capability deny wins.
 
+The `admin` capability grants access to administrative commands and exposes the
+active configuration files at `/opt/openlore/lore.json` and
+`/opt/openlore/openlore.yml`. These mounted files are always read-only; use the
+corresponding OpenLore administration commands to modify configuration. The
+`/opt/openlore` directory is hidden from identities without `admin`, and the
+host configuration filenames are excluded from the ordinary lore tree.
+
 ## Docset paths
 
 Each docset exposes one or more virtual paths. A path may directly mount the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 // Config holds the resolved server configuration.
 type Config struct {
 	ConfigVersion   string
+	ConfigFile      string
 	Port            int
 	MetricsPort     int
 	HostKeyPath     string
@@ -448,6 +449,7 @@ func New(opts ...Option) (Config, error) {
 // no error is returned and the config is unchanged.
 func WithConfigFile(path string) Option {
 	return func(cfg *Config) error {
+		cfg.ConfigFile = path
 		data, err := os.ReadFile(path)
 		if err != nil {
 			if os.IsNotExist(err) {

--- a/pkg/openlore/authz.go
+++ b/pkg/openlore/authz.go
@@ -367,15 +367,17 @@ func (s *Server) grantsForPath(id Identity, p string) (config.DocsetSpec, []Gran
 	return ds, grants, len(grants) > 0
 }
 
-// allDocsetRoots returns the display roots of every configured docset — the full
-// set of access boundaries used to carve nested docsets out of ancestor grants
-// during read scoping.
-func (s *Server) allDocsetRoots() []string {
+// readBoundaries returns every path that carves its subtree out of an ancestor
+// docset grant. This includes all docsets and the admin-only config directory.
+func (s *Server) readBoundaries() []string {
 	var roots []string
 	for _, ds := range s.auth.Docsets {
 		for _, pm := range ds.Paths {
 			roots = append(roots, displayPath(pm))
 		}
+	}
+	if _, ok := s.merge.mounts["opt"]; ok {
+		roots = append(roots, "/opt/openlore")
 	}
 	return roots
 }
@@ -447,6 +449,15 @@ func (s *Server) readableRoots(id Identity) []string {
 		}
 	}
 	roots = append(roots, s.merge.SystemMountPaths()...)
+	var policy AuthorizationPolicy
+	if id.policySnapshot != nil {
+		policy = *id.policySnapshot
+	} else if current, err := s.currentPolicy(id); err == nil {
+		policy = current
+	}
+	if s.hasCapabilityForPolicy(policy, "admin") {
+		roots = append(roots, "/opt/openlore")
+	}
 	return roots
 }
 

--- a/pkg/openlore/rbac_test.go
+++ b/pkg/openlore/rbac_test.go
@@ -2,12 +2,14 @@ package openlore
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -236,5 +238,87 @@ func TestRBACCapabilityDenyAndRuntimeLookup(t *testing.T) {
 	store.policy.Roles = []string{"reader"}
 	if !s.hasCurrentCapability(id, "spawn") {
 		t.Fatal("capability checks must observe current role membership")
+	}
+}
+
+func TestAdminConfigMountIsRestrictedAndReadOnly(t *testing.T) {
+	root := t.TempDir()
+	loreFile := filepath.Join(root, "lore.json")
+	serverFile := filepath.Join(root, "openlore.yml")
+	lore := `{
+  "roles": {
+    "admins": {"allow": {"capabilities": ["admin"]}},
+    "members": {}
+  },
+  "docsets": {
+    "root": {
+      "paths": ["/"],
+      "access": {"allow": {"admins": "ro", "members": "ro"}}
+    }
+  },
+  "identities": [
+    {"name": "alice", "roles": ["admins"]},
+    {"name": "bob", "roles": ["members"]}
+  ]
+}`
+	if err := os.WriteFile(loreFile, []byte(lore), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(serverFile, []byte("version: \"1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewServer(root, WithConfigFile(serverFile), WithAuthFile(loreFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := func(name string) Identity {
+		return Identity{
+			IdentityName: name,
+			Principal:    AuthenticatedPrincipal{IdentityName: name},
+			Scopes:       []string{ScopeFull},
+		}
+	}
+
+	adminFS := s.buildSessionFS(identity("alice"))
+	for path, want := range map[string]string{
+		"/opt/openlore/lore.json":    lore,
+		"/opt/openlore/openlore.yml": "version: \"1\"\n",
+	} {
+		got, err := adminFS.ReadFile(path)
+		if err != nil || string(got) != want {
+			t.Fatalf("admin ReadFile(%s) = %q, %v", path, got, err)
+		}
+	}
+	if _, err := adminFS.ReadFile("/lore.json"); err == nil {
+		t.Fatal("host lore.json remained accessible through the ordinary lore tree")
+	}
+	if _, err := adminFS.ReadFile("/openlore.yml"); err == nil {
+		t.Fatal("host openlore.yml remained accessible through the ordinary lore tree")
+	}
+
+	nonAdminFS := s.buildSessionFS(identity("bob"))
+	for _, path := range []string{"/opt", "/opt/openlore", "/opt/openlore/lore.json", "/opt/openlore/openlore.yml"} {
+		if _, err := nonAdminFS.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("non-admin Stat(%s) error = %v, want not exist", path, err)
+		}
+	}
+
+	writable := adminFS.(vfs.WritableFS)
+	if _, err := writable.WriteFileAtomic("/opt/openlore/lore.json", []byte("{}"), vfs.WriteOpts{}); !errors.Is(err, vfs.ErrReadOnly) {
+		t.Fatalf("admin config write error = %v, want read-only", err)
+	}
+	if err := os.WriteFile(serverFile, []byte("version: \"2\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := adminFS.ReadFile("/opt/openlore/openlore.yml"); err != nil || string(got) != "version: \"2\"\n" {
+		t.Fatalf("mounted config did not reflect command-path update: %q, %v", got, err)
+	}
+
+	if !s.buildSessionShell(identity("alice")).ActionAllowed(cmds.ActionAdmin) {
+		t.Fatal("admin capability did not expose administrative commands")
+	}
+	if s.buildSessionShell(identity("bob")).ActionAllowed(cmds.ActionAdmin) {
+		t.Fatal("non-admin identity can invoke administrative commands")
 	}
 }

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -238,20 +239,30 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		}
 	}
 
+	// Keep the host configuration files out of the ordinary lore tree. Their
+	// canonical VFS location is the admin-only, read-only /opt/openlore mount.
+	servedFiles := cfg.Files
+	servedFiles.Denied = append([]string(nil), cfg.Files.Denied...)
+	for _, configFile := range []string{cfg.AuthFile, cfg.ConfigFile} {
+		if configFile != "" {
+			servedFiles.Denied = append(servedFiles.Denied, filepath.Base(configFile))
+		}
+	}
+
 	// Set up root directory. A caller-supplied rootFS wins (installed before the
 	// writable block so the write log has a live substrate); otherwise serve
 	// rootDir via a DirFS.
 	if rootFS != nil {
 		s.merge.SetRoot(rootFS)
 	} else if rootDir != "" {
-		dirFS := NewDirFS(rootDir, cfg.Files).WithDocsetRoots(docsetRoots)
+		dirFS := NewDirFS(rootDir, servedFiles).WithDocsetRoots(docsetRoots)
 		s.merge.SetRoot(dirFS)
 	} else if cfg.WritableDir != "" {
 		info, err := os.Stat(cfg.WritableDir)
 		if err != nil || !info.IsDir() {
 			return nil, fmt.Errorf("writable_dir %q is not a directory", cfg.WritableDir)
 		}
-		upper := NewDirFS(cfg.WritableDir, cfg.Files).WithDocsetRoots(docsetRoots)
+		upper := NewDirFS(cfg.WritableDir, servedFiles).WithDocsetRoots(docsetRoots)
 		if lowerFS != nil {
 			s.merge.SetRoot(NewOverlayFS(upper, lowerFS))
 		} else {
@@ -259,6 +270,15 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		}
 	} else if lowerFS != nil {
 		s.merge.SetRoot(lowerFS)
+	}
+
+	// Expose the active identity policy and server configuration at the
+	// conventional /opt/openlore path. The mount itself is physically read-only;
+	// admin commands modify the host files through their dedicated code paths.
+	// Session read scoping below makes the mount visible only to identities with
+	// the explicit "admin" capability.
+	if s.authEnforced && (cfg.AuthFile != "" || cfg.ConfigFile != "") {
+		s.merge.Mount("opt", newConfigFilesFS(cfg.AuthFile, cfg.ConfigFile))
 	}
 
 	// Enable the experimental writable substrate when the global lock is open.
@@ -797,7 +817,7 @@ func (s *Server) buildCanonicalSessionFS(id Identity) vfs.FileSystem {
 	// unenforced/trusted mode the session sees the whole merge FS (all mounts).
 	sessionFS := vfs.FileSystem(s.merge)
 	if s.authEnforced {
-		sessionFS = newScopedReadFS(sessionFS, s.readableRoots(id), s.allDocsetRoots())
+		sessionFS = newScopedReadFS(sessionFS, s.readableRoots(id), s.readBoundaries())
 	}
 	// Read (before-read) gate: run the read middleware chain in front of every
 	// Stat/ReadDir/ReadFile so a plugin can (e.g.) refresh the substrate or
@@ -897,21 +917,26 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 	// an unrecognized/guest identity is read-only; a recognized
 	// identity may write and publish within its docsets.
 	if s.authEnforced {
+		allowed := []cmds.Action{}
 		if canWrite {
-			allowed := []cmds.Action{cmds.ActionWrite, cmds.ActionPublish}
+			allowed = append(allowed, cmds.ActionWrite, cmds.ActionPublish)
 			// spawn runs an external command as the OpenLore service
 			// user, so it's gated on an explicit `spawn` capability
 			// (Part D) — never granted to ordinary writers.
 			if s.hasCapabilityForPolicy(*id.policySnapshot, "spawn") {
 				allowed = append(allowed, cmds.ActionSpawn)
 			}
-			sh.SetAllowedActions(allowed)
-		} else {
-			sh.SetAllowedActions(nil) // read-only (ActionRead implied)
 		}
+		if s.hasCapabilityForPolicy(*id.policySnapshot, "admin") {
+			allowed = append(allowed, cmds.ActionAdmin)
+		}
+		sh.SetAllowedActions(allowed)
 		sh.SetActionAuthorizer(func(action cmds.Action) bool {
-			if action == cmds.ActionSpawn {
+			switch action {
+			case cmds.ActionSpawn:
 				return s.hasCurrentCapability(id, "spawn")
+			case cmds.ActionAdmin:
+				return s.hasCurrentCapability(id, "admin")
 			}
 			return true
 		})

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -622,6 +623,94 @@ func (d *DirFS) ReadFile(p string) ([]byte, error) {
 
 	full := d.resolve(p)
 	return os.ReadFile(full)
+}
+
+// configFilesFS exposes the active host configuration files under the fixed
+// /openlore directory of its mount. It deliberately implements only
+// vfs.FileSystem: configuration remains read-only through the VFS while the
+// dedicated administration commands continue to update the host files.
+type configFilesFS struct {
+	files map[string]string
+}
+
+func newConfigFilesFS(loreFile, serverFile string) *configFilesFS {
+	files := map[string]string{}
+	if loreFile != "" {
+		files["lore.json"] = loreFile
+	}
+	if serverFile != "" {
+		files["openlore.yml"] = serverFile
+	}
+	return &configFilesFS{files: files}
+}
+
+func (c *configFilesFS) Stat(p string) (*vfs.FileInfo, error) {
+	clean := vfs.CleanPath(p)
+	if clean == "/" || clean == "/openlore" {
+		name := "/"
+		if clean == "/openlore" {
+			name = "openlore"
+		}
+		return &vfs.FileInfo{FileName: name, FilePath: clean, Dir: true}, nil
+	}
+	name, hostPath, ok := c.resolve(clean)
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	info, err := os.Stat(hostPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, os.ErrNotExist
+	}
+	return &vfs.FileInfo{
+		FileName:    name,
+		FilePath:    clean,
+		FileSize:    info.Size(),
+		FileModTime: info.ModTime(),
+	}, nil
+}
+
+func (c *configFilesFS) ReadDir(p string) ([]vfs.FileInfo, error) {
+	clean := vfs.CleanPath(p)
+	switch clean {
+	case "/":
+		return []vfs.FileInfo{{FileName: "openlore", FilePath: "/openlore", Dir: true}}, nil
+	case "/openlore":
+		var entries []vfs.FileInfo
+		for name := range c.files {
+			info, err := c.Stat("/openlore/" + name)
+			if err == nil {
+				entries = append(entries, *info)
+			}
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].FileName < entries[j].FileName })
+		return entries, nil
+	default:
+		return nil, os.ErrNotExist
+	}
+}
+
+func (c *configFilesFS) ReadFile(p string) ([]byte, error) {
+	_, hostPath, ok := c.resolve(vfs.CleanPath(p))
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return os.ReadFile(hostPath)
+}
+
+func (c *configFilesFS) resolve(p string) (string, string, bool) {
+	const prefix = "/openlore/"
+	if !strings.HasPrefix(p, prefix) {
+		return "", "", false
+	}
+	name := strings.TrimPrefix(p, prefix)
+	if name == "" || strings.Contains(name, "/") {
+		return "", "", false
+	}
+	hostPath, ok := c.files[name]
+	return name, hostPath, ok
 }
 
 // MergeFS merges multiple filesystems under named mount points.


### PR DESCRIPTION
## Summary

- mount the active lore policy and server config at `/opt/openlore/lore.json` and `/opt/openlore/openlore.yml`
- restrict the mount and admin-class commands to identities with the explicit `admin` capability
- keep mounted configuration read-only while reflecting changes made through dedicated administration commands
- exclude active configuration filenames from the ordinary lore tree to prevent root-docset bypasses
- document the admin capability behavior

## Testing

- `go test ./...`
- `git diff --check`