### PR TITLE
Warn when validation has no validators

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,7 +91,9 @@ metrics/revenue.md:15:8: warning [openlore/alias-target] link targets aliased do
   be portable to a server with different aliases.
 
 The command does not fetch URLs. Errors produce a non-zero exit status; warnings
-alone do not.
+alone do not. If no validator plugin is enabled, the command exits non-zero with
+`lore validate: no validators enabled` rather than reporting an empty scan as
+valid.
 
 ## Metadata queries with `lore meta`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -91,9 +91,9 @@ metrics/revenue.md:15:8: warning [openlore/alias-target] link targets aliased do
   be portable to a server with different aliases.
 
 The command does not fetch URLs. Errors produce a non-zero exit status; warnings
-alone do not. If no validator plugin is enabled, the command exits non-zero with
-`lore validate: no validators enabled` rather than reporting an empty scan as
-valid.
+alone do not. If no validator plugin is enabled, the command emits
+`lore validate: warning: no validators enabled` rather than reporting an empty
+scan as valid.
 
 ## Metadata queries with `lore meta`
 

--- a/pkg/openlore/okf_plugin_test.go
+++ b/pkg/openlore/okf_plugin_test.go
@@ -450,13 +450,15 @@ func TestRegisterPlugin_ValidateCommandIsCoreAndValidatorsAreSessionLocal(t *tes
 	}
 	withOut.Reset()
 	withoutOut.Reset()
+	errOut.Reset()
 	if code := withShell.ExecPipeline("lore validate", &withOut, &errOut, nil); code != 1 {
 		t.Fatalf("with plugin exit=%d, want 1: %s", code, withOut.String())
 	}
-	if code := withoutShell.ExecPipeline("lore validate", &withoutOut, &errOut, nil); code != 0 {
-		t.Fatalf("without plugin exit=%d, want 0: %s", code, withoutOut.String())
+	errOut.Reset()
+	if code := withoutShell.ExecPipeline("lore validate", &withoutOut, &errOut, nil); code != 1 {
+		t.Fatalf("without plugin exit=%d, want 1: %s", code, errOut.String())
 	}
-	if !strings.Contains(withOut.String(), "okf/concept") || withoutOut.String() != "0 errors, 0 warnings\n" {
-		t.Fatalf("validators not session-local: with=%q without=%q", withOut.String(), withoutOut.String())
+	if !strings.Contains(withOut.String(), "okf/concept") || withoutOut.String() != "" || !strings.Contains(errOut.String(), "no validators enabled") {
+		t.Fatalf("validators not session-local: with=%q without=%q stderr=%q", withOut.String(), withoutOut.String(), errOut.String())
 	}
 }

--- a/pkg/openlore/okf_plugin_test.go
+++ b/pkg/openlore/okf_plugin_test.go
@@ -455,10 +455,10 @@ func TestRegisterPlugin_ValidateCommandIsCoreAndValidatorsAreSessionLocal(t *tes
 		t.Fatalf("with plugin exit=%d, want 1: %s", code, withOut.String())
 	}
 	errOut.Reset()
-	if code := withoutShell.ExecPipeline("lore validate", &withoutOut, &errOut, nil); code != 1 {
-		t.Fatalf("without plugin exit=%d, want 1: %s", code, errOut.String())
+	if code := withoutShell.ExecPipeline("lore validate", &withoutOut, &errOut, nil); code != 0 {
+		t.Fatalf("without plugin exit=%d, want 0: %s", code, errOut.String())
 	}
-	if !strings.Contains(withOut.String(), "okf/concept") || withoutOut.String() != "" || !strings.Contains(errOut.String(), "no validators enabled") {
+	if !strings.Contains(withOut.String(), "okf/concept") || withoutOut.String() != "" || !strings.Contains(errOut.String(), "warning: no validators enabled") {
 		t.Fatalf("validators not session-local: with=%q without=%q stderr=%q", withOut.String(), withoutOut.String(), errOut.String())
 	}
 }

--- a/pkg/shell/cmds/lore_test.go
+++ b/pkg/shell/cmds/lore_test.go
@@ -99,14 +99,14 @@ func TestLoreDocsets_GrepByAttribute(t *testing.T) {
 	}
 }
 
-func TestLoreValidate_RequiresEnabledValidator(t *testing.T) {
+func TestLoreValidate_WarnsWithoutEnabledValidator(t *testing.T) {
 	sh := shell.NewShell(testFS())
 	var out, errOut bytes.Buffer
 	code := sh.ExecPipeline("lore validate /docs", &out, &errOut, nil)
-	if code != 1 {
-		t.Fatalf("exit = %d, want 1", code)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
 	}
-	if out.String() != "" || !strings.Contains(errOut.String(), "no validators enabled") {
+	if out.String() != "" || !strings.Contains(errOut.String(), "warning: no validators enabled") {
 		t.Fatalf("stdout=%q stderr=%q", out.String(), errOut.String())
 	}
 }

--- a/pkg/shell/cmds/lore_test.go
+++ b/pkg/shell/cmds/lore_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 )
@@ -95,5 +96,32 @@ func TestLoreDocsets_GrepByAttribute(t *testing.T) {
 	}
 	if !strings.Contains(out, "backend") || strings.Contains(out, "public ") {
 		t.Fatalf("grep inbox should return only the backend row, got:\n%s", out)
+	}
+}
+
+func TestLoreValidate_RequiresEnabledValidator(t *testing.T) {
+	sh := shell.NewShell(testFS())
+	var out, errOut bytes.Buffer
+	code := sh.ExecPipeline("lore validate /docs", &out, &errOut, nil)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if out.String() != "" || !strings.Contains(errOut.String(), "no validators enabled") {
+		t.Fatalf("stdout=%q stderr=%q", out.String(), errOut.String())
+	}
+}
+
+func TestLoreValidate_RunsEnabledValidator(t *testing.T) {
+	sh := shell.NewShell(testFS())
+	sh.SetValidators([]validation.Validator{func(validation.Bundle) []validation.Diagnostic {
+		return nil
+	}})
+	var out, errOut bytes.Buffer
+	code := sh.ExecPipeline("lore validate /docs", &out, &errOut, nil)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errOut.String())
+	}
+	if out.String() != "0 errors, 0 warnings\n" {
+		t.Fatalf("stdout=%q", out.String())
 	}
 }

