### PR TITLE
Add recursive rg command and benchmark corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 # Built binaries
 /openlore
 /lix
+
+# Local recursive-search benchmark data
+/.benchdata/
+/bench-results/

--- a/benchmarks/recursive-rg.md
+++ b/benchmarks/recursive-rg.md
@@ -1,0 +1,49 @@
+# Recursive `rg` optimization benchmark
+
+This experiment starts with the intentionally naive `Ripgrep` function in
+`pkg/shell/cmds/rg.go`. It collects and sorts every path, reads complete files,
+splits each file into lines, and searches sequentially. Optimize the real work;
+artificial delays and benchmark-specific shortcuts are forbidden.
+
+## Corpora
+
+Run:
+
+```bash
+./scripts/fetch-rg-corpus.sh
+```
+
+The primary corpus is the English Markdown from
+[MDN content](https://github.com/mdn/content), pinned to commit
+`c808a24d4e4f7bda00e7117f315965ed39b780e5`. It contains more than 14,000
+Markdown files and roughly 59 MB of content. The checkout retains MDN's
+`LICENSE.md`; corpus files are downloaded locally and are not committed.
+
+Ripgrep's own `tests/data` is deliberately not used: it has only a handful of
+flat functional fixtures. The setup also generates 4,096 Markdown files spread
+over a 64-level tree to isolate recursive traversal costs.
+
+## Measurement
+
+```bash
+OPENLORE_RG_CORPUS="$PWD/.benchdata/mdn-content/files/en-us" \
+  ./scripts/benchmark-rg.sh baseline-mdn
+
+# After changing the implementation:
+OPENLORE_RG_CORPUS="$PWD/.benchdata/mdn-content/files/en-us" \
+  ./scripts/benchmark-rg.sh candidate-mdn
+```
+
+The benchmark fixes `GOMAXPROCS=1`, uses warm filesystem caches, runs each case
+ten times, and records `ns/op`, throughput, allocations, Go version, host, and
+commit. Compare complete samples with `benchstat`; do not compare best runs.
+
+```bash
+go run golang.org/x/perf/cmd/benchstat@latest \
+  bench-results/baseline-mdn.txt bench-results/candidate-mdn.txt
+```
+
+A candidate is valid only if `go test ./...` and `go test -race
+./pkg/shell/cmds -run Rg` pass and command output remains byte-for-byte stable.
+Prefer improvements whose confidence interval excludes zero and reject a
+headline win that regresses any primary workload by more than 5%.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,6 +23,7 @@ Run `help` in a session for the command list available on that server.
 | Command | Description |
 |---|---|
 | `grep` | Search patterns (`-i`, `-n`, `-r`, `-v`, `-c`, `-l`, `-o`, `-L`, `-w`, `-x`, `-m`) |
+| `rg` | Recursively search files with deterministic output (`-i`, `-n`, `-l`) |
 | `find` | Find files (`-name`, `-type f\|d`) |
 
 ## Text processing

--- a/pkg/shell/cmds/help.go
+++ b/pkg/shell/cmds/help.go
@@ -21,6 +21,7 @@ func CmdHelp(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin i
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "SEARCH")
 	fmt.Fprintln(w, "  grep [-inrvcloLwxm] <pattern> [path]    Search for pattern in files")
+	fmt.Fprintln(w, "  rg [-inl] <pattern> [path ...]          Recursively search files")
 	fmt.Fprintln(w, "  find [path] [-name pat] [-type f|d]     Find files")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "TEXT PROCESSING")

