### PR TITLE
Add delegated identity permissions dashboard

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -424,6 +424,7 @@ type DelegateEntry struct {
 	Roles            []string `json:"roles,omitempty"`
 	DenyDocsets      []string `json:"deny_docsets,omitempty"`
 	DenyCapabilities []string `json:"deny_capabilities,omitempty"`
+	ClientAuth       string   `json:"client_auth,omitempty"`
 }
 
 // MarshalJSON preserves the semantic distinction between an omitted roles
@@ -435,6 +436,7 @@ func (d DelegateEntry) MarshalJSON() ([]byte, error) {
 		Roles            []string `json:"roles,omitempty"`
 		DenyDocsets      []string `json:"deny_docsets,omitempty"`
 		DenyCapabilities []string `json:"deny_capabilities,omitempty"`
+		ClientAuth       string   `json:"client_auth,omitempty"`
 	}
 	if d.Roles == nil {
 		return json.Marshal(wire(d))
@@ -444,6 +446,7 @@ func (d DelegateEntry) MarshalJSON() ([]byte, error) {
 		Roles            []string `json:"roles"`
 		DenyDocsets      []string `json:"deny_docsets,omitempty"`
 		DenyCapabilities []string `json:"deny_capabilities,omitempty"`
+		ClientAuth       string   `json:"client_auth,omitempty"`
 	}
 	return json.Marshal(wireWithRoles(d))
 }