--- a/pkg/shell/cmds/lore_validate.go
+++ b/pkg/shell/cmds/lore_validate.go
@@ -35,8 +35,8 @@ func cmdLoreValidate(ctx CmdContext, args []string, w io.Writer, errW io.Writer,
 
 	validators := ctx.Validators()
 	if len(validators) == 0 {
-		fmt.Fprintln(errW, "lore validate: no validators enabled")
-		return 1
+		fmt.Fprintln(errW, "lore validate: warning: no validators enabled")
+		return 0
 	}
 	diagnostics, err := validation.Scan(ctx.FS(), root, validators...)
 	if err != nil {

--- a/pkg/shell/cmds/lore_validate.go
+++ b/pkg/shell/cmds/lore_validate.go
@@ -33,7 +33,12 @@ func cmdLoreValidate(ctx CmdContext, args []string, w io.Writer, errW io.Writer,
 		return 1
 	}
 
-	diagnostics, err := validation.Scan(ctx.FS(), root, ctx.Validators()...)
+	validators := ctx.Validators()
+	if len(validators) == 0 {
+		fmt.Fprintln(errW, "lore validate: no validators enabled")
+		return 1
+	}
+	diagnostics, err := validation.Scan(ctx.FS(), root, validators...)
 	if err != nil {
 		fmt.Fprintf(errW, "lore validate: %s\n", err)
 		return 1


### PR DESCRIPTION
## Summary
- make `lore validate` emit a clear warning when no validator plugin is enabled
- avoid reporting an empty validator scan as `0 errors, 0 warnings`
- keep warnings non-fatal with a zero exit status
- document the behavior and cover both enabled and disabled validator cases

## Verification
- `go test ./...`
- `git diff --check`

## Production follow-up already completed
- enabled enforced OKF validation on seven validated production bundle roots
- fixed invalid frontmatter on the company-timeline nested `events/index.md`
- converted the company-timeline `log.md` to OKF date sections
- verified malformed writes are rejected before reaching disk

The production policy and knowledge-file changes are host-local and are intentionally not included in this PR.