--- a/pkg/shell/cmds/registry.go
+++ b/pkg/shell/cmds/registry.go
@@ -18,6 +18,7 @@ func init() {
 	Register("tail", CmdTail)
 	Register("find", CmdFind)
 	Register("grep", CmdGrep)
+	Register("rg", CmdRg)
 	Register("wc", CmdWc)
 	Register("cd", CmdCd)
 	Register("tree", CmdTree)

--- a/pkg/shell/cmds/rg.go
+++ b/pkg/shell/cmds/rg.go
@@ -1,0 +1,165 @@
+package cmds
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+// RipgrepOptions is the deliberately small behavior surface of Ripgrep.
+// The implementation is intentionally naive: it collects and sorts every
+// path, reads each complete file, splits it into lines, and searches files
+// sequentially. The recursive-search experiment asks agents to make this
+// faster without changing its observable behavior.
+type RipgrepOptions struct {
+	CaseInsensitive  bool
+	LineNumbers      bool
+	FilesWithMatches bool
+}
+
+// RipgrepMatch is one matching line. In FilesWithMatches mode, LineNumber and
+// Line identify the first match but callers should render only Path.
+type RipgrepMatch struct {
+	Path       string
+	LineNumber int
+	Line       string
+}
+
+// Ripgrep recursively searches roots in fsys. Results are ordered by path and
+// then line number, independent of filesystem traversal order.
+func Ripgrep(fsys vfs.FileSystem, roots []string, pattern string, opts RipgrepOptions) ([]RipgrepMatch, error) {
+	if opts.CaseInsensitive {
+		pattern = "(?i)" + pattern
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pattern: %w", err)
+	}
+
+	seenRoots := make(map[string]struct{}, len(roots))
+	var files []string
+	for _, root := range roots {
+		root = vfs.CleanPath(root)
+		if _, ok := seenRoots[root]; ok {
+			continue
+		}
+		seenRoots[root] = struct{}{}
+
+		info, err := fsys.Stat(root)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", root, err)
+		}
+		if !info.Dir {
+			files = append(files, root)
+			continue
+		}
+		if err := vfs.WalkDir(fsys, root, func(path string, info *vfs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.Dir {
+				files = append(files, path)
+			}
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("%s: %w", root, err)
+		}
+	}
+	sort.Strings(files)
+
+	var matches []RipgrepMatch
+	for _, file := range files {
+		data, err := fsys.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", file, err)
+		}
+		if len(data) == 0 {
+			continue
+		}
+		lines := strings.Split(string(data), "\n")
+		if lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+		for i, line := range lines {
+			line = strings.TrimSuffix(line, "\r")
+			if !re.MatchString(line) {
+				continue
+			}
+			matches = append(matches, RipgrepMatch{Path: file, LineNumber: i + 1, Line: line})
+			if opts.FilesWithMatches {
+				break
+			}
+		}
+	}
+	return matches, nil
+}
+
+// CmdRg implements a focused recursive search command:
+//
+//	rg [-i] [-n] [-l] PATTERN [PATH ...]
+func CmdRg(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
+	var opts RipgrepOptions
+	var pattern string
+	var targets []string
+	options := true
+
+	for _, arg := range args {
+		if options && arg == "--" {
+			options = false
+			continue
+		}
+		if options && strings.HasPrefix(arg, "-") && arg != "-" {
+			for _, flag := range arg[1:] {
+				switch flag {
+				case 'i':
+					opts.CaseInsensitive = true
+				case 'n':
+					opts.LineNumbers = true
+				case 'l':
+					opts.FilesWithMatches = true
+				default:
+					fmt.Fprintf(errW, "rg: unknown option: -%c\n", flag)
+					return 2
+				}
+			}
+			continue
+		}
+		options = false
+		if pattern == "" {
+			pattern = arg
+		} else {
+			targets = append(targets, ctx.Resolve(arg))
+		}
+	}
+
+	if pattern == "" {
+		fmt.Fprintln(errW, "rg: missing pattern")
+		return 2
+	}
+	if len(targets) == 0 {
+		targets = []string{ctx.Cwd()}
+	}
+
+	matches, err := Ripgrep(ctx.FS(), targets, pattern, opts)
+	if err != nil {
+		fmt.Fprintf(errW, "rg: %v\n", err)
+		return 2
+	}
+	for _, match := range matches {
+		if opts.FilesWithMatches {
+			fmt.Fprintln(w, match.Path)
+		} else if opts.LineNumbers {
+			fmt.Fprintf(w, "%s:%d:%s\n", match.Path, match.LineNumber, match.Line)
+		} else {
+			fmt.Fprintf(w, "%s:%s\n", match.Path, match.Line)
+		}
+	}
+	if len(matches) == 0 {
+		return 1
+	}
+	return 0
+}