--- a/internal/passkeys/login.html
+++ b/internal/passkeys/login.html
@@ -4,31 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Login — OpenLore</title>
-<style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0d1117; color: #c9d1d9; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
-  .card { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 2.5rem; max-width: 420px; width: 100%; text-align: center; }
-  h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
-  .subtitle { color: #8b949e; margin-bottom: 1.5rem; font-size: 0.9rem; }
-  button { background: #238636; color: #fff; border: none; padding: 0.75rem 2rem; border-radius: 8px; font-size: 1rem; cursor: pointer; width: 100%; transition: background 0.2s; }
-  button:hover { background: #2ea043; }
-  button:disabled { background: #30363d; color: #8b949e; cursor: not-allowed; }
-  #status { margin-top: 1rem; font-size: 0.9rem; min-height: 1.5rem; }
-  .success { color: #3fb950; }
-  .error { color: #f85149; }
-  .info { color: #8b949e; }
-  .setup-box { background: #1c2128; border: 1px solid #30363d; border-radius: 8px; padding: 1.25rem; margin-bottom: 1.5rem; text-align: left; }
-  .setup-box h2 { font-size: 1rem; margin-bottom: 0.5rem; color: #c9d1d9; }
-  .setup-box p { font-size: 0.85rem; color: #8b949e; margin-bottom: 0.75rem; line-height: 1.5; }
-  .setup-box code { background: #0d1117; padding: 0.15rem 0.4rem; border-radius: 4px; font-size: 0.8rem; color: #79c0ff; }
-  .setup-box pre { background: #0d1117; border-radius: 6px; padding: 0.75rem; margin-top: 0.5rem; overflow-x: auto; }
-  .setup-box pre code { padding: 0; background: none; }
-  .hidden { display: none; }
-  .spinner { display: inline-block; width: 16px; height: 16px; border: 2px solid #30363d; border-top-color: #58a6ff; border-radius: 50%; animation: spin 0.6s linear infinite; vertical-align: middle; margin-right: 0.5rem; }
-  @keyframes spin { to { transform: rotate(360deg); } }
-</style>
+<link rel="stylesheet" href="/assets/openlore.css">
 </head>
-<body>
+<body class="centered">
 <div class="card">
   <h1>📜 OpenLore</h1>
 

--- a/internal/passkeys/passkeys.go
+++ b/internal/passkeys/passkeys.go
@@ -332,7 +332,10 @@ func (p *Passkeys) handleLoginFinish(w http.ResponseWriter, r *http.Request) {
 	// Set the browser session cookie for the /lore docs browser. The cookie
 	// carries the identity name; the browser resolves its grants live from the
 	// identity table.
-	p.sessions.SetCookie(w, matched.Identity)
+	if err := p.sessions.SetCookie(w, matched.Identity); err != nil {
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
 
 	// OAuth authorization-code flow: if this login was reached via /authorize
 	// (?authz=<id>), finalize it and hand the browser a redirect back to the
@@ -356,6 +359,21 @@ func randomToken() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// Session authenticates a browser request using the passkey session cookie.
+func (p *Passkeys) Session(r *http.Request) (*SessionInfo, bool) {
+	return p.sessions.ValidateRequest(r)
+}
+
+// CSRFToken derives a form token bound to an authenticated browser session.
+func (p *Passkeys) CSRFToken(session *SessionInfo) string {
+	return p.sessions.CSRFToken(session)
+}
+
+// ValidateCSRF verifies a form token against an authenticated browser session.
+func (p *Passkeys) ValidateCSRF(session *SessionInfo, token string) bool {
+	return p.sessions.ValidateCSRF(session, token)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/passkeys/passkeys_test.go
+++ b/internal/passkeys/passkeys_test.go
@@ -48,6 +48,25 @@ func TestLoginStatusEmpty(t *testing.T) {
 	}
 }
 
+func TestPasskeyPagesUseSharedStylesheet(t *testing.T) {
+	pk, mux := newTestPasskeys(t)
+	pr, err := pk.pending.Create("alice", "MacBook")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range []string{"/passkey/login", "/passkey/r/" + pr.Token} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+		body := rec.Body.String()
+		if !strings.Contains(body, `href="/assets/openlore.css"`) {
+			t.Errorf("%s does not use the shared stylesheet", target)
+		}
+		if strings.Contains(body, "<style>") {
+			t.Errorf("%s still contains inline styles", target)
+		}
+	}
+}
+
 func TestLoginBeginSetsCookieAndChallenge(t *testing.T) {
 	_, mux := newTestPasskeys(t)
 	rr := httptest.NewRecorder()

--- a/internal/passkeys/register.html
+++ b/internal/passkeys/register.html
@@ -4,34 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Register Passkey — OpenLore</title>
-<style>
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0d1117; color: #c9d1d9; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
-  .card { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 2.5rem; max-width: 420px; width: 100%; text-align: center; }
-  h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
-  .subtitle { color: #8b949e; margin-bottom: 1.5rem; font-size: 0.9rem; }
-  .info { background: #1c2128; border: 1px solid #30363d; border-radius: 8px; padding: 1rem; margin-bottom: 1.5rem; text-align: left; font-size: 0.85rem; }
-  .info dt { color: #8b949e; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; }
-  .info dd { margin: 0.25rem 0 0.75rem; color: #c9d1d9; }
-  .info dd:last-child { margin-bottom: 0; }
-  button { background: #238636; color: #fff; border: none; padding: 0.75rem 2rem; border-radius: 8px; font-size: 1rem; cursor: pointer; width: 100%; transition: background 0.2s; }
-  button:hover { background: #2ea043; }
-  button:disabled { background: #30363d; color: #8b949e; cursor: not-allowed; }
-  #status { margin-top: 1rem; font-size: 0.9rem; min-height: 1.5rem; }
-  .success { color: #3fb950; }
-  .error { color: #f85149; }
-  .spinner { display: inline-block; width: 16px; height: 16px; border: 2px solid #30363d; border-top-color: #58a6ff; border-radius: 50%; animation: spin 0.6s linear infinite; vertical-align: middle; margin-right: 0.5rem; }
-  @keyframes spin { to { transform: rotate(360deg); } }
-</style>
+<link rel="stylesheet" href="/assets/openlore.css">
 </head>
-<body>
+<body class="centered">
 <div class="card">
   <h1>📜 Register Passkey</h1>
   <p class="subtitle">Link this device to your OpenLore server</p>
-  <div class="info">
+  <div class="info-box">
     <dl>
       <dt>Device Name</dt>
-      <dd><input id="passkey-name" type="text" value="" placeholder="e.g. Adil MacBook" style="background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;padding:0.4rem 0.6rem;width:100%;font-size:0.9rem;"></dd>
+      <dd><input id="passkey-name" type="text" value="" placeholder="e.g. Adil MacBook"></dd>
       <dt>Identity</dt>
       <dd id="identity-name">—</dd>
     </dl>

--- a/internal/passkeys/session.go
+++ b/internal/passkeys/session.go
@@ -2,8 +2,10 @@ package passkeys
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -29,13 +31,18 @@ func NewSessionManager(key []byte, ttl time.Duration) *SessionManager {
 // SessionInfo holds the decoded session values.
 type SessionInfo struct {
 	Identity  string
+	ID        string
 	ExpiresAt time.Time
 }
 
 // SetCookie creates and sets a signed session cookie on the response.
-func (sm *SessionManager) SetCookie(w http.ResponseWriter, identity string) {
+func (sm *SessionManager) SetCookie(w http.ResponseWriter, identity string) error {
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return err
+	}
 	expiry := time.Now().Add(sm.ttl)
-	payload := fmt.Sprintf("%s:%d", identity, expiry.Unix())
+	payload := fmt.Sprintf("%s:%s:%d", identity, hex.EncodeToString(nonce), expiry.Unix())
 	sig := sm.sign(payload)
 	value := base64.RawURLEncoding.EncodeToString([]byte(payload)) + "." + base64.RawURLEncoding.EncodeToString(sig)
 
@@ -47,6 +54,7 @@ func (sm *SessionManager) SetCookie(w http.ResponseWriter, identity string) {
 		SameSite: http.SameSiteLaxMode,
 		Expires:  expiry,
 	})
+	return nil
 }
 
 // ValidateRequest checks the session cookie and returns session info if valid.
@@ -75,13 +83,23 @@ func (sm *SessionManager) ValidateRequest(r *http.Request) (*SessionInfo, bool) 
 		return nil, false
 	}
 
-	sepIdx := strings.LastIndex(payload, ":")
-	if sepIdx < 0 {
+	expirySep := strings.LastIndex(payload, ":")
+	if expirySep < 0 {
 		return nil, false
 	}
-
-	identity := payload[:sepIdx]
-	expiryUnix, err := strconv.ParseInt(payload[sepIdx+1:], 10, 64)
+	idSep := strings.LastIndex(payload[:expirySep], ":")
+	if idSep < 0 {
+		return nil, false
+	}
+	identity := payload[:idSep]
+	sessionID := payload[idSep+1 : expirySep]
+	if len(sessionID) != 64 {
+		return nil, false
+	}
+	if _, err := hex.DecodeString(sessionID); err != nil {
+		return nil, false
+	}
+	expiryUnix, err := strconv.ParseInt(payload[expirySep+1:], 10, 64)
 	if err != nil {
 		return nil, false
 	}
@@ -91,7 +109,18 @@ func (sm *SessionManager) ValidateRequest(r *http.Request) (*SessionInfo, bool) 
 		return nil, false
 	}
 
-	return &SessionInfo{Identity: identity, ExpiresAt: expiry}, true
+	return &SessionInfo{Identity: identity, ID: sessionID, ExpiresAt: expiry}, true
+}
+
+// CSRFToken returns a token bound to one authenticated browser session.
+func (sm *SessionManager) CSRFToken(session *SessionInfo) string {
+	return base64.RawURLEncoding.EncodeToString(sm.sign("csrf:" + session.ID))
+}
+
+// ValidateCSRF checks a submitted token against the authenticated session.
+func (sm *SessionManager) ValidateCSRF(session *SessionInfo, token string) bool {
+	got, err := base64.RawURLEncoding.DecodeString(token)
+	return err == nil && hmac.Equal(got, sm.sign("csrf:"+session.ID))
 }
 
 // ClearCookie removes the session cookie.

--- a/internal/passkeys/session_test.go
+++ b/internal/passkeys/session_test.go
@@ -1,0 +1,37 @@
+package passkeys
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSessionCSRFTokenIsBoundToSession(t *testing.T) {
+	manager := NewSessionManager([]byte("secret"), time.Hour)
+	requestForSession := func() *SessionInfo {
+		rec := httptest.NewRecorder()
+		if err := manager.SetCookie(rec, "alice"); err != nil {
+			t.Fatal(err)
+		}
+		req := httptest.NewRequest("GET", "/settings/permissions", nil)
+		req.AddCookie(rec.Result().Cookies()[0])
+		session, ok := manager.ValidateRequest(req)
+		if !ok {
+			t.Fatal("issued session did not validate")
+		}
+		return session
+	}
+
+	first := requestForSession()
+	second := requestForSession()
+	token := manager.CSRFToken(first)
+	if !manager.ValidateCSRF(first, token) {
+		t.Fatal("session rejected its own CSRF token")
+	}
+	if manager.ValidateCSRF(second, token) {
+		t.Fatal("CSRF token was accepted for another session")
+	}
+	if manager.ValidateCSRF(first, token+"x") {
+		t.Fatal("tampered CSRF token was accepted")
+	}
+}

--- a/internal/webstyle/openlore.css
+++ b/internal/webstyle/openlore.css
@@ -1,0 +1,70 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #161b22;
+  --panel-muted: #1c2128;
+  --border: #30363d;
+  --text: #c9d1d9;
+  --muted: #8b949e;
+  --link: #58a6ff;
+  --success: #3fb950;
+  --danger: #f85149;
+  --button: #238636;
+  --button-hover: #2ea043;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { min-height: 100vh; background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+body.centered { display: flex; align-items: center; justify-content: center; padding: 1rem; }
+a { color: var(--link); }
+.card { width: 100%; max-width: 420px; padding: 2.5rem; border: 1px solid var(--border); border-radius: 12px; background: var(--panel); text-align: center; }
+.card.wide { max-width: 760px; text-align: left; }
+h1 { margin-bottom: .5rem; font-size: 1.5rem; }
+h2 { font-size: 1.1rem; }
+.subtitle { margin-bottom: 1.5rem; color: var(--muted); font-size: .9rem; line-height: 1.5; }
+button, a.btn { display: block; width: 100%; padding: .75rem 2rem; border: 0; border-radius: 8px; background: var(--button); color: #fff; font: inherit; cursor: pointer; text-align: center; text-decoration: none; }
+button:hover, a.btn:hover { background: var(--button-hover); }
+button:disabled { background: var(--border); color: var(--muted); cursor: not-allowed; }
+.secondary, .secondary-btn { margin-top: .75rem; border: 1px solid var(--border); background: #21262d; }
+.secondary:hover, .secondary-btn:hover { background: var(--border); }
+.danger { border: 1px solid #da3633; background: transparent; color: var(--danger); }
+.danger:hover { background: #da3633; color: #fff; }
+.success { color: var(--success); }
+.verified { color: var(--success); }
+.unverified { color: var(--muted); }
+.error { color: var(--danger); }
+.info, .muted { color: var(--muted); }
+.hidden { display: none; }
+#status { min-height: 1.5rem; margin-top: 1rem; font-size: .9rem; }
+.setup-box, .info-box { margin-bottom: 1.5rem; padding: 1.25rem; border: 1px solid var(--border); border-radius: 8px; background: var(--panel-muted); text-align: left; }
+.setup-box h2 { margin-bottom: .5rem; color: var(--text); font-size: 1rem; }
+.setup-box p { margin-bottom: .75rem; color: var(--muted); font-size: .85rem; line-height: 1.5; }
+.setup-box code, pre { border-radius: 6px; background: var(--bg); }
+.setup-box code { padding: .15rem .4rem; color: #79c0ff; font-size: .8rem; }
+.setup-box pre { margin-top: .5rem; padding: .75rem; overflow-x: auto; }
+.setup-box pre code { padding: 0; background: none; }
+.info-box { color: var(--text); font-size: .85rem; }
+.info-box dt { color: var(--muted); font-size: .75rem; letter-spacing: .05em; text-transform: uppercase; }
+.info-box dd { margin: .25rem 0 .75rem; }
+.info-box dd:last-child { margin-bottom: 0; }
+input[type=text] { width: 100%; padding: .4rem .6rem; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--text); font: inherit; }
+fieldset { margin: 1.25rem 0; padding: 1rem; border: 1px solid var(--border); border-radius: 8px; }
+legend { padding: 0 .35rem; font-weight: 600; }
+label.toggle { display: flex; align-items: center; gap: .55rem; padding: .3rem 0; }
+.spinner { display: inline-block; width: 16px; height: 16px; margin-right: .5rem; border: 2px solid var(--border); border-top-color: var(--link); border-radius: 50%; animation: spin .6s linear infinite; vertical-align: middle; }
+@keyframes spin { to { transform: rotate(360deg); } }
+.settings { width: min(960px, 100%); margin: 0 auto; padding: 2rem 1rem 4rem; }
+.settings header { margin-bottom: 2rem; }
+.delegate-list { display: grid; gap: 1rem; }
+.delegate { padding: 1.25rem; border: 1px solid var(--border); border-radius: 12px; background: var(--panel); }
+.delegate-head { display: flex; align-items: start; justify-content: space-between; gap: 1rem; margin-bottom: .75rem; }
+.display-name { margin-top: .2rem; color: var(--muted); font-size: .9rem; }
+.badge { flex: none; padding: .25rem .5rem; border: 1px solid var(--border); border-radius: 999px; color: var(--muted); font-size: .75rem; }
+.badge.verified { border-color: #238636; color: var(--success); }
+.preview { margin: .75rem 0 1rem; color: var(--muted); font-size: .85rem; line-height: 1.5; }
+.disconnect-form { margin-top: .75rem; }
+.empty { padding: 2rem; border: 1px dashed var(--border); border-radius: 12px; color: var(--muted); text-align: center; }
+.confirm-label { display: block; margin-bottom: .5rem; color: var(--muted); font-size: .8rem; }
+@media (prefers-color-scheme: light) {
+  :root { color-scheme: light; --bg: #f6f8fa; --panel: #fff; --panel-muted: #f6f8fa; --border: #d0d7de; --text: #1f2328; --muted: #59636e; --link: #0969da; }
+  .secondary, .secondary-btn { background: #f6f8fa; color: var(--text); }
+}

--- a/internal/webstyle/webstyle.go
+++ b/internal/webstyle/webstyle.go
@@ -1,0 +1,8 @@
+package webstyle
+
+import _ "embed"
+
+//go:embed openlore.css
+var CSS []byte
+
+const Link = `<link rel="stylesheet" href="/assets/openlore.css">`

--- a/pkg/openlore/authorize.go
+++ b/pkg/openlore/authorize.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/internal/webstyle"
 )
 
 // authorizeRequest holds the validated parameters of an in-flight OAuth
@@ -237,18 +238,8 @@ var authorizeChoiceTmpl = template.Must(template.New("authorize").Parse(`<!DOCTY
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Connect — OpenLore</title>
-<style>
-  *{box-sizing:border-box;margin:0;padding:0}
-  body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#c9d1d9;display:flex;align-items:center;justify-content:center;min-height:100vh}
-  .card{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:2.5rem;max-width:420px;width:100%;text-align:center}
-  h1{font-size:1.5rem;margin-bottom:.5rem}
-  .subtitle{color:#8b949e;margin-bottom:1.5rem;font-size:.9rem}
-  button,a.btn{display:block;width:100%;background:#238636;color:#fff;border:none;padding:.75rem 2rem;border-radius:8px;font-size:1rem;cursor:pointer;text-decoration:none;margin-bottom:.75rem}
-  button:hover,a.btn:hover{background:#2ea043}
-  a.btn.secondary{background:#21262d;border:1px solid #30363d}
-  a.btn.secondary:hover{background:#30363d}
-</style></head>
-<body><div class="card">
+` + webstyle.Link + `</head>
+<body class="centered"><div class="card">
   <h1>📜 OpenLore</h1>
   <p class="subtitle">How do you want to connect?</p>
   {{if .Passkeys}}<a class="btn" href="{{.LoginURL}}">Log in with passkey</a>{{end}}
@@ -387,13 +378,13 @@ type consentView struct {
 	EnabledDocsets, EnabledCapabilities                           map[string]bool
 }
 
-var consentTmpl = template.Must(template.New("consent").Parse(`<!doctype html><html><head><meta charset="utf-8"><title>Authorize OpenLore</title></head><body>
-<main><h1>Authorize {{.ClientName}}</h1><p class="{{.AuthClass}}">{{.AuthLabel}}</p><p>Acting for <strong>{{.Principal}}</strong></p>
+var consentTmpl = template.Must(template.New("consent").Parse(`<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Authorize OpenLore</title>` + webstyle.Link + `</head><body class="centered">
+<main class="card wide"><h1>Authorize {{.ClientName}}</h1><p class="{{.AuthClass}}">{{.AuthLabel}}</p><p>Acting for <strong>{{.Principal}}</strong></p>
 <form method="post" action="` + authorizeConsentPath + `"><input type="hidden" name="consent" value="{{.Consent}}">
-<fieldset><legend>Agent identity</legend>{{range .Delegates}}<label><input type="radio" name="delegate" value="{{.}}"{{if eq . $.Selected}} checked{{end}}> {{.}}</label><br>{{end}}
-{{if .FixedIdentity}}<label><input type="radio" name="delegate" value="new"{{if not .Selected}} checked{{end}}> connect as {{.FixedIdentity}}</label>{{else}}<label><input type="radio" name="delegate" value="new"{{if not .Selected}} checked{{end}}> create new: <input name="name" pattern="[a-z0-9-]+" value="{{.DefaultName}}">@{{.Domain}}</label>{{end}}</fieldset>
-<fieldset><legend>Docsets</legend>{{range .Docsets}}<label><input type="checkbox" name="docset" value="{{.}}"{{if index $.EnabledDocsets .}} checked{{end}}> {{.}}</label><br>{{end}}</fieldset>
-<fieldset><legend>Capabilities</legend>{{range .Capabilities}}<label><input type="checkbox" name="capability" value="{{.}}"{{if index $.EnabledCapabilities .}} checked{{end}}> {{.}}</label><br>{{end}}</fieldset>
+<fieldset><legend>Agent identity</legend>{{range .Delegates}}<label class="toggle"><input type="radio" name="delegate" value="{{.}}"{{if eq . $.Selected}} checked{{end}}> {{.}}</label>{{end}}
+{{if .FixedIdentity}}<label class="toggle"><input type="radio" name="delegate" value="new"{{if not .Selected}} checked{{end}}> connect as {{.FixedIdentity}}</label>{{else}}<label class="toggle"><input type="radio" name="delegate" value="new"{{if not .Selected}} checked{{end}}> create new: <input name="name" pattern="[a-z0-9-]+" value="{{.DefaultName}}">@{{.Domain}}</label>{{end}}</fieldset>
+<fieldset><legend>Docsets</legend>{{range .Docsets}}<label class="toggle"><input type="checkbox" name="docset" value="{{.}}"{{if index $.EnabledDocsets .}} checked{{end}}> {{.}}</label>{{end}}</fieldset>
+<fieldset><legend>Capabilities</legend>{{range .Capabilities}}<label class="toggle"><input type="checkbox" name="capability" value="{{.}}"{{if index $.EnabledCapabilities .}} checked{{end}}> {{.}}</label>{{end}}</fieldset>
 <button type="submit">Authorize</button></form></main></body></html>`))
 
 func (s *Server) authorizeConsentHandler(w http.ResponseWriter, r *http.Request) {
@@ -574,6 +565,7 @@ func (s *Server) authorizeConsentHandler(w http.ResponseWriter, r *http.Request)
 		d := &p.Delegates[idx]
 		d.DenyDocsets = difference(docsets, selectedDocsets)
 		d.DenyCapabilities = difference(capabilities, selectedCapabilities)
+		d.ClientAuth = string(baselineClientAuth(client))
 		return nil
 	})
 	if err != nil {

--- a/pkg/openlore/config_management.go
+++ b/pkg/openlore/config_management.go
@@ -68,7 +68,10 @@ func (s *Server) updateAuth(attribution Attribution, eventType string, mutate fu
 	if s.audit != nil {
 		_ = s.audit.Record(context.Background(), AuditEvent{Type: eventType, Attribution: attribution, Details: details})
 	}
-	return afterErr
+	if afterErr != nil && s.logger != nil {
+		s.logger.Error("post-configuration action failed after configuration was persisted", "event", eventType, "error", afterErr)
+	}
+	return nil
 }
 
 func (s *Server) reloadAuth(attribution Attribution) error {

--- a/pkg/openlore/config_management.go
+++ b/pkg/openlore/config_management.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 )
 
-func (s *Server) updateAuth(attribution Attribution, eventType string, mutate func(*config.AuthConfig) error) error {
+func (s *Server) updateAuth(attribution Attribution, eventType string, mutate func(*config.AuthConfig) error, after ...func() (map[string]any, error)) error {
 	s.authMu.Lock()
 	defer s.authMu.Unlock()
 	b, err := json.Marshal(s.currentAuth())
@@ -54,10 +54,21 @@ func (s *Server) updateAuth(attribution Attribution, eventType string, mutate fu
 	if s.passkeys != nil {
 		s.passkeys.SetAuthConfig(&next)
 	}
-	if s.audit != nil {
-		_ = s.audit.Record(context.Background(), AuditEvent{Type: eventType, Attribution: attribution})
+	var details map[string]any
+	var afterErr error
+	if len(after) > 0 {
+		details, afterErr = after[0]()
+		if afterErr != nil {
+			if details == nil {
+				details = map[string]any{}
+			}
+			details["error"] = afterErr.Error()
+		}
 	}
-	return nil
+	if s.audit != nil {
+		_ = s.audit.Record(context.Background(), AuditEvent{Type: eventType, Attribution: attribution, Details: details})
+	}
+	return afterErr
 }
 
 func (s *Server) reloadAuth(attribution Attribution) error {

--- a/pkg/openlore/identitystore.go
+++ b/pkg/openlore/identitystore.go
@@ -92,16 +92,17 @@ func (s *Server) initAuth() error {
 	s.cimdResolver = resolver
 	s.clientAuth = newClientAuthenticator(resolver, strings.TrimRight(tc.Issuer, "/")+tokenPath, s.audit)
 	s.tokens = &tokenEndpoint{
-		issuer:     s.issuer,
-		refresh:    s.refreshStore,
-		codes:      s.authCodes,
-		accessTTL:  parseDurationDefault(tc.AccessTTL, 30*time.Minute),
-		refreshTTL: parseDurationDefault(tc.RefreshTTL, 720*time.Hour),
-		audience:   tc.Audience,
-		delegation: s,
-		cimd:       resolver,
-		clientAuth: s.clientAuth,
-		audit:      s.audit,
+		issuer:       s.issuer,
+		refresh:      s.refreshStore,
+		codes:        s.authCodes,
+		accessTTL:    parseDurationDefault(tc.AccessTTL, 30*time.Minute),
+		refreshTTL:   parseDurationDefault(tc.RefreshTTL, 720*time.Hour),
+		audience:     tc.Audience,
+		delegation:   s,
+		cimd:         resolver,
+		clientAuth:   s.clientAuth,
+		audit:        s.audit,
+		delegateAuth: s,
 	}
 	// The token endpoint's jwt-bearer grant delegates the verify+match+narrow
 	// exchange back to the server (which holds the auth config + verifier).

--- a/pkg/openlore/identitystore.go
+++ b/pkg/openlore/identitystore.go
@@ -103,6 +103,7 @@ func (s *Server) initAuth() error {
 		clientAuth:   s.clientAuth,
 		audit:        s.audit,
 		delegateAuth: s,
+		logger:       s.logger,
 	}
 	// The token endpoint's jwt-bearer grant delegates the verify+match+narrow
 	// exchange back to the server (which holds the auth config + verifier).

--- a/pkg/openlore/refreshstore.go
+++ b/pkg/openlore/refreshstore.go
@@ -46,6 +46,8 @@ type RefreshTokenStore interface {
 	Rotate(oldToken string, newToken RefreshToken) error
 	// RevokeChain deletes every token descending from one login.
 	RevokeChain(chainID string) error
+	// RevokeDelegation revokes every chain issued to actor on behalf of subject.
+	RevokeDelegation(subject, actor string) (int, error)
 }
 
 // fileRefreshStore is a mutex-guarded JSON-file RefreshTokenStore.
@@ -135,6 +137,24 @@ func (s *fileRefreshStore) RevokeChain(chainID string) error {
 	defer s.mu.Unlock()
 	s.revokeChainLocked(chainID)
 	return s.persist()
+}
+
+func (s *fileRefreshStore) RevokeDelegation(subject, actor string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	chains := map[string]bool{}
+	for _, rt := range s.tokens {
+		if rt.Subject == subject && rt.Actor == actor {
+			chains[rt.ChainID] = true
+		}
+	}
+	for chainID := range chains {
+		s.revokeChainLocked(chainID)
+	}
+	if err := s.persist(); err != nil {
+		return 0, err
+	}
+	return len(chains), nil
 }
 
 func (s *fileRefreshStore) revokeChainLocked(chainID string) {

--- a/pkg/openlore/refreshstore_test.go
+++ b/pkg/openlore/refreshstore_test.go
@@ -78,6 +78,37 @@ func TestRefreshStore_RotateUnknownInvalid(t *testing.T) {
 	}
 }
 
+func TestRefreshStore_RevokeDelegationRevokesMatchingDistinctChains(t *testing.T) {
+	rs := testRefreshStore(t)
+	expires := time.Now().Add(time.Hour)
+	for _, rt := range []RefreshToken{
+		{Token: "a1", Subject: "alice", Actor: "claude", ChainID: "c1", ExpiresAt: expires},
+		{Token: "a2", Subject: "alice", Actor: "claude", ChainID: "c1", ExpiresAt: expires},
+		{Token: "b", Subject: "alice", Actor: "claude", ChainID: "c2", ExpiresAt: expires},
+		{Token: "other-principal", Subject: "bob", Actor: "claude", ChainID: "c3", ExpiresAt: expires},
+		{Token: "other-actor", Subject: "alice", Actor: "chatgpt", ChainID: "c4", ExpiresAt: expires},
+	} {
+		if err := rs.Save(rt); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+
+	revoked, err := rs.RevokeDelegation("alice", "claude")
+	if err != nil || revoked != 2 {
+		t.Fatalf("RevokeDelegation: revoked=%d err=%v", revoked, err)
+	}
+	for _, token := range []string{"a1", "a2", "b"} {
+		if _, ok, _ := rs.Lookup(token); ok {
+			t.Errorf("matching token %q was not revoked", token)
+		}
+	}
+	for _, token := range []string{"other-principal", "other-actor"} {
+		if _, ok, _ := rs.Lookup(token); !ok {
+			t.Errorf("unrelated token %q was revoked", token)
+		}
+	}
+}
+
 func TestRefreshStore_Persistence(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "refresh.json")

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aakarim/go-openlore/internal/metrics"
 	"github.com/aakarim/go-openlore/internal/passkeys"
 	"github.com/aakarim/go-openlore/internal/skills"
+	"github.com/aakarim/go-openlore/internal/webstyle"
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/shell"
@@ -1462,6 +1463,15 @@ func (s *Server) ListenAndServe() error {
 				httpCfg.ExtraHandlers["/legal/"] = legalHandler
 				s.logger.Info("legal notices mounted", "path", "/legal", "http_port", s.config.HTTPPort)
 			}
+			httpCfg.ExtraHandlers["/assets/openlore.css"] = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+					return
+				}
+				w.Header().Set("Content-Type", "text/css; charset=utf-8")
+				w.Header().Set("Cache-Control", "public, max-age=3600")
+				_, _ = w.Write(webstyle.CSS)
+			})
 
 			// A single MCP server backs both the Streamable HTTP endpoint and
 			// the plain JSON HTTP API below. Its `shell` tool builds a
@@ -1550,6 +1560,9 @@ func (s *Server) ListenAndServe() error {
 				s.passkeys.SetTokenIssuer(s)
 
 				httpCfg.Extenders = append(httpCfg.Extenders, s.passkeys)
+				httpCfg.ExtraHandlers[permissionsPath] = http.HandlerFunc(s.handlePermissionsPage)
+				httpCfg.ExtraHandlers[permissionsUpdatePath] = http.HandlerFunc(s.handleDelegateUpdate)
+				httpCfg.ExtraHandlers[permissionsRemovePath] = http.HandlerFunc(s.handleDelegateRemove)
 
 				lorePath := s.config.Passkeys.LorePath
 				if lorePath == "" {

--- a/pkg/openlore/settings_permissions.go
+++ b/pkg/openlore/settings_permissions.go
@@ -26,6 +26,7 @@ type permissionToggle struct {
 type delegateView struct {
 	Identity              string
 	DisplayName           string
+	ResolutionError       string
 	ClientAuth            ClientAuthLevel
 	ClientAuthLabel       string
 	ClientAuthVerified    bool
@@ -47,11 +48,12 @@ var permissionsTmpl = template.Must(template.New("permissions").Funcs(template.F
 <main class="settings"><header><h1>Delegate permissions</h1><p class="subtitle">Signed in as <strong>{{.Principal}}</strong>. Delegates inherit your access, minus these denials. Effective permissions never exceed yours.</p></header>
 {{if .Delegates}}<div class="delegate-list">{{range .Delegates}}<section class="delegate">
 <div class="delegate-head"><div><h2>{{.Identity}}</h2>{{if .DisplayName}}<p class="display-name">{{.DisplayName}}</p>{{end}}</div><span class="badge{{if .ClientAuthVerified}} verified{{end}}">{{.ClientAuthLabel}}</span></div>
+{{if .ResolutionError}}<p class="preview"><strong>Permissions unavailable:</strong> {{.ResolutionError}}. You can still disconnect this delegate.</p>{{else}}
 <form method="post" action="` + permissionsUpdatePath + `"><input type="hidden" name="csrf" value="{{$.CSRF}}"><input type="hidden" name="actor" value="{{.Identity}}">
 <fieldset><legend>Docsets</legend>{{range .Docsets}}<label class="toggle"><input type="checkbox" name="allowed_docsets" value="{{.Name}}"{{if .Allowed}} checked{{end}}> {{.Name}}</label>{{else}}<span class="muted">No docset access</span>{{end}}</fieldset>
 <fieldset><legend>Capabilities</legend>{{range .Capabilities}}<label class="toggle"><input type="checkbox" name="allowed_capabilities" value="{{.Name}}"{{if .Allowed}} checked{{end}}> {{.Name}}</label>{{else}}<span class="muted">No capabilities</span>{{end}}</fieldset>
 <p class="preview"><strong>Can currently reach:</strong> {{if .EffectiveDocsets}}{{join .EffectiveDocsets ", "}}{{else}}no docsets{{end}}{{if .EffectiveCapabilities}}; capabilities: {{join .EffectiveCapabilities ", "}}{{end}}.<br><strong>Denied:</strong> {{if .DeniedDocsets}}{{join .DeniedDocsets ", "}}{{else}}no docsets{{end}}{{if .DeniedCapabilities}}; capabilities: {{join .DeniedCapabilities ", "}}{{end}}.</p>
-<button type="submit">Save permissions</button></form><form class="disconnect-form" method="post" action="` + permissionsRemovePath + `" onsubmit="return confirm('Disconnect {{.Identity}}? Existing access tokens remain valid until they expire.')"><input type="hidden" name="csrf" value="{{$.CSRF}}"><input type="hidden" name="actor" value="{{.Identity}}"><button class="danger" type="submit">Disconnect</button></form>
+<button type="submit">Save permissions</button></form>{{end}}<form class="disconnect-form" method="post" action="` + permissionsRemovePath + `" onsubmit="return confirm('Disconnect {{.Identity}}? Existing access tokens remain valid until they expire.')"><input type="hidden" name="csrf" value="{{$.CSRF}}"><input type="hidden" name="actor" value="{{.Identity}}"><button class="danger" type="submit">Disconnect</button></form>
 </section>{{end}}</div>{{else}}<div class="empty">No OAuth clients are delegated to act for your identity.</div>{{end}}</main></body></html>`))
 
 func (s *Server) permissionsSession(w http.ResponseWriter, r *http.Request) (*passkeys.SessionInfo, bool) {
@@ -88,26 +90,31 @@ func (s *Server) handlePermissionsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	views := make([]delegateView, 0, len(principal.Delegates))
 	for _, delegate := range principal.Delegates {
-		effectiveDocsets, effectiveCapabilities, err := s.permissionsFor(session.Identity, delegate.Identity)
-		if err != nil {
-			continue
-		}
-		allowedDocsets := stringSet(effectiveDocsets)
-		allowedCapabilities := stringSet(effectiveCapabilities)
 		view := delegateView{
-			Identity: delegate.Identity, ClientAuth: ClientAuthLevel(delegate.ClientAuth),
+			Identity:           delegate.Identity,
+			ClientAuth:         ClientAuthLevel(delegate.ClientAuth),
 			ClientAuthLabel:    clientAuthLabel(ClientAuthLevel(delegate.ClientAuth)),
 			ClientAuthVerified: ClientAuthLevel(delegate.ClientAuth).Verified(),
-			EffectiveDocsets:   effectiveDocsets, EffectiveCapabilities: effectiveCapabilities,
-			DeniedDocsets: difference(docsets, allowedDocsets), DeniedCapabilities: difference(capabilities, allowedCapabilities),
 		}
 		if identity, found := s.findAuthIdentity(delegate.Identity); found {
 			if identity.ClientIDMetadata != nil {
 				view.DisplayName = identity.ClientIDMetadata.PinnedName
-			} else {
+			} else if strings.HasPrefix(identity.Comment, "Display: ") {
 				view.DisplayName = strings.TrimPrefix(identity.Comment, "Display: ")
 			}
 		}
+		effectiveDocsets, effectiveCapabilities, err := s.permissionsFor(session.Identity, delegate.Identity)
+		if err != nil {
+			view.ResolutionError = err.Error()
+			views = append(views, view)
+			continue
+		}
+		allowedDocsets := stringSet(effectiveDocsets)
+		allowedCapabilities := stringSet(effectiveCapabilities)
+		view.EffectiveDocsets = effectiveDocsets
+		view.EffectiveCapabilities = effectiveCapabilities
+		view.DeniedDocsets = difference(docsets, allowedDocsets)
+		view.DeniedCapabilities = difference(capabilities, allowedCapabilities)
 		for _, name := range docsets {
 			view.Docsets = append(view.Docsets, permissionToggle{Name: name, Allowed: allowedDocsets[name]})
 		}
@@ -282,7 +289,7 @@ func (s *Server) recordDelegateClientAuth(principal, actor string, level ClientA
 	if clientAuthRank(ClientAuthLevel(delegate.ClientAuth)) >= clientAuthRank(level) {
 		return nil
 	}
-	return s.updateAuth(Attribution{Principal: principal, Actor: actor, ClientAuth: level}, "delegate.update", func(auth *config.AuthConfig) error {
+	return s.updateAuth(Attribution{Principal: principal, Actor: actor, ClientAuth: level}, "delegate.client_auth", func(auth *config.AuthConfig) error {
 		delegate, err := authDelegate(auth, principal, actor)
 		if err != nil {
 			return err

--- a/pkg/openlore/settings_permissions.go
+++ b/pkg/openlore/settings_permissions.go
@@ -1,0 +1,310 @@
+package openlore
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/internal/passkeys"
+	"github.com/aakarim/go-openlore/internal/webstyle"
+)
+
+const (
+	permissionsPath       = "/settings/permissions"
+	permissionsUpdatePath = "/settings/permissions/update"
+	permissionsRemovePath = "/settings/permissions/remove"
+)
+
+type permissionToggle struct {
+	Name    string
+	Allowed bool
+}
+
+type delegateView struct {
+	Identity              string
+	DisplayName           string
+	ClientAuth            ClientAuthLevel
+	ClientAuthLabel       string
+	ClientAuthVerified    bool
+	Docsets               []permissionToggle
+	Capabilities          []permissionToggle
+	EffectiveDocsets      []string
+	EffectiveCapabilities []string
+	DeniedDocsets         []string
+	DeniedCapabilities    []string
+}
+
+type permissionsView struct {
+	Principal string
+	CSRF      string
+	Delegates []delegateView
+}
+
+var permissionsTmpl = template.Must(template.New("permissions").Funcs(template.FuncMap{"join": strings.Join}).Parse(`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Delegate permissions — OpenLore</title>` + webstyle.Link + `</head><body>
+<main class="settings"><header><h1>Delegate permissions</h1><p class="subtitle">Signed in as <strong>{{.Principal}}</strong>. Delegates inherit your access, minus these denials. Effective permissions never exceed yours.</p></header>
+{{if .Delegates}}<div class="delegate-list">{{range .Delegates}}<section class="delegate">
+<div class="delegate-head"><div><h2>{{.Identity}}</h2>{{if .DisplayName}}<p class="display-name">{{.DisplayName}}</p>{{end}}</div><span class="badge{{if .ClientAuthVerified}} verified{{end}}">{{.ClientAuthLabel}}</span></div>
+<form method="post" action="` + permissionsUpdatePath + `"><input type="hidden" name="csrf" value="{{$.CSRF}}"><input type="hidden" name="actor" value="{{.Identity}}">
+<fieldset><legend>Docsets</legend>{{range .Docsets}}<label class="toggle"><input type="checkbox" name="allowed_docsets" value="{{.Name}}"{{if .Allowed}} checked{{end}}> {{.Name}}</label>{{else}}<span class="muted">No docset access</span>{{end}}</fieldset>
+<fieldset><legend>Capabilities</legend>{{range .Capabilities}}<label class="toggle"><input type="checkbox" name="allowed_capabilities" value="{{.Name}}"{{if .Allowed}} checked{{end}}> {{.Name}}</label>{{else}}<span class="muted">No capabilities</span>{{end}}</fieldset>
+<p class="preview"><strong>Can currently reach:</strong> {{if .EffectiveDocsets}}{{join .EffectiveDocsets ", "}}{{else}}no docsets{{end}}{{if .EffectiveCapabilities}}; capabilities: {{join .EffectiveCapabilities ", "}}{{end}}.<br><strong>Denied:</strong> {{if .DeniedDocsets}}{{join .DeniedDocsets ", "}}{{else}}no docsets{{end}}{{if .DeniedCapabilities}}; capabilities: {{join .DeniedCapabilities ", "}}{{end}}.</p>
+<button type="submit">Save permissions</button></form><form class="disconnect-form" method="post" action="` + permissionsRemovePath + `" onsubmit="return confirm('Disconnect {{.Identity}}? Existing access tokens remain valid until they expire.')"><input type="hidden" name="csrf" value="{{$.CSRF}}"><input type="hidden" name="actor" value="{{.Identity}}"><button class="danger" type="submit">Disconnect</button></form>
+</section>{{end}}</div>{{else}}<div class="empty">No OAuth clients are delegated to act for your identity.</div>{{end}}</main></body></html>`))
+
+func (s *Server) permissionsSession(w http.ResponseWriter, r *http.Request) (*passkeys.SessionInfo, bool) {
+	if s.passkeys == nil {
+		http.Error(w, "passkey authentication is not enabled", http.StatusNotFound)
+		return nil, false
+	}
+	session, ok := s.passkeys.Session(r)
+	if !ok {
+		http.Redirect(w, r, "/passkey/login?redirect="+permissionsPath, http.StatusFound)
+		return nil, false
+	}
+	if _, ok := s.findAuthIdentity(session.Identity); !ok {
+		http.Error(w, "unknown identity", http.StatusForbidden)
+		return nil, false
+	}
+	return session, true
+}
+
+func (s *Server) handlePermissionsPage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	session, ok := s.permissionsSession(w, r)
+	if !ok {
+		return
+	}
+	principal, _ := s.findAuthIdentity(session.Identity)
+	docsets, capabilities, err := s.permissionsFor(session.Identity, "")
+	if err != nil {
+		http.Error(w, "failed to resolve permissions", http.StatusInternalServerError)
+		return
+	}
+	views := make([]delegateView, 0, len(principal.Delegates))
+	for _, delegate := range principal.Delegates {
+		effectiveDocsets, effectiveCapabilities, err := s.permissionsFor(session.Identity, delegate.Identity)
+		if err != nil {
+			continue
+		}
+		allowedDocsets := stringSet(effectiveDocsets)
+		allowedCapabilities := stringSet(effectiveCapabilities)
+		view := delegateView{
+			Identity: delegate.Identity, ClientAuth: ClientAuthLevel(delegate.ClientAuth),
+			ClientAuthLabel:    clientAuthLabel(ClientAuthLevel(delegate.ClientAuth)),
+			ClientAuthVerified: ClientAuthLevel(delegate.ClientAuth).Verified(),
+			EffectiveDocsets:   effectiveDocsets, EffectiveCapabilities: effectiveCapabilities,
+			DeniedDocsets: difference(docsets, allowedDocsets), DeniedCapabilities: difference(capabilities, allowedCapabilities),
+		}
+		if identity, found := s.findAuthIdentity(delegate.Identity); found {
+			if identity.ClientIDMetadata != nil {
+				view.DisplayName = identity.ClientIDMetadata.PinnedName
+			} else {
+				view.DisplayName = strings.TrimPrefix(identity.Comment, "Display: ")
+			}
+		}
+		for _, name := range docsets {
+			view.Docsets = append(view.Docsets, permissionToggle{Name: name, Allowed: allowedDocsets[name]})
+		}
+		for _, name := range capabilities {
+			view.Capabilities = append(view.Capabilities, permissionToggle{Name: name, Allowed: allowedCapabilities[name]})
+		}
+		views = append(views, view)
+	}
+	sort.Slice(views, func(i, j int) bool { return views[i].Identity < views[j].Identity })
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = permissionsTmpl.Execute(w, permissionsView{Principal: session.Identity, CSRF: s.passkeys.CSRFToken(session), Delegates: views})
+}
+
+func (s *Server) handleDelegateUpdate(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.validPermissionsPost(w, r)
+	if !ok {
+		return
+	}
+	actor := r.Form.Get("actor")
+	docsets, capabilities, err := s.permissionsFor(session.Identity, "")
+	if err != nil {
+		http.Error(w, "failed to resolve permissions", http.StatusInternalServerError)
+		return
+	}
+	selectedDocsets := stringSet(r.Form["allowed_docsets"])
+	selectedCapabilities := stringSet(r.Form["allowed_capabilities"])
+	err = s.updateAuth(Attribution{Principal: session.Identity, Actor: actor}, "delegate.update", func(auth *config.AuthConfig) error {
+		delegate, err := authDelegate(auth, session.Identity, actor)
+		if err != nil {
+			return err
+		}
+		delegate.DenyDocsets = difference(docsets, selectedDocsets)
+		delegate.DenyCapabilities = difference(capabilities, selectedCapabilities)
+		return nil
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, permissionsPath, http.StatusSeeOther)
+}
+
+func (s *Server) handleDelegateRemove(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.validPermissionsPost(w, r)
+	if !ok {
+		return
+	}
+	actor := r.Form.Get("actor")
+	err := s.updateAuth(Attribution{Principal: session.Identity, Actor: actor}, "delegate.remove", func(auth *config.AuthConfig) error {
+		for i := range auth.Identities {
+			if auth.Identities[i].Name != session.Identity {
+				continue
+			}
+			for j, delegate := range auth.Identities[i].Delegates {
+				if delegate.Identity == actor {
+					auth.Identities[i].Delegates = append(auth.Identities[i].Delegates[:j], auth.Identities[i].Delegates[j+1:]...)
+					return nil
+				}
+			}
+			return fmt.Errorf("delegate %q not found", actor)
+		}
+		return fmt.Errorf("principal %q not found", session.Identity)
+	}, func() (map[string]any, error) {
+		if s.refreshStore == nil {
+			return map[string]any{"revoked_refresh_chains": 0}, nil
+		}
+		revoked, err := s.refreshStore.RevokeDelegation(session.Identity, actor)
+		return map[string]any{"revoked_refresh_chains": revoked}, err
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, permissionsPath, http.StatusSeeOther)
+}
+
+func (s *Server) validPermissionsPost(w http.ResponseWriter, r *http.Request) (*passkeys.SessionInfo, bool) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return nil, false
+	}
+	session, ok := s.permissionsSession(w, r)
+	if !ok {
+		return nil, false
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "malformed form", http.StatusBadRequest)
+		return nil, false
+	}
+	if !s.passkeys.ValidateCSRF(session, r.Form.Get("csrf")) {
+		http.Error(w, "invalid CSRF token", http.StatusForbidden)
+		return nil, false
+	}
+	return session, true
+}
+
+func (s *Server) permissionsFor(principal, actor string) ([]string, []string, error) {
+	id, ok := s.identityForName(principal)
+	if !ok {
+		return nil, nil, fmt.Errorf("principal %q not found", principal)
+	}
+	if actor != "" {
+		id.Principal.Claims = map[string]any{"actor": actor}
+		id.Attribution.Actor = actor
+	}
+	policy, err := s.currentPolicy(id)
+	if err != nil {
+		return nil, nil, err
+	}
+	var docsets []string
+	for name := range s.currentAuth().Docsets {
+		if _, allowed := s.effectiveGrantNames(id, name); allowed {
+			docsets = append(docsets, name)
+		}
+	}
+	seen := map[string]bool{}
+	for _, role := range policy.Roles {
+		for _, capability := range s.currentAuth().Roles[role].Allow.Capabilities {
+			if s.hasCapabilityForPolicy(policy, capability) {
+				seen[capability] = true
+			}
+		}
+	}
+	seen["lore:config:edit"] = s.hasCapabilityForPolicy(policy, "lore:config:edit")
+	var capabilities []string
+	for capability, allowed := range seen {
+		if allowed {
+			capabilities = append(capabilities, capability)
+		}
+	}
+	sort.Strings(docsets)
+	sort.Strings(capabilities)
+	return docsets, capabilities, nil
+}
+
+func authDelegate(auth *config.AuthConfig, principal, actor string) (*config.DelegateEntry, error) {
+	for i := range auth.Identities {
+		if auth.Identities[i].Name == principal {
+			for j := range auth.Identities[i].Delegates {
+				if auth.Identities[i].Delegates[j].Identity == actor {
+					return &auth.Identities[i].Delegates[j], nil
+				}
+			}
+			return nil, fmt.Errorf("delegate %q not found", actor)
+		}
+	}
+	return nil, fmt.Errorf("principal %q not found", principal)
+}
+
+func clientAuthLabel(level ClientAuthLevel) string {
+	switch level {
+	case AuthPrivateKeyJWTMTLS:
+		return "mTLS"
+	case AuthPrivateKeyJWT:
+		return "JWKS"
+	case AuthCIMD:
+		return "CIMD"
+	default:
+		return "Unverified"
+	}
+}
+
+func (s *Server) recordDelegateClientAuth(principal, actor string, level ClientAuthLevel) error {
+	current, ok := s.findAuthIdentity(principal)
+	if !ok {
+		return fmt.Errorf("principal %q not found", principal)
+	}
+	delegate, ok := findDelegate(current, actor)
+	if !ok {
+		return fmt.Errorf("delegate %q not found", actor)
+	}
+	if clientAuthRank(ClientAuthLevel(delegate.ClientAuth)) >= clientAuthRank(level) {
+		return nil
+	}
+	return s.updateAuth(Attribution{Principal: principal, Actor: actor, ClientAuth: level}, "delegate.update", func(auth *config.AuthConfig) error {
+		delegate, err := authDelegate(auth, principal, actor)
+		if err != nil {
+			return err
+		}
+		if clientAuthRank(ClientAuthLevel(delegate.ClientAuth)) < clientAuthRank(level) {
+			delegate.ClientAuth = string(level)
+		}
+		return nil
+	})
+}
+
+func clientAuthRank(level ClientAuthLevel) int {
+	switch level {
+	case AuthPrivateKeyJWTMTLS:
+		return 4
+	case AuthPrivateKeyJWT:
+		return 3
+	case AuthCIMD:
+		return 2
+	case AuthDCRDomain, AuthDCRLocal:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/pkg/openlore/settings_permissions_test.go
+++ b/pkg/openlore/settings_permissions_test.go
@@ -2,6 +2,7 @@ package openlore
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -19,6 +20,21 @@ type captureAuditLog struct{ events []AuditEvent }
 func (l *captureAuditLog) Record(_ context.Context, event AuditEvent) error {
 	l.events = append(l.events, event)
 	return nil
+}
+
+type actorFailingAuthorizationStore struct{ AuthorizationStore }
+
+func (s actorFailingAuthorizationStore) ResolveAuthorization(ctx context.Context, principal AuthenticatedPrincipal) (AuthorizationPolicy, error) {
+	if actor, _ := principal.Claims["actor"].(string); actor != "" {
+		return AuthorizationPolicy{}, errors.New("delegate policy references an unknown role")
+	}
+	return s.AuthorizationStore.ResolveAuthorization(ctx, principal)
+}
+
+type failingRevokeStore struct{ RefreshTokenStore }
+
+func (s failingRevokeStore) RevokeDelegation(string, string) (int, error) {
+	return 0, errors.New("refresh store unavailable")
 }
 
 func newPermissionsTestServer(t *testing.T) (*Server, *passkeys.SessionManager, *captureAuditLog) {
@@ -115,6 +131,32 @@ func TestPermissionsPageRequiresSessionAndShowsEffectiveAccess(t *testing.T) {
 	}
 }
 
+func TestPermissionsPageKeepsUnresolvableDelegateDisconnectable(t *testing.T) {
+	s, manager, _ := newPermissionsTestServer(t)
+	s.authorizationStore = actorFailingAuthorizationStore{AuthorizationStore: s.authorizationStore}
+	s.currentAuth().Identities[1].Comment = "cron agent for reports"
+	s.currentAuth().Identities[1].CreatedBy = ""
+
+	req := authenticatedPermissionsRequest(t, manager, http.MethodGet, permissionsPath, nil)
+	rec := httptest.NewRecorder()
+	s.handlePermissionsPage(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"claude@claude.ai", "Permissions unavailable", "unknown role", "Disconnect"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
+	if strings.Contains(body, "cron agent for reports") {
+		t.Error("arbitrary identity comment was rendered as a display name")
+	}
+	if strings.Contains(body, "Save permissions") {
+		t.Error("page offered to edit permissions that could not be resolved")
+	}
+}
+
 func TestDelegateUpdateIsCSRFProtectedAndSelfService(t *testing.T) {
 	s, manager, audit := newPermissionsTestServer(t)
 
@@ -188,6 +230,24 @@ func TestDelegateRemoveRevokesRefreshChainsAndAuditsCount(t *testing.T) {
 	}
 }
 
+func TestDelegateRemoveRedirectsWhenRefreshRevocationFails(t *testing.T) {
+	s, manager, audit := newPermissionsTestServer(t)
+	s.refreshStore = failingRevokeStore{RefreshTokenStore: s.refreshStore}
+	req := authenticatedFormRequest(t, s, manager, permissionsRemovePath, url.Values{"actor": {"claude@claude.ai"}})
+	rec := httptest.NewRecorder()
+	s.handleDelegateRemove(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	principal, _ := s.findAuthIdentity("alice")
+	if _, ok := findDelegate(principal, "claude@claude.ai"); ok {
+		t.Fatal("delegate was not removed")
+	}
+	if len(audit.events) != 1 || audit.events[0].Details["error"] != "refresh store unavailable" {
+		t.Fatalf("audit events=%+v", audit.events)
+	}
+}
+
 func TestRecordDelegateClientAuthKeepsStrongestVerification(t *testing.T) {
 	s, _, audit := newPermissionsTestServer(t)
 	if err := s.recordDelegateClientAuth("alice", "claude@claude.ai", AuthPrivateKeyJWT); err != nil {
@@ -201,7 +261,7 @@ func TestRecordDelegateClientAuthKeepsStrongestVerification(t *testing.T) {
 	if delegate.ClientAuth != string(AuthPrivateKeyJWT) || clientAuthLabel(ClientAuthLevel(delegate.ClientAuth)) != "JWKS" {
 		t.Fatalf("client auth=%q", delegate.ClientAuth)
 	}
-	if len(audit.events) != 1 || audit.events[0].Type != "delegate.update" {
+	if len(audit.events) != 1 || audit.events[0].Type != "delegate.client_auth" {
 		t.Fatalf("audit events=%+v", audit.events)
 	}
 }

--- a/pkg/openlore/settings_permissions_test.go
+++ b/pkg/openlore/settings_permissions_test.go
@@ -1,0 +1,207 @@
+package openlore
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/internal/passkeys"
+)
+
+type captureAuditLog struct{ events []AuditEvent }
+
+func (l *captureAuditLog) Record(_ context.Context, event AuditEvent) error {
+	l.events = append(l.events, event)
+	return nil
+}
+
+func newPermissionsTestServer(t *testing.T) (*Server, *passkeys.SessionManager, *captureAuditLog) {
+	t.Helper()
+	s := newTokenTestServer(t, true, "deny")
+	s.auth.Roles["alice"] = config.RoleSpec{Allow: config.CapabilityRules{Capabilities: []string{"lore:publish"}}}
+	s.auth.Identities[0].Delegates = []config.DelegateEntry{{Identity: "claude@claude.ai", DenyDocsets: []string{"secret"}, ClientAuth: string(AuthCIMD)}}
+	s.auth.Identities = append(s.auth.Identities,
+		config.AuthIdentity{Name: "claude@claude.ai", Comment: "Display: Claude", CreatedBy: "oauth"},
+		config.AuthIdentity{Name: "bob", Roles: []string{"alice"}, Delegates: []config.DelegateEntry{{Identity: "chatgpt@chatgpt.com"}}},
+		config.AuthIdentity{Name: "chatgpt@chatgpt.com", Comment: "Display: ChatGPT", CreatedBy: "oauth"},
+	)
+	s.config.AuthFile = filepath.Join(t.TempDir(), "lore.json")
+	writeAuthFixture(t, s.config.AuthFile, s.auth)
+	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
+	audit := &captureAuditLog{}
+	s.audit = audit
+	key := []byte("settings-test-key")
+	pk, err := passkeys.New(passkeys.Config{
+		Enabled: true, RPID: "localhost", RPName: "OpenLore", RPOrigins: []string{"http://localhost"},
+		PasskeysFile: filepath.Join(t.TempDir(), "passkeys.json"), SessionTTL: time.Hour,
+	}, key, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pk.Shutdown)
+	pk.SetAuthConfig(s.auth)
+	s.passkeys = pk
+	return s, passkeys.NewSessionManager(key, time.Hour), audit
+}
+
+func authenticatedPermissionsRequest(t *testing.T, manager *passkeys.SessionManager, method, target string, form url.Values) *http.Request {
+	t.Helper()
+	var body *strings.Reader
+	if form == nil {
+		body = strings.NewReader("")
+	} else {
+		body = strings.NewReader(form.Encode())
+	}
+	req := httptest.NewRequest(method, target, body)
+	if form != nil {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	rec := httptest.NewRecorder()
+	if err := manager.SetCookie(rec, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(rec.Result().Cookies()[0])
+	return req
+}
+
+func csrfForRequest(t *testing.T, s *Server, req *http.Request) string {
+	t.Helper()
+	session, ok := s.passkeys.Session(req)
+	if !ok {
+		t.Fatal("session did not validate")
+	}
+	return s.passkeys.CSRFToken(session)
+}
+
+func authenticatedFormRequest(t *testing.T, s *Server, manager *passkeys.SessionManager, target string, form url.Values) *http.Request {
+	t.Helper()
+	cookieReq := authenticatedPermissionsRequest(t, manager, http.MethodPost, target, nil)
+	form.Set("csrf", csrfForRequest(t, s, cookieReq))
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookieReq.Cookies()[0])
+	return req
+}
+
+func TestPermissionsPageRequiresSessionAndShowsEffectiveAccess(t *testing.T) {
+	s, manager, _ := newPermissionsTestServer(t)
+
+	unauthenticated := httptest.NewRecorder()
+	s.handlePermissionsPage(unauthenticated, httptest.NewRequest(http.MethodGet, permissionsPath, nil))
+	if unauthenticated.Code != http.StatusFound || !strings.HasPrefix(unauthenticated.Header().Get("Location"), "/passkey/login") {
+		t.Fatalf("unauthenticated response: status=%d location=%q", unauthenticated.Code, unauthenticated.Header().Get("Location"))
+	}
+
+	req := authenticatedPermissionsRequest(t, manager, http.MethodGet, permissionsPath, nil)
+	rec := httptest.NewRecorder()
+	s.handlePermissionsPage(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"claude@claude.ai", "Claude", ">CIMD<", "Delegates inherit your access, minus these denials", "public", "secret", "lore:publish"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("page missing %q", want)
+		}
+	}
+	if !strings.Contains(body, `name="allowed_docsets" value="public" checked`) || strings.Contains(body, `name="allowed_docsets" value="secret" checked`) {
+		t.Errorf("page did not render effective docset toggles: %s", body)
+	}
+}
+
+func TestDelegateUpdateIsCSRFProtectedAndSelfService(t *testing.T) {
+	s, manager, audit := newPermissionsTestServer(t)
+
+	badReq := authenticatedPermissionsRequest(t, manager, http.MethodPost, permissionsUpdatePath, url.Values{"actor": {"claude@claude.ai"}})
+	badRec := httptest.NewRecorder()
+	s.handleDelegateUpdate(badRec, badReq)
+	if badRec.Code != http.StatusForbidden {
+		t.Fatalf("missing CSRF status=%d", badRec.Code)
+	}
+
+	form := url.Values{
+		"actor":                {"claude@claude.ai"},
+		"allowed_docsets":      {"public", "secret"},
+		"allowed_capabilities": {"lore:publish"},
+	}
+	req := authenticatedFormRequest(t, s, manager, permissionsUpdatePath, form)
+	rec := httptest.NewRecorder()
+	s.handleDelegateUpdate(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	principal, _ := s.findAuthIdentity("alice")
+	delegate, _ := findDelegate(principal, "claude@claude.ai")
+	if len(delegate.DenyDocsets) != 0 || len(delegate.DenyCapabilities) != 0 {
+		t.Fatalf("delegate denials=%+v", delegate)
+	}
+	if len(audit.events) != 1 || audit.events[0].Type != "delegate.update" {
+		t.Fatalf("audit events=%+v", audit.events)
+	}
+
+	foreignReq := authenticatedFormRequest(t, s, manager, permissionsUpdatePath, url.Values{"actor": {"chatgpt@chatgpt.com"}})
+	foreignRec := httptest.NewRecorder()
+	s.handleDelegateUpdate(foreignRec, foreignReq)
+	if foreignRec.Code != http.StatusBadRequest {
+		t.Fatalf("foreign delegate update status=%d", foreignRec.Code)
+	}
+}
+
+func TestDelegateRemoveRevokesRefreshChainsAndAuditsCount(t *testing.T) {
+	s, manager, audit := newPermissionsTestServer(t)
+	expires := time.Now().Add(time.Hour)
+	for _, token := range []RefreshToken{
+		{Token: "one", Subject: "alice", Actor: "claude@claude.ai", ChainID: "chain-1", ExpiresAt: expires},
+		{Token: "two", Subject: "alice", Actor: "claude@claude.ai", ChainID: "chain-2", ExpiresAt: expires},
+		{Token: "other", Subject: "bob", Actor: "claude@claude.ai", ChainID: "chain-3", ExpiresAt: expires},
+	} {
+		if err := s.refreshStore.Save(token); err != nil {
+			t.Fatal(err)
+		}
+	}
+	req := authenticatedFormRequest(t, s, manager, permissionsRemovePath, url.Values{"actor": {"claude@claude.ai"}})
+	rec := httptest.NewRecorder()
+	s.handleDelegateRemove(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	principal, _ := s.findAuthIdentity("alice")
+	if _, ok := findDelegate(principal, "claude@claude.ai"); ok {
+		t.Fatal("delegate was not removed")
+	}
+	for _, token := range []string{"one", "two"} {
+		if _, ok, _ := s.refreshStore.Lookup(token); ok {
+			t.Errorf("refresh token %q was not revoked", token)
+		}
+	}
+	if _, ok, _ := s.refreshStore.Lookup("other"); !ok {
+		t.Fatal("unrelated refresh token was revoked")
+	}
+	if len(audit.events) != 1 || audit.events[0].Type != "delegate.remove" || audit.events[0].Details["revoked_refresh_chains"] != 2 {
+		t.Fatalf("audit events=%+v", audit.events)
+	}
+}
+
+func TestRecordDelegateClientAuthKeepsStrongestVerification(t *testing.T) {
+	s, _, audit := newPermissionsTestServer(t)
+	if err := s.recordDelegateClientAuth("alice", "claude@claude.ai", AuthPrivateKeyJWT); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.recordDelegateClientAuth("alice", "claude@claude.ai", AuthCIMD); err != nil {
+		t.Fatal(err)
+	}
+	principal, _ := s.findAuthIdentity("alice")
+	delegate, _ := findDelegate(principal, "claude@claude.ai")
+	if delegate.ClientAuth != string(AuthPrivateKeyJWT) || clientAuthLabel(ClientAuthLevel(delegate.ClientAuth)) != "JWKS" {
+		t.Fatalf("client auth=%q", delegate.ClientAuth)
+	}
+	if len(audit.events) != 1 || audit.events[0].Type != "delegate.update" {
+		t.Fatalf("audit events=%+v", audit.events)
+	}
+}

--- a/pkg/openlore/tokenendpoint.go
+++ b/pkg/openlore/tokenendpoint.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -110,6 +111,7 @@ type tokenEndpoint struct {
 	clientAuth   ClientAuthenticator
 	audit        AuditLog
 	delegateAuth delegateClientAuthRecorder
+	logger       *slog.Logger
 }
 
 type delegateClientAuthRecorder interface {
@@ -213,8 +215,11 @@ func (t *tokenEndpoint) handleAuthorizationCode(w http.ResponseWriter, r *http.R
 	}
 	if c.Actor != "" && t.delegateAuth != nil {
 		if err := t.delegateAuth.recordDelegateClientAuth(c.Subject, c.Actor, clientAuth); err != nil {
-			oauthError(w, http.StatusInternalServerError, "server_error", "failed to record client authentication")
-			return
+			logger := t.logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.Error("failed to record delegated client authentication", "principal", c.Subject, "actor", c.Actor, "error", err)
 		}
 	}
 	t.issue(w, Attribution{Principal: c.Subject, Actor: c.Actor, ClientAuth: clientAuth}, c.Scope, randomToken(), c.ClientID)

--- a/pkg/openlore/tokenendpoint.go
+++ b/pkg/openlore/tokenendpoint.go
@@ -104,11 +104,16 @@ type tokenEndpoint struct {
 	// wif performs the jwt-bearer (WIF) exchange: verify an external IdP
 	// assertion, match it to a rule, and return the subject/scope/TTL to mint.
 	// nil when no OIDC issuers are configured (grant stays unsupported).
-	wif        wifExchanger
-	delegation delegationExchanger
-	cimd       CIMDResolver
-	clientAuth ClientAuthenticator
-	audit      AuditLog
+	wif          wifExchanger
+	delegation   delegationExchanger
+	cimd         CIMDResolver
+	clientAuth   ClientAuthenticator
+	audit        AuditLog
+	delegateAuth delegateClientAuthRecorder
+}
+
+type delegateClientAuthRecorder interface {
+	recordDelegateClientAuth(principal, actor string, level ClientAuthLevel) error
 }
 
 // wifExchanger verifies an external IdP assertion and resolves it to the
@@ -203,6 +208,12 @@ func (t *tokenEndpoint) handleAuthorizationCode(w http.ResponseWriter, r *http.R
 		}
 		if !verifyPKCE(c.CodeChallengeMethod, verifier, c.CodeChallenge) {
 			oauthError(w, http.StatusBadRequest, "invalid_grant", "PKCE verification failed")
+			return
+		}
+	}
+	if c.Actor != "" && t.delegateAuth != nil {
+		if err := t.delegateAuth.recordDelegateClientAuth(c.Subject, c.Actor, clientAuth); err != nil {
+			oauthError(w, http.StatusInternalServerError, "server_error", "failed to record client authentication")
 			return
 		}
 	}

--- a/pkg/openlore/tokenendpoint_test.go
+++ b/pkg/openlore/tokenendpoint_test.go
@@ -2,12 +2,19 @@ package openlore
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 )
+
+type failingDelegateClientAuthRecorder struct{}
+
+func (failingDelegateClientAuthRecorder) recordDelegateClientAuth(string, string, ClientAuthLevel) error {
+	return errors.New("lore.json is read-only")
+}
 
 func postForm(t *testing.T, h http.Handler, form url.Values) (*httptest.ResponseRecorder, tokenResponse) {
 	t.Helper()
@@ -49,6 +56,20 @@ func TestTokenEndpoint_AuthorizationCodeGrant(t *testing.T) {
 	}
 	if claims.Subject != "alice" {
 		t.Errorf("sub = %q, want alice", claims.Subject)
+	}
+}
+
+func TestTokenEndpoint_ClientAuthRecordingFailureDoesNotBlockToken(t *testing.T) {
+	s := newTokenTestServer(t, true, "allow")
+	s.tokens.delegateAuth = failingDelegateClientAuthRecorder{}
+	code := s.authCodes.Issue(authCode{Subject: "alice", Actor: "claude@claude.ai", Scope: ScopeFull})
+
+	rec, resp := postForm(t, s.tokens, url.Values{
+		"grant_type": {"authorization_code"},
+		"code":       {code},
+	})
+	if rec.Code != http.StatusOK || resp.AccessToken == "" {
+		t.Fatalf("status=%d response=%+v body=%s", rec.Code, resp, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a passkey-authenticated self-service dashboard at `/settings/permissions`
- let principals update delegate docset/capability denials and disconnect delegates with session-bound CSRF protection
- revoke delegated refresh-token chains on disconnect and audit updates/removals
- show effective access and recorded CIMD/JWKS/mTLS verification levels
- share one embedded light/dark stylesheet across dashboard, OAuth consent, and passkey pages

## Verification
- `go test ./...`
- `go test -race ./internal/passkeys ./pkg/openlore`
- `go vet ./...`
- `go build ./cmd/openlore`
- browser preview checked at desktop width in light color scheme