### PR TITLE
Add MCP tool safety annotations

### DIFF
--- a/pkg/openlore/mcp.go
+++ b/pkg/openlore/mcp.go
@@ -21,6 +21,7 @@ type mcpConfig struct {
 	instructions     string
 	shellDescription string
 	envVars          map[string]string
+	readOnly         bool
 	// shellFactory, when set, builds the shell for each `shell` tool call from
 	// the request context (used to scope the shell per authenticated identity).
 	// When nil, a shell is built from the fixed filesystem plus envVars.
@@ -50,6 +51,13 @@ func WithMCPEnvVars(vars map[string]string) MCPOption {
 	return func(c *mcpConfig) { c.envVars = vars }
 }
 
+// WithMCPReadOnly describes whether the shell's filesystem is globally
+// read-only. The hint is reported to MCP clients and does not replace runtime
+// filesystem or identity-level authorization.
+func WithMCPReadOnly(readOnly bool) MCPOption {
+	return func(c *mcpConfig) { c.readOnly = readOnly }
+}
+
 // withMCPShellFactory sets a per-request shell factory. Used internally by the
 // server to scope the `shell` tool to the authenticated identity resolved from
 // the request context. Unexported: external callers scope by passing their own
@@ -62,7 +70,7 @@ func withMCPShellFactory(fn func(ctx context.Context) *shell.Shell) MCPOption {
 // returned server exposes two tools — `shell` and `list_commands` — that let
 // agents browse and operate on the filesystem via a restricted shell.
 func NewMCPServer(fs vfs.FileSystem, opts ...MCPOption) *mcp.Server {
-	var cfg mcpConfig
+	cfg := mcpConfig{readOnly: true}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -85,14 +93,28 @@ func NewMCPServer(fs vfs.FileSystem, opts ...MCPOption) *mcp.Server {
 	if cfg.shellDescription != "" {
 		shellDesc = cfg.shellDescription
 	}
+	destructive := !cfg.readOnly
+	closedWorld := false
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "shell",
 		Description: shellDesc,
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "OpenLore Shell",
+			ReadOnlyHint:    cfg.readOnly,
+			DestructiveHint: &destructive,
+			OpenWorldHint:   &closedWorld,
+		},
 	}, newMCPShellHandler(fs, cfg.envVars, cfg.shellFactory))
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "list_commands",
 		Description: "List all available shell commands.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:          "List OpenLore Commands",
+			ReadOnlyHint:   true,
+			IdempotentHint: true,
+			OpenWorldHint:  &closedWorld,
+		},
 	}, newMCPListCommandsHandler())
 
 	return server

--- a/pkg/openlore/mcp.go
+++ b/pkg/openlore/mcp.go
@@ -94,7 +94,7 @@ func NewMCPServer(fs vfs.FileSystem, opts ...MCPOption) *mcp.Server {
 		shellDesc = cfg.shellDescription
 	}
 	destructive := !cfg.readOnly
-	closedWorld := false
+	openWorld := false
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "shell",
 		Description: shellDesc,
@@ -102,7 +102,7 @@ func NewMCPServer(fs vfs.FileSystem, opts ...MCPOption) *mcp.Server {
 			Title:           "OpenLore Shell",
 			ReadOnlyHint:    cfg.readOnly,
 			DestructiveHint: &destructive,
-			OpenWorldHint:   &closedWorld,
+			OpenWorldHint:   &openWorld,
 		},
 	}, newMCPShellHandler(fs, cfg.envVars, cfg.shellFactory))
 
@@ -113,7 +113,7 @@ func NewMCPServer(fs vfs.FileSystem, opts ...MCPOption) *mcp.Server {
 			Title:          "List OpenLore Commands",
 			ReadOnlyHint:   true,
 			IdempotentHint: true,
-			OpenWorldHint:  &closedWorld,
+			OpenWorldHint:  &openWorld,
 		},
 	}, newMCPListCommandsHandler())
 