--- a/pkg/shell/cmds/rg_benchmark_test.go
+++ b/pkg/shell/cmds/rg_benchmark_test.go
@@ -1,0 +1,125 @@
+package cmds
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+var benchmarkMatches []RipgrepMatch
+
+type benchmarkDiskFS struct {
+	root string
+}
+
+func (f benchmarkDiskFS) hostPath(p string) string {
+	p = vfs.CleanPath(p)
+	if p == "/" {
+		return f.root
+	}
+	return filepath.Join(f.root, filepath.FromSlash(p[1:]))
+}
+
+func (f benchmarkDiskFS) Stat(p string) (*vfs.FileInfo, error) {
+	info, err := os.Stat(f.hostPath(p))
+	if err != nil {
+		return nil, err
+	}
+	return &vfs.FileInfo{FileName: info.Name(), FilePath: vfs.CleanPath(p), Dir: info.IsDir(), FileModTime: info.ModTime(), FileSize: info.Size()}, nil
+}
+
+func (f benchmarkDiskFS) ReadDir(p string) ([]vfs.FileInfo, error) {
+	entries, err := os.ReadDir(f.hostPath(p))
+	if err != nil {
+		return nil, err
+	}
+	result := make([]vfs.FileInfo, 0, len(entries))
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		if !entry.IsDir() && filepath.Ext(entry.Name()) != ".md" {
+			continue
+		}
+		result = append(result, vfs.FileInfo{FileName: entry.Name(), FilePath: vfs.CleanPath(p + "/" + entry.Name()), Dir: entry.IsDir(), FileModTime: info.ModTime(), FileSize: info.Size()})
+	}
+	return result, nil
+}
+
+func (f benchmarkDiskFS) ReadFile(p string) ([]byte, error) {
+	return os.ReadFile(f.hostPath(p))
+}
+
+func BenchmarkRipgrepCorpus(b *testing.B) {
+	root := os.Getenv("OPENLORE_RG_CORPUS")
+	if root == "" {
+		b.Skip("set OPENLORE_RG_CORPUS to a prepared corpus directory")
+	}
+	root, err := filepath.Abs(root)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	var bytes int64
+	var files int64
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if filepath.Ext(entry.Name()) != ".md" {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		bytes += info.Size()
+		files++
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if files == 0 {
+		b.Fatal("corpus has no files")
+	}
+
+	fsys := benchmarkDiskFS{root: root}
+	cases := []struct {
+		name    string
+		pattern string
+		opts    RipgrepOptions
+	}{
+		{name: "miss", pattern: "OPENLORE_RG_NOT_PRESENT_7f42c19b"},
+		{name: "rare-literal", pattern: "AbortController"},
+		{name: "common-insensitive", pattern: "javascript", opts: RipgrepOptions{CaseInsensitive: true}},
+		{name: "heading-regex", pattern: `^#{2,4} `, opts: RipgrepOptions{LineNumbers: true}},
+		{name: "files-with-matches", pattern: "javascript", opts: RipgrepOptions{FilesWithMatches: true}},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			if _, err := regexp.Compile(tc.pattern); err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.SetBytes(bytes)
+			b.ReportMetric(float64(files), "files/op")
+			for b.Loop() {
+				matches, err := Ripgrep(fsys, []string{"/"}, tc.pattern, tc.opts)
+				if err != nil {
+					b.Fatal(fmt.Errorf("searching corpus: %w", err))
+				}
+				benchmarkMatches = matches
+			}
+		})
+	}
+}

