### PR TITLE
Support /dev/null and stderr redirects

### DIFF
--- a/pkg/openlore/write_surface_test.go
+++ b/pkg/openlore/write_surface_test.go
@@ -72,14 +72,44 @@ func TestRedirect_DevNullDiscardsWithoutWriteCapability(t *testing.T) {
 	sh := shell.NewShell(d)
 	sh.SetAllowedActions(nil) // read-only session
 
-	for _, line := range []string{"echo discarded > /dev/null", "echo discarded >> /dev/null"} {
+	for _, line := range []string{
+		"echo discarded > /dev/null",
+		"echo discarded >> /dev/null",
+		"cat /missing 2>/dev/null",
+		"cat /missing 2>>/dev/null",
+	} {
 		out, errs, code := run(sh, line)
-		if code != 0 || out != "" || errs != "" {
+		if strings.HasPrefix(line, "echo") && code != 0 {
+			t.Errorf("%q: got code=%d", line, code)
+		}
+		if strings.HasPrefix(line, "cat") && code == 0 {
+			t.Errorf("%q: command failure was suppressed", line)
+		}
+		if out != "" || errs != "" {
 			t.Errorf("%q: got code=%d out=%q err=%q", line, code, out, errs)
 		}
 	}
 	if _, err := os.Stat(d.resolve("/dev/null")); !os.IsNotExist(err) {
 		t.Fatal("redirect to /dev/null must not create a virtual file")
+	}
+}
+
+func TestRedirect_StderrToFile(t *testing.T) {
+	sh, d, _ := newWritableShell(t)
+
+	out, errs, code := run(sh, "cat /first-missing 2>/errors.log")
+	if code == 0 || out != "" || errs != "" {
+		t.Fatalf("stderr redirect: got code=%d out=%q err=%q", code, out, errs)
+	}
+	first, err := d.ReadFile("/errors.log")
+	if err != nil || !strings.Contains(string(first), "first-missing") {
+		t.Fatalf("redirected stderr = %q, err=%v", first, err)
+	}
+
+	run(sh, "cat /second-missing 2>>/errors.log")
+	got, err := d.ReadFile("/errors.log")
+	if err != nil || !strings.Contains(string(got), "first-missing") || !strings.Contains(string(got), "second-missing") {
+		t.Fatalf("appended stderr = %q, err=%v", got, err)
 	}
 }
 

--- a/pkg/openlore/write_surface_test.go
+++ b/pkg/openlore/write_surface_test.go
@@ -66,6 +66,23 @@ func TestRedirect_ReadOnly_HardError(t *testing.T) {
 	}
 }
 
+func TestRedirect_DevNullDiscardsWithoutWriteCapability(t *testing.T) {
+	dir := t.TempDir()
+	d := NewDirFS(dir, config.FilesConfig{}) // read-only substrate
+	sh := shell.NewShell(d)
+	sh.SetAllowedActions(nil) // read-only session
+
+	for _, line := range []string{"echo discarded > /dev/null", "echo discarded >> /dev/null"} {
+		out, errs, code := run(sh, line)
+		if code != 0 || out != "" || errs != "" {
+			t.Errorf("%q: got code=%d out=%q err=%q", line, code, out, errs)
+		}
+	}
+	if _, err := os.Stat(d.resolve("/dev/null")); !os.IsNotExist(err) {
+		t.Fatal("redirect to /dev/null must not create a virtual file")
+	}
+}
+
 func TestRedirect_MidStreamError_CommitsNothing(t *testing.T) {
 	sh, d, _ := newWritableShell(t)
 

--- a/pkg/shell/parser/ast.go
+++ b/pkg/shell/parser/ast.go
@@ -22,18 +22,19 @@ type CallExpr struct {
 	// MergeStderr is set when the command had a `2>&1` redirection,
 	// causing the shell to send the command's stderr down its stdout.
 	MergeStderr bool
-	// Redirect is set when the command's stdout is redirected to a file via
-	// `> file` or `>> file`. The shell buffers stdout and commits it as a
-	// single atomic whole-object write (never a stream).
+	// Redirect is set when the command's stdout or stderr is redirected to a
+	// file. The shell buffers the selected stream and commits it as a single
+	// atomic whole-object write (never a stream).
 	Redirect *Redirect
 }
 
 func (*CallExpr) isCommand() {}
 
-// Redirect represents a stdout-to-file redirection (`>` or `>>`).
+// Redirect represents a stdout- or stderr-to-file redirection.
 type Redirect struct {
 	Target *Word // the destination path
 	Append bool  // true for `>>`
+	Stderr bool  // true for `2>` or `2>>`
 }
 
 // Heredoc holds the body of a `<<DELIM` here-document. Body is captured

--- a/pkg/shell/parser/heredoc_test.go
+++ b/pkg/shell/parser/heredoc_test.go
@@ -146,3 +146,26 @@ func TestStderrMergeBeforePipe(t *testing.T) {
 		t.Errorf("left side MergeStderr should be true")
 	}
 }
+
+func TestStderrFileRedirectTokens(t *testing.T) {
+	for _, tc := range []struct {
+		src    string
+		target string
+		append bool
+	}{
+		{src: "cat /missing 2>/dev/null", target: "/dev/null"},
+		{src: "cat /missing 2>> errors.log", target: "errors.log", append: true},
+	} {
+		f, err := parser.Parse(tc.src)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.src, err)
+		}
+		call := f.Stmts[0].Cmd.(*parser.CallExpr)
+		if call.Redirect == nil || !call.Redirect.Stderr || call.Redirect.Append != tc.append {
+			t.Fatalf("%q: redirect = %#v", tc.src, call.Redirect)
+		}
+		if got := call.Redirect.Target.Parts[0].(*parser.Lit).Value; got != tc.target {
+			t.Errorf("%q: target = %q, want %q", tc.src, got, tc.target)
+		}
+	}
+}