--- a/pkg/openlore/mcp_test.go
+++ b/pkg/openlore/mcp_test.go
@@ -2,6 +2,7 @@ package openlore
 
 import (
 	"testing"
+	"testing/fstest"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -23,7 +24,8 @@ func TestMCPToolAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := NewMCPServer(nil, tt.opts...)
+			fs := NewFSAdapter(fstest.MapFS{"test.md": {Data: []byte("test")}})
+			server := NewMCPServer(fs, tt.opts...)
 			serverTransport, clientTransport := mcp.NewInMemoryTransports()
 			serverSession, err := server.Connect(t.Context(), serverTransport, nil)
 			if err != nil {
@@ -48,7 +50,11 @@ func TestMCPToolAnnotations(t *testing.T) {
 				tools[tool.Name] = tool
 			}
 
-			shellAnnotations := tools["shell"].Annotations
+			shellTool, ok := tools["shell"]
+			if !ok {
+				t.Fatal("shell tool is not registered")
+			}
+			shellAnnotations := shellTool.Annotations
 			if shellAnnotations == nil {
 				t.Fatal("shell annotations are nil")
 			}
@@ -65,7 +71,11 @@ func TestMCPToolAnnotations(t *testing.T) {
 				t.Errorf("shell openWorldHint = %v, want false", shellAnnotations.OpenWorldHint)
 			}
 
-			listAnnotations := tools["list_commands"].Annotations
+			listTool, ok := tools["list_commands"]
+			if !ok {
+				t.Fatal("list_commands tool is not registered")
+			}
+			listAnnotations := listTool.Annotations
 			if listAnnotations == nil {
 				t.Fatal("list_commands annotations are nil")
 			}

--- a/pkg/openlore/mcp_test.go
+++ b/pkg/openlore/mcp_test.go
@@ -1,0 +1,86 @@
+package openlore
+
+import (
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestMCPToolAnnotations(t *testing.T) {
+	tests := []struct {
+		name              string
+		opts              []MCPOption
+		wantShellReadOnly bool
+		wantDestructive   bool
+	}{
+		{name: "read-only by default", wantShellReadOnly: true},
+		{
+			name:            "writable filesystem",
+			opts:            []MCPOption{WithMCPReadOnly(false)},
+			wantDestructive: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := NewMCPServer(nil, tt.opts...)
+			serverTransport, clientTransport := mcp.NewInMemoryTransports()
+			serverSession, err := server.Connect(t.Context(), serverTransport, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer serverSession.Close()
+
+			client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+			clientSession, err := client.Connect(t.Context(), clientTransport, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer clientSession.Close()
+
+			result, err := clientSession.ListTools(t.Context(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tools := make(map[string]*mcp.Tool, len(result.Tools))
+			for _, tool := range result.Tools {
+				tools[tool.Name] = tool
+			}
+
+			shellAnnotations := tools["shell"].Annotations
+			if shellAnnotations == nil {
+				t.Fatal("shell annotations are nil")
+			}
+			if shellAnnotations.Title != "OpenLore Shell" {
+				t.Errorf("shell title = %q", shellAnnotations.Title)
+			}
+			if shellAnnotations.ReadOnlyHint != tt.wantShellReadOnly {
+				t.Errorf("shell readOnlyHint = %t, want %t", shellAnnotations.ReadOnlyHint, tt.wantShellReadOnly)
+			}
+			if shellAnnotations.DestructiveHint == nil || *shellAnnotations.DestructiveHint != tt.wantDestructive {
+				t.Errorf("shell destructiveHint = %v, want %t", shellAnnotations.DestructiveHint, tt.wantDestructive)
+			}
+			if shellAnnotations.OpenWorldHint == nil || *shellAnnotations.OpenWorldHint {
+				t.Errorf("shell openWorldHint = %v, want false", shellAnnotations.OpenWorldHint)
+			}
+
+			listAnnotations := tools["list_commands"].Annotations
+			if listAnnotations == nil {
+				t.Fatal("list_commands annotations are nil")
+			}
+			if listAnnotations.Title != "List OpenLore Commands" {
+				t.Errorf("list_commands title = %q", listAnnotations.Title)
+			}
+			if !listAnnotations.ReadOnlyHint {
+				t.Error("list_commands readOnlyHint = false, want true")
+			}
+			if !listAnnotations.IdempotentHint {
+				t.Error("list_commands idempotentHint = false, want true")
+			}
+			if listAnnotations.OpenWorldHint == nil || *listAnnotations.OpenWorldHint {
+				t.Errorf("list_commands openWorldHint = %v, want false", listAnnotations.OpenWorldHint)
+			}
+		})
+	}
+}

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -1409,7 +1409,11 @@ func (s *Server) ListenAndServe() error {
 			// callers get the same lore/capability scoping as an SSH session.
 			var mcpServer *mcp.Server
 			if (s.config.MCPEnabled && s.config.MCPPath != "") || (s.config.APIEnabled && s.config.APIPath != "") {
-				mcpServer = NewMCPServer(s.fs, withMCPShellFactory(s.shellForContext))
+				mcpServer = NewMCPServer(
+					s.fs,
+					WithMCPReadOnly(s.config.Readonly),
+					withMCPShellFactory(s.shellForContext),
+				)
 			}
 
 			// Mount the MCP-over-HTTP (Streamable HTTP) endpoint on the HTTP


### PR DESCRIPTION
## Summary
- annotate the MCP shell with read-only, destructive, and closed-world hints
- derive the shell safety posture from the server's global read-only configuration
- mark command discovery as read-only, idempotent, and closed-world
- verify annotations through an in-memory MCP client/server exchange

## Testing
- go test ./...