--- a/pkg/shell/cmds/rg_test.go
+++ b/pkg/shell/cmds/rg_test.go
@@ -1,0 +1,82 @@
+package cmds_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRgRecursiveOrderingAndLineNumbers(t *testing.T) {
+	fs := newMapFS()
+	fs.AddDir("/")
+	fs.AddDir("/docs")
+	fs.AddDir("/docs/deep")
+	fs.AddFile("/docs/z.md", "zero\nNeedle last\n")
+	fs.AddFile("/docs/deep/a.md", "needle first\nother\n")
+
+	out, errOut, code := execCmd(t, fs, "rg -in needle /docs")
+	if code != 0 || errOut != "" {
+		t.Fatalf("rg failed: code=%d stderr=%q", code, errOut)
+	}
+	want := "/docs/deep/a.md:1:needle first\n/docs/z.md:2:Needle last\n"
+	if out != want {
+		t.Fatalf("output mismatch:\n got %q\nwant %q", out, want)
+	}
+}
+
+func TestRgFilesWithMatchesAndDuplicateRoots(t *testing.T) {
+	fs := testFS()
+	out, errOut, code := execCmd(t, fs, "rg -l apple /docs /docs")
+	if code != 0 || errOut != "" {
+		t.Fatalf("rg failed: code=%d stderr=%q", code, errOut)
+	}
+	if out != "/docs/notes.txt\n/docs/sorted1.txt\n" {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestRgNoMatchAndErrors(t *testing.T) {
+	fs := testFS()
+
+	t.Run("no match", func(t *testing.T) {
+		out, errOut, code := execCmd(t, fs, "rg absent /docs")
+		if code != 1 || out != "" || errOut != "" {
+			t.Fatalf("code=%d stdout=%q stderr=%q", code, out, errOut)
+		}
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		out, errOut, code := execCmd(t, fs, "rg '[' /docs")
+		if code != 2 || out != "" || !strings.Contains(errOut, "rg: invalid pattern:") {
+			t.Fatalf("code=%d stdout=%q stderr=%q", code, out, errOut)
+		}
+	})
+
+	t.Run("unknown flag", func(t *testing.T) {
+		out, errOut, code := execCmd(t, fs, "rg -x apple /docs")
+		if code != 2 || out != "" || errOut != "rg: unknown option: -x\n" {
+			t.Fatalf("code=%d stdout=%q stderr=%q", code, out, errOut)
+		}
+	})
+
+	t.Run("missing path is atomic", func(t *testing.T) {
+		out, _, code := execCmd(t, fs, "rg apple /docs/notes.txt /missing")
+		if code != 2 || out != "" {
+			t.Fatalf("code=%d stdout=%q", code, out)
+		}
+	})
+}
+
+func TestRgLineEndingsAndLongLine(t *testing.T) {
+	fs := newMapFS()
+	fs.AddDir("/")
+	fs.AddFile("/lines.md", "windows needle\r\n"+strings.Repeat("x", 128<<10)+" needle")
+
+	out, errOut, code := execCmd(t, fs, "rg -n needle /lines.md")
+	if code != 0 || errOut != "" {
+		t.Fatalf("rg failed: code=%d stderr=%q", code, errOut)
+	}
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if len(lines) != 2 || strings.Contains(lines[0], "\r") || !strings.HasPrefix(lines[1], "/lines.md:2:") {
+		t.Fatalf("unexpected output shape: first=%q lines=%d", lines[0], len(lines))
+	}
+}

--- a/scripts/benchmark-rg.sh
+++ b/scripts/benchmark-rg.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+corpus=${OPENLORE_RG_CORPUS:-}
+label=${1:-candidate}
+
+if [[ -z "$corpus" || ! -d "$corpus" ]]; then
+  echo "OPENLORE_RG_CORPUS must name a prepared corpus directory" >&2
+  echo "Run ./scripts/fetch-rg-corpus.sh first." >&2
+  exit 2
+fi
+
+mkdir -p "$repo_root/bench-results"
+output="$repo_root/bench-results/$label.txt"
+
+{
+  echo "go: $(go version)"
+  echo "commit: $(git -C "$repo_root" rev-parse HEAD)"
+  echo "corpus: $(cd "$corpus" && pwd)"
+  echo "os: $(uname -a)"
+  echo
+  OPENLORE_RG_CORPUS="$corpus" GOMAXPROCS=1 \
+    go test ./pkg/shell/cmds -run '^$' -bench '^BenchmarkRipgrepCorpus/' \
+      -benchmem -benchtime=3x -count=10
+} | tee "$output"
+
+echo "Wrote $output"

--- a/scripts/fetch-rg-corpus.sh
+++ b/scripts/fetch-rg-corpus.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+data_root="$repo_root/.benchdata"
+mdn_root="$data_root/mdn-content"
+deep_root="$data_root/deep-markdown"
+mdn_commit=c808a24d4e4f7bda00e7117f315965ed39b780e5
+
+mkdir -p "$data_root"
+
+if [[ ! -d "$mdn_root/.git" ]]; then
+  git init -q "$mdn_root"
+  git -C "$mdn_root" remote add origin https://github.com/mdn/content.git
+  git -C "$mdn_root" sparse-checkout init --no-cone
+  printf '/files/en-us/\n/LICENSE.md\n' >"$mdn_root/.git/info/sparse-checkout"
+fi
+
+if [[ "$(git -C "$mdn_root" rev-parse HEAD 2>/dev/null || true)" != "$mdn_commit" ]]; then
+  git -C "$mdn_root" fetch --depth=1 origin "$mdn_commit"
+  git -C "$mdn_root" checkout -q --detach FETCH_HEAD
+fi
+
+actual=$(git -C "$mdn_root" rev-parse HEAD)
+[[ "$actual" == "$mdn_commit" ]] || {
+  echo "MDN commit mismatch: got $actual, want $mdn_commit" >&2
+  exit 1
+}
+
+rm -rf "$deep_root"
+DEEP_ROOT="$deep_root" python3 <<'PY'
+import os
+from pathlib import Path
+
+root = Path(os.environ["DEEP_ROOT"])
+path = root
+payload = "OpenLore recursive search benchmark. javascript markdown content.\n" + ("x" * 1984) + "\n"
+for depth in range(64):
+    path = path / f"d{depth:02d}"
+    path.mkdir(parents=True)
+    for leaf in range(64):
+        marker = "deepest-sentinel\n" if depth == 63 and leaf == 63 else ""
+        (path / f"document-{leaf:02d}.md").write_text(
+            f"# Depth {depth}, document {leaf}\n{marker}{payload}", encoding="utf-8"
+        )
+PY
+
+MDN_ROOT="$mdn_root/files/en-us" DEEP_ROOT="$deep_root" python3 <<'PY'
+import os
+from pathlib import Path
+
+for label, value in (("MDN", os.environ["MDN_ROOT"]), ("deep", os.environ["DEEP_ROOT"])):
+    root = Path(value)
+    files = list(root.rglob("*.md"))
+    size = sum(p.stat().st_size for p in files)
+    depth = max((len(p.relative_to(root).parts) - 1 for p in files), default=0)
+    print(f"{label}: path={root} markdown_files={len(files)} bytes={size} max_depth={depth}")
+
+mdn_files = list(Path(os.environ["MDN_ROOT"]).rglob("*.md"))
+if len(mdn_files) < 14_000:
+    raise SystemExit(f"MDN corpus unexpectedly small: {len(mdn_files)} Markdown files")
+PY
+
+cat <<EOF
+
+Benchmark MDN:
+  OPENLORE_RG_CORPUS="$mdn_root/files/en-us" ./scripts/benchmark-rg.sh baseline-mdn
+
+Benchmark deep synthetic corpus:
+  OPENLORE_RG_CORPUS="$deep_root" ./scripts/benchmark-rg.sh baseline-deep
+EOF


### PR DESCRIPTION
## Summary

- add a deliberately naive recursive `rg [-inl] PATTERN [PATH ...]` shell command
- freeze ordering, line-ending, long-line, duplicate-root, error, and exit-code behavior with tests
- add corpus benchmarks for miss, literal, case-insensitive, regex, and files-with-matches workloads
- add scripts for a pinned MDN Markdown corpus and a generated depth-64 corpus

This is the optimization target and benchmark foundation. It intentionally favors clear behavior over speed.

## Verification

- `go test ./...`
- `go vet ./...`
- `bash -n scripts/*.sh`
- `git diff --check origin/main...HEAD`