--- a/pkg/shell/parser/lexer.go
+++ b/pkg/shell/parser/lexer.go
@@ -10,23 +10,25 @@ type tokenKind int
 const (
 	tokEOF tokenKind = iota
 	tokNewline
-	tokSemi        // ;
-	tokAndIf       // &&
-	tokOrIf        // ||
-	tokPipe        // |
-	tokPipeAll     // |&
-	tokBang        // !
-	tokLParen      // (
-	tokRParen      // )
-	tokLBrace      // {
-	tokRBrace      // }
-	tokDblLBracket // [[
-	tokDblRBracket // ]]
-	tokHeredoc     // <<DELIM heredoc opener
-	tokRedirMerge  // 2>&1 stderr→stdout merge
-	tokRedirOut    // > stdout overwrite redirection
-	tokRedirAppend // >> stdout append redirection
-	tokWord        // everything else
+	tokSemi           // ;
+	tokAndIf          // &&
+	tokOrIf           // ||
+	tokPipe           // |
+	tokPipeAll        // |&
+	tokBang           // !
+	tokLParen         // (
+	tokRParen         // )
+	tokLBrace         // {
+	tokRBrace         // }
+	tokDblLBracket    // [[
+	tokDblRBracket    // ]]
+	tokHeredoc        // <<DELIM heredoc opener
+	tokRedirMerge     // 2>&1 stderr→stdout merge
+	tokRedirOut       // > stdout overwrite redirection
+	tokRedirAppend    // >> stdout append redirection
+	tokRedirErrOut    // 2> stderr overwrite redirection
+	tokRedirErrAppend // 2>> stderr append redirection
+	tokWord           // everything else
 )
 
 // token is a lexer token.
@@ -92,6 +94,23 @@ func (l *lexer) next() token {
 	}
 
 	ch := l.peek()
