### PR TITLE
Fix writable OAuth auth state

### DIFF
--- a/.github/workflows/deploy-openlore-sh.yml
+++ b/.github/workflows/deploy-openlore-sh.yml
@@ -57,7 +57,15 @@ jobs:
             sudo systemctl stop openlore
             cp /tmp/openlore /opt/openlore/openlore
             chmod +x /opt/openlore/openlore
-            mkdir -p /opt/openlore/published /opt/openlore/config
+            mkdir -p /opt/openlore/published /opt/openlore/config /opt/openlore/data
+            if [ -f /opt/openlore/lore.json ] && [ ! -f /opt/openlore/config/lore.json ]; then
+              mv /opt/openlore/lore.json /opt/openlore/config/lore.json
+            fi
+            sudo sed -i \
+              -e "s|--auth /opt/openlore/lore.json|--auth /opt/openlore/config/lore.json|" \
+              -e "s|^ReadWritePaths=.*|ReadWritePaths=/opt/openlore/.ssh /opt/openlore/published /opt/openlore/config /opt/openlore/data|" \
+              /etc/systemd/system/openlore.service
+            sudo systemctl daemon-reload
             sudo systemctl start openlore
             sleep 2
             sudo systemctl is-active openlore

--- a/assets/config/openlore.yml
+++ b/assets/config/openlore.yml
@@ -10,7 +10,7 @@ http_port: 8080
 metrics_port: 0
 default_cwd: /
 
-auth_file: ./lore.json
+auth_file: ./config/lore.json
 data_dir: ./data
 
 # Disk-backed lore is overlaid at the virtual root. Its directory hierarchy is

--- a/openlore.sh/openlore.yml
+++ b/openlore.sh/openlore.yml
@@ -10,7 +10,7 @@ http_port: 8080
 metrics_port: 0
 default_cwd: /
 
-auth_file: ./lore.json
+auth_file: ./config/lore.json
 data_dir: ./data
 
 # Disk-backed lore is overlaid at the virtual root. Its directory hierarchy is

--- a/openlore.sh/setup.sh
+++ b/openlore.sh/setup.sh
@@ -25,7 +25,7 @@ fi
 
 echo "==> Setting up $INSTALL_DIR..."
 mkdir -p "$INSTALL_DIR/skills" "$INSTALL_DIR/.ssh"
-mkdir -p "$INSTALL_DIR/published"
+mkdir -p "$INSTALL_DIR/published" "$INSTALL_DIR/config" "$INSTALL_DIR/data"
 
 echo "==> Installing binary..."
 cp "$BINARY" "$INSTALL_DIR/openlore"
@@ -38,7 +38,7 @@ fi
 
 echo "==> Installing auth config..."
 if [ -f "$LORE_JSON" ]; then
-    cp "$LORE_JSON" "$INSTALL_DIR/lore.json"
+    cp "$LORE_JSON" "$INSTALL_DIR/config/lore.json"
 fi
 
 chown -R "$USER:$USER" "$INSTALL_DIR"
@@ -54,7 +54,7 @@ Type=simple
 User=$USER
 Group=$USER
 WorkingDirectory=$INSTALL_DIR
-ExecStart=$INSTALL_DIR/openlore --skills-dir $INSTALL_DIR/skills -p 2222 --http-port 8080 --metrics-port 0 --host-key $INSTALL_DIR/.ssh/openlore_ed25519 --auth $INSTALL_DIR/lore.json
+ExecStart=$INSTALL_DIR/openlore --skills-dir $INSTALL_DIR/skills -p 2222 --http-port 8080 --metrics-port 0 --host-key $INSTALL_DIR/.ssh/openlore_ed25519 --auth $INSTALL_DIR/config/lore.json
 Restart=always
 RestartSec=5
 
@@ -62,7 +62,7 @@ RestartSec=5
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
-ReadWritePaths=$INSTALL_DIR/.ssh $INSTALL_DIR/published
+ReadWritePaths=$INSTALL_DIR/.ssh $INSTALL_DIR/published $INSTALL_DIR/config $INSTALL_DIR/data
 PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes


### PR DESCRIPTION
## Summary
- move mutable `lore.json` state into `/opt/openlore/config`
- allow systemd writes to the OAuth config and control-plane data directories
- migrate existing openlore.sh deployments during the next deploy

## Verification
- `go test ./...`
- `bash -n openlore.sh/setup.sh`
- workflow YAML parsed successfully
- `git diff --check`