+	if ch == '2' && l.peekAt(1) == '>' {
+		l.advance()
+		l.advance()
+		if l.peek() == '&' {
+			l.advance()
+			if l.peek() == '1' {
+				l.advance()
+				return token{kind: tokRedirMerge, val: "2>&1"}
+			}
+			return token{kind: tokWord, val: "2>&"}
+		}
+		if l.peek() == '>' {
+			l.advance()
+			return token{kind: tokRedirErrAppend}
+		}
+		return token{kind: tokRedirErrOut}
+	}
 
 	switch ch {
 	case '\n':

--- a/pkg/shell/parser/parser.go
+++ b/pkg/shell/parser/parser.go
@@ -453,7 +453,7 @@ func parseSimpleCommand(t *tokenizer) (Command, error) {
 	}
 
 	// Parse command and arguments, plus interleaved redirections (`2>&1`,
-	// `<<DELIM`).
+	// `2>`, `2>>`, `<<DELIM`).
 	for {
 		tok := t.peek()
 		switch tok.kind {
@@ -469,15 +469,16 @@ func parseSimpleCommand(t *tokenizer) (Command, error) {
 		case tokRedirMerge:
 			t.next()
 			call.MergeStderr = true
-		case tokRedirOut, tokRedirAppend:
-			appendMode := tok.kind == tokRedirAppend
+		case tokRedirOut, tokRedirAppend, tokRedirErrOut, tokRedirErrAppend:
+			appendMode := tok.kind == tokRedirAppend || tok.kind == tokRedirErrAppend
+			stderr := tok.kind == tokRedirErrOut || tok.kind == tokRedirErrAppend
 			t.next()
 			tgt := t.peek()
 			if tgt.kind != tokWord {
 				return nil, fmt.Errorf("syntax error: expected filename after %s", redirOpString(appendMode))
 			}
 			t.next()
-			call.Redirect = &Redirect{Target: parseWordString(tgt.val), Append: appendMode}
+			call.Redirect = &Redirect{Target: parseWordString(tgt.val), Append: appendMode, Stderr: stderr}
 		default:
 			return finalizeCall(call), nil
 		}

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -287,6 +287,9 @@ func (s *Shell) execCall(call *parser.CallExpr, w io.Writer, errW io.Writer, std
 		// /dev/null is a built-in sink, not a path in the virtual filesystem.
 		// It does not require write capability because it cannot mutate state.
 		if target == "/dev/null" {
+			if call.Redirect.Stderr {
+				return s.execCallInner(call, w, io.Discard, stdin)
+			}
 			return s.execCallInner(call, io.Discard, errW, stdin)
 		}
 		// A file redirect is a write; gate it at parse time (Part B) so a
@@ -296,6 +299,13 @@ func (s *Shell) execCall(call *parser.CallExpr, w io.Writer, errW io.Writer, std
 			return 1
 		}
 		var buf bytes.Buffer
+		if call.Redirect.Stderr {
+			code := s.execCallInner(call, w, &buf, stdin)
+			if redirectCode := cmds.WriteFileMsg(s, errW, "redirect", target, buf.Bytes(), call.Redirect.Append); redirectCode != 0 {
+				return redirectCode
+			}
+			return code
+		}
 		code := s.execCallInner(call, &buf, errW, stdin)
 		if code != 0 {
 			return code

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -283,10 +283,15 @@ func (s *Shell) execCall(call *parser.CallExpr, w io.Writer, errW io.Writer, std
 	// commits it as a single atomic whole-object write. Nothing is committed
 	// unless the command succeeds (commit-on-success only — no half-files).
 	if call.Redirect != nil {
+		target := s.expandWord(call.Redirect.Target)
+		// /dev/null is a built-in sink, not a path in the virtual filesystem.
+		// It does not require write capability because it cannot mutate state.
+		if target == "/dev/null" {
+			return s.execCallInner(call, io.Discard, errW, stdin)
+		}
 		// A file redirect is a write; gate it at parse time (Part B) so a
 		// read-only session cannot use `>`/`>>` to mutate a docset.
 		if !s.ActionAllowed(cmds.ActionWrite) {
-			target := s.expandWord(call.Redirect.Target)
 			fmt.Fprintf(errW, "redirect: %s: read-only filesystem\n", target)
 			return 1
 		}
@@ -295,7 +300,6 @@ func (s *Shell) execCall(call *parser.CallExpr, w io.Writer, errW io.Writer, std
 		if code != 0 {
 			return code
 		}
-		target := s.expandWord(call.Redirect.Target)
 		return cmds.WriteFileMsg(s, errW, "redirect", target, buf.Bytes(), call.Redirect.Append)
 	}
 	return s.execCallInner(call, w, errW, stdin)


### PR DESCRIPTION
## Summary
- treat `/dev/null` as a built-in shell output sink
- support stderr overwrite and append redirects with `2>` and `2>>`
- allow stdout and stderr redirects to `/dev/null` in read-only sessions
- avoid creating a virtual filesystem entry for discarded output

## Testing
- `go test ./...`