### PR TITLE
fix(oauth): tolerate concurrent refresh retries

### DIFF
--- a/assets/config/openlore.yml
+++ b/assets/config/openlore.yml
@@ -62,5 +62,5 @@ passkeys:
 tokens:
   issuer: https://openlore.sh
   audience: https://openlore.sh
-  access_ttl: 30m
+  access_ttl: 1h
   refresh_ttl: 720h

--- a/assets/lore/mcp.md
+++ b/assets/lore/mcp.md
@@ -140,7 +140,7 @@ access policy):
 tokens:
   issuer: https://your-host
   audience: https://your-host
-  access_ttl: 30m
+  access_ttl: 1h
   refresh_ttl: 720h
 ```
 

--- a/assets/lore/workload-identity-federation.md
+++ b/assets/lore/workload-identity-federation.md
@@ -60,7 +60,7 @@ keys (JWKS) to verify assertion signatures.
 tokens:
   issuer: https://openlore.example       # your OpenLore instance (iss + JWKS base)
   audience: https://openlore.example     # one audience per instance
-  access_ttl: 30m
+  access_ttl: 1h
   refresh_ttl: 720h
 
 oidc_issuers:

--- a/cmd/openlore/main.go
+++ b/cmd/openlore/main.go
@@ -543,7 +543,7 @@ func main() {
 				tokCmd := flag.NewFlagSet("token mint", flag.ExitOnError)
 				identity := tokCmd.String("identity", "", "identity name = token `sub` (required)")
 				scope := tokCmd.String("scope", openlore.ScopeFull, "token scope")
-				ttl := tokCmd.Duration("ttl", 30*time.Minute, "access token lifetime")
+				ttl := tokCmd.Duration("ttl", time.Hour, "access token lifetime")
 				configPath := tokCmd.String("config", "./openlore.yml", "path to openlore.yml (holds the tokens block + data dir)")
 				tokCmd.Parse(os.Args[3:])
 

--- a/docs/authenticated-oauth-clients.md
+++ b/docs/authenticated-oauth-clients.md
@@ -55,3 +55,8 @@ openlore oauth keys rotate --revoke-previous --config ./openlore.yml
 The server observes CLI rotations without restarting. Clients can disconnect by
 posting their refresh token to `/oauth/revoke`; OpenLore revokes the full refresh
 chain, while already-issued access tokens expire at their normal short TTL.
+
+Access tokens last one hour by default. Refresh tokens rotate on use. OpenLore
+returns the same successor refresh token when a client retries within 30 seconds,
+so a lost response or concurrent reconnect does not revoke an otherwise valid
+session. Reuse after that grace period still revokes the full refresh chain.

--- a/docs/workload-identity-federation.md
+++ b/docs/workload-identity-federation.md
@@ -61,7 +61,7 @@ auth:
   tokens:
     issuer: https://openlore.example       # your OpenLore instance (iss + JWKS base)
     audience: https://openlore.example     # one audience per instance
-    access_ttl: 30m
+    access_ttl: 1h
     refresh_ttl: 720h
 
   oidc_issuers:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -283,7 +283,7 @@ type DocsetAccess struct {
 type AuthTokensConfig struct {
 	Issuer     string `yaml:"issuer" json:"issuer,omitempty"`           // `iss` claim + JWKS base
 	Audience   string `yaml:"audience" json:"audience,omitempty"`       // required `aud`; one per instance
-	AccessTTL  string `yaml:"access_ttl" json:"access_ttl,omitempty"`   // duration string, default 30m
+	AccessTTL  string `yaml:"access_ttl" json:"access_ttl,omitempty"`   // duration string, default 1h
 	RefreshTTL string `yaml:"refresh_ttl" json:"refresh_ttl,omitempty"` // duration string, default 720h
 }
 

--- a/openlore.yml.example
+++ b/openlore.yml.example
@@ -165,7 +165,7 @@ host_key_path: .ssh/openlore_ed25519
 # tokens:
 #   issuer: https://docs.example.com      # `iss` claim + JWKS base URL
 #   audience: https://docs.example.com    # required `aud`; one per instance
-#   access_ttl: 30m                       # access-token lifetime
+#   access_ttl: 1h                        # access-token lifetime
 #   refresh_ttl: 720h                     # refresh-token lifetime
 #
 # Workload Identity Federation (WIF): external IdPs whose JWTs are exchanged for

--- a/pkg/openlore/identitystore.go
+++ b/pkg/openlore/identitystore.go
@@ -58,7 +58,7 @@ func (s *Server) initAuth() error {
 		if err != nil {
 			return err
 		}
-		iss.retireGrace = parseDurationDefault(tc.AccessTTL, 30*time.Minute)
+		iss.retireGrace = parseDurationDefault(tc.AccessTTL, time.Hour)
 		s.issuer = iss
 	}
 	if s.refreshStore == nil {
@@ -95,7 +95,7 @@ func (s *Server) initAuth() error {
 		issuer:       s.issuer,
 		refresh:      s.refreshStore,
 		codes:        s.authCodes,
-		accessTTL:    parseDurationDefault(tc.AccessTTL, 30*time.Minute),
+		accessTTL:    parseDurationDefault(tc.AccessTTL, time.Hour),
 		refreshTTL:   parseDurationDefault(tc.RefreshTTL, 720*time.Hour),
 		audience:     tc.Audience,
 		delegation:   s,

--- a/pkg/openlore/issuer.go
+++ b/pkg/openlore/issuer.go
@@ -79,7 +79,7 @@ func NewIssuerFromConfig(cfg config.Config) (Issuer, error) {
 	}
 	issuer, err := newESIssuer(cfg.Tokens.Issuer, cfg.Tokens.Audience, filepath.Join(dataDir, "auth", "es256.pem"))
 	if err == nil {
-		issuer.retireGrace = parseDurationDefault(cfg.Tokens.AccessTTL, 30*time.Minute)
+		issuer.retireGrace = parseDurationDefault(cfg.Tokens.AccessTTL, time.Hour)
 	}
 	return issuer, err
 }
@@ -115,7 +115,7 @@ func newESIssuer(issuer, audience, keyPath string) (*esIssuer, error) {
 		audience: audience,
 		key:      key,
 		kid:      keyID(&key.PublicKey),
-		keyPath:  keyPath + ".keys.json", retireGrace: 30 * time.Minute,
+		keyPath:  keyPath + ".keys.json", retireGrace: time.Hour,
 	}
 	if err := e.loadKeySet(); err != nil {
 		return nil, err

--- a/pkg/openlore/refreshstore.go
+++ b/pkg/openlore/refreshstore.go
@@ -10,12 +10,19 @@ import (
 	"time"
 )
 
-// ErrRefreshReuse signals that an already-used refresh token was presented — a
-// theft indicator. The store revokes the whole chain when this happens.
+// ErrRefreshReuse signals that an already-used refresh token was presented
+// outside the short retry window. The store revokes the whole chain when this
+// happens.
 var ErrRefreshReuse = errors.New("refresh token reuse detected")
 
 // ErrRefreshInvalid signals an unknown or expired refresh token.
 var ErrRefreshInvalid = errors.New("invalid refresh token")
+
+// refreshRetryGrace lets an OAuth client safely retry a refresh request whose
+// response was lost, or issue concurrent refreshes during reconnect. Both
+// requests receive the same successor refresh token. Reuse after this window
+// remains a theft signal and revokes the chain.
+const refreshRetryGrace = 30 * time.Second
 
 // RefreshToken is a stateful, revocable credential. Tokens in the same ChainID
 // descend from one login; rotation issues a new token in the chain and marks
@@ -30,6 +37,13 @@ type RefreshToken struct {
 	ChainID    string          `json:"chain_id"`
 	ExpiresAt  time.Time       `json:"expires_at"`
 	Used       bool            `json:"used"`
+	RotatedAt  time.Time       `json:"rotated_at,omitempty"`
+	ReplacedBy string          `json:"replaced_by,omitempty"`
+}
+
+type RefreshRotation struct {
+	Token   RefreshToken
+	Retried bool
 }
 
 // RefreshTokenStore persists refresh tokens with rotation and reuse detection.
@@ -40,10 +54,11 @@ type RefreshTokenStore interface {
 	Save(rt RefreshToken) error
 	// Lookup returns the token if present.
 	Lookup(token string) (RefreshToken, bool, error)
-	// Rotate consumes oldToken and stores newToken (same chain) atomically. If
-	// oldToken was already used it revokes the whole chain and returns
-	// ErrRefreshReuse; if unknown/expired it returns ErrRefreshInvalid.
-	Rotate(oldToken string, newToken RefreshToken) error
+	// Rotate consumes oldToken and stores newToken (same chain) atomically.
+	// Immediate retries return the previously stored successor. Reuse outside
+	// the retry window revokes the chain and returns ErrRefreshReuse;
+	// unknown/expired tokens return ErrRefreshInvalid.
+	Rotate(oldToken string, newToken RefreshToken) (RefreshRotation, error)
 	// RevokeChain deletes every token descending from one login.
 	RevokeChain(chainID string) error
 	// RevokeDelegation revokes every chain issued to actor on behalf of subject.
@@ -102,34 +117,45 @@ func (s *fileRefreshStore) Lookup(token string) (RefreshToken, bool, error) {
 	return rt, ok, nil
 }
 
-func (s *fileRefreshStore) Rotate(oldToken string, newToken RefreshToken) error {
+func (s *fileRefreshStore) Rotate(oldToken string, newToken RefreshToken) (RefreshRotation, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	old, ok := s.tokens[oldToken]
 	if !ok {
-		return ErrRefreshInvalid
+		return RefreshRotation{}, ErrRefreshInvalid
 	}
 	if old.Used {
+		elapsed := time.Since(old.RotatedAt)
+		if elapsed >= 0 && elapsed <= refreshRetryGrace {
+			if successor, ok := s.tokens[old.ReplacedBy]; ok {
+				return RefreshRotation{Token: successor, Retried: true}, nil
+			}
+		}
 		// Reuse of a rotated token → theft. Revoke the whole chain.
 		s.revokeChainLocked(old.ChainID)
 		if err := s.persist(); err != nil {
-			return err
+			return RefreshRotation{}, err
 		}
-		return ErrRefreshReuse
+		return RefreshRotation{}, ErrRefreshReuse
 	}
 	if !old.ExpiresAt.IsZero() && old.ExpiresAt.Before(time.Now()) {
 		delete(s.tokens, oldToken)
 		if err := s.persist(); err != nil {
-			return err
+			return RefreshRotation{}, err
 		}
-		return ErrRefreshInvalid
+		return RefreshRotation{}, ErrRefreshInvalid
 	}
 
 	old.Used = true
+	old.RotatedAt = time.Now()
+	old.ReplacedBy = newToken.Token
 	s.tokens[oldToken] = old
 	s.tokens[newToken.Token] = newToken
-	return s.persist()
+	if err := s.persist(); err != nil {
+		return RefreshRotation{}, err
+	}
+	return RefreshRotation{Token: newToken}, nil
 }
 
 func (s *fileRefreshStore) RevokeChain(chainID string) error {

--- a/pkg/openlore/refreshstore.go
+++ b/pkg/openlore/refreshstore.go
@@ -18,6 +18,10 @@ var ErrRefreshReuse = errors.New("refresh token reuse detected")
 // ErrRefreshInvalid signals an unknown or expired refresh token.
 var ErrRefreshInvalid = errors.New("invalid refresh token")
 
+// ErrRefreshStaleRetry signals that an immediate retry's successor has already
+// been consumed or expired. The current chain remains valid and is not revoked.
+var ErrRefreshStaleRetry = errors.New("stale refresh retry")
+
 // refreshRetryGrace lets an OAuth client safely retry a refresh request whose
 // response was lost, or issue concurrent refreshes during reconnect. Both
 // requests receive the same successor refresh token. Reuse after this window
@@ -129,8 +133,12 @@ func (s *fileRefreshStore) Rotate(oldToken string, newToken RefreshToken) (Refre
 		elapsed := time.Since(old.RotatedAt)
 		if elapsed >= 0 && elapsed <= refreshRetryGrace {
 			if successor, ok := s.tokens[old.ReplacedBy]; ok {
+				if successor.Used || (!successor.ExpiresAt.IsZero() && successor.ExpiresAt.Before(time.Now())) {
+					return RefreshRotation{}, ErrRefreshStaleRetry
+				}
 				return RefreshRotation{Token: successor, Retried: true}, nil
 			}
+			return RefreshRotation{}, ErrRefreshStaleRetry
 		}
 		// Reuse of a rotated token → theft. Revoke the whole chain.
 		s.revokeChainLocked(old.ChainID)

--- a/pkg/openlore/refreshstore_test.go
+++ b/pkg/openlore/refreshstore_test.go
@@ -37,27 +37,54 @@ func TestRefreshStore_RotateIssuesNewAndConsumesOld(t *testing.T) {
 	rs.Save(old)
 
 	next := RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)}
-	if err := rs.Rotate("old", next); err != nil {
+	rotation, err := rs.Rotate("old", next)
+	if err != nil {
 		t.Fatalf("Rotate: %v", err)
+	}
+	if rotation.Token.Token != "new" || rotation.Retried {
+		t.Fatalf("rotation = %+v", rotation)
 	}
 	// New token is present and unused.
 	if got, ok, _ := rs.Lookup("new"); !ok || got.Used {
 		t.Fatalf("new token missing or already used: ok=%v", ok)
 	}
 	// Old token is now marked used.
-	if got, ok, _ := rs.Lookup("old"); !ok || !got.Used {
-		t.Fatalf("old token should be marked used: ok=%v used=%v", ok, got.Used)
+	if got, ok, _ := rs.Lookup("old"); !ok || !got.Used || got.ReplacedBy != "new" || got.RotatedAt.IsZero() {
+		t.Fatalf("old token should point to its replacement: ok=%v token=%+v", ok, got)
 	}
 }
 
-func TestRefreshStore_ReuseRevokesChain(t *testing.T) {
+func TestRefreshStore_ImmediateRetryReturnsSameSuccessor(t *testing.T) {
 	rs := testRefreshStore(t)
-	// A chain of two rotated tokens.
 	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
-	rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
 
-	// Re-presenting the already-used "old" is theft → revoke whole chain.
-	err := rs.Rotate("old", RefreshToken{Token: "attacker", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
+	rotation, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if rotation.Token.Token != "new" || !rotation.Retried {
+		t.Fatalf("retry rotation = %+v", rotation)
+	}
+	if _, ok, _ := rs.Lookup("discarded"); ok {
+		t.Fatal("retry candidate must not be stored")
+	}
+}
+
+func TestRefreshStore_ReuseAfterGraceRevokesChain(t *testing.T) {
+	rs := testRefreshStore(t)
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	old := rs.tokens["old"]
+	old.RotatedAt = time.Now().Add(-refreshRetryGrace - time.Second)
+	rs.tokens["old"] = old
+
+	// Re-presenting the used token after the retry grace is theft → revoke.
+	_, err := rs.Rotate("old", RefreshToken{Token: "attacker", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
 	if !errors.Is(err, ErrRefreshReuse) {
 		t.Fatalf("expected ErrRefreshReuse, got %v", err)
 	}
@@ -72,7 +99,7 @@ func TestRefreshStore_ReuseRevokesChain(t *testing.T) {
 
 func TestRefreshStore_RotateUnknownInvalid(t *testing.T) {
 	rs := testRefreshStore(t)
-	err := rs.Rotate("nope", RefreshToken{Token: "x", ChainID: "c1"})
+	_, err := rs.Rotate("nope", RefreshToken{Token: "x", ChainID: "c1"})
 	if !errors.Is(err, ErrRefreshInvalid) {
 		t.Fatalf("expected ErrRefreshInvalid, got %v", err)
 	}
@@ -113,14 +140,18 @@ func TestRefreshStore_Persistence(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "refresh.json")
 	rs, _ := newFileRefreshStore(path)
-	rs.Save(RefreshToken{Token: "a", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
 
-	// A fresh store reading the same file sees the token.
+	// A fresh store reading the same file can safely satisfy an in-flight retry.
 	rs2, err := newFileRefreshStore(path)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
-	if _, ok, _ := rs2.Lookup("a"); !ok {
-		t.Fatalf("token did not persist across reopen")
+	rotation, err := rs2.Rotate("old", RefreshToken{Token: "discarded", ChainID: "c1"})
+	if err != nil || !rotation.Retried || rotation.Token.Token != "new" {
+		t.Fatalf("persisted retry: rotation=%+v err=%v", rotation, err)
 	}
 }

--- a/pkg/openlore/refreshstore_test.go
+++ b/pkg/openlore/refreshstore_test.go
@@ -73,6 +73,29 @@ func TestRefreshStore_ImmediateRetryReturnsSameSuccessor(t *testing.T) {
 	}
 }
 
+func TestRefreshStore_StaleRetryDoesNotRevokeCurrentChain(t *testing.T) {
+	rs := testRefreshStore(t)
+	expires := time.Now().Add(time.Hour)
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rs.Rotate("new", RefreshToken{Token: "newest", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	if !errors.Is(err, ErrRefreshStaleRetry) {
+		t.Fatalf("expected ErrRefreshStaleRetry, got %v", err)
+	}
+	if current, ok, _ := rs.Lookup("newest"); !ok || current.Used {
+		t.Fatalf("stale retry revoked current token: ok=%v token=%+v", ok, current)
+	}
+	if _, err := rs.Rotate("newest", RefreshToken{Token: "next", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+		t.Fatalf("current chain is unusable after stale retry: %v", err)
+	}
+}
+
 func TestRefreshStore_ReuseAfterGraceRevokesChain(t *testing.T) {
 	rs := testRefreshStore(t)
 	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})

--- a/pkg/openlore/tokenendpoint.go
+++ b/pkg/openlore/tokenendpoint.go
@@ -334,6 +334,9 @@ func (t *tokenEndpoint) handleRefreshToken(w http.ResponseWriter, r *http.Reques
 		oauthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
 		return
 	}
+	// Subsequent audit events describe the authentication achieved by this
+	// request, which may be stronger than the level stored on the old token.
+	old.ClientAuth = clientAuth
 	// Rotate: mint a new refresh token in the same chain and consume the old.
 	newRefresh := RefreshToken{
 		Token:      randomToken(),

--- a/pkg/openlore/tokenendpoint.go
+++ b/pkg/openlore/tokenendpoint.go
@@ -313,20 +313,24 @@ func (t *tokenEndpoint) issueAccessOnly(w http.ResponseWriter, attribution Attri
 func (t *tokenEndpoint) handleRefreshToken(w http.ResponseWriter, r *http.Request) {
 	presented := r.Form.Get("refresh_token")
 	if presented == "" {
+		t.recordRefresh(r.Context(), "missing_token", RefreshToken{}, nil)
 		oauthError(w, http.StatusBadRequest, "invalid_request", "refresh_token required")
 		return
 	}
 	old, ok, err := t.refresh.Lookup(presented)
 	if err != nil {
+		t.recordRefresh(r.Context(), "lookup_failed", RefreshToken{}, err)
 		oauthError(w, http.StatusInternalServerError, "server_error", "lookup failed")
 		return
 	}
 	if !ok {
+		t.recordRefresh(r.Context(), "unknown_token", RefreshToken{}, nil)
 		oauthError(w, http.StatusBadRequest, "invalid_grant", "unknown refresh token")
 		return
 	}
 	clientAuth, err := t.authenticateBoundClient(r, old)
 	if err != nil {
+		t.recordRefresh(r.Context(), "invalid_client", old, err)
 		oauthError(w, http.StatusUnauthorized, "invalid_client", err.Error())
 		return
 	}
@@ -341,12 +345,57 @@ func (t *tokenEndpoint) handleRefreshToken(w http.ResponseWriter, r *http.Reques
 		ChainID:    old.ChainID,
 		ExpiresAt:  time.Now().Add(t.refreshTTL),
 	}
-	if err := t.refresh.Rotate(presented, newRefresh); err != nil {
+	rotation, err := t.refresh.Rotate(presented, newRefresh)
+	if err != nil {
 		// Reuse or invalid → deny (chain already revoked on reuse).
+		t.recordRefresh(r.Context(), "rotation_rejected", old, err)
 		oauthError(w, http.StatusBadRequest, "invalid_grant", "refresh token rejected")
 		return
 	}
-	t.issueRotated(w, Attribution{Principal: old.Subject, Actor: old.Actor, ClientAuth: clientAuth}, old.Scope, newRefresh.Token)
+	if !t.issueRotated(w, Attribution{Principal: old.Subject, Actor: old.Actor, ClientAuth: clientAuth}, old.Scope, rotation.Token.Token) {
+		t.recordRefresh(r.Context(), "mint_failed", old, nil)
+		return
+	}
+	outcome := "success"
+	if rotation.Retried {
+		outcome = "retry"
+	}
+	t.recordRefresh(r.Context(), outcome, old, nil)
+}
+
+func (t *tokenEndpoint) recordRefresh(ctx context.Context, outcome string, token RefreshToken, refreshErr error) {
+	details := map[string]any{"outcome": outcome}
+	if token.ClientID != "" {
+		details["client_id"] = token.ClientID
+	}
+	if token.ChainID != "" {
+		details["chain_id"] = token.ChainID
+	}
+	if refreshErr != nil {
+		details["error"] = refreshErr.Error()
+	}
+	attribution := Attribution{Principal: token.Subject, Actor: token.Actor, ClientAuth: token.ClientAuth}
+	// Only durable-audit attempts tied to a known chain. The endpoint is public;
+	// persisting arbitrary missing/unknown-token probes would allow log spam.
+	if t.audit != nil && token.ChainID != "" {
+		_ = t.audit.Record(ctx, AuditEvent{Type: "token.refresh", Attribution: attribution, Details: details})
+	}
+	logger := t.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	args := []any{"outcome", outcome, "principal", token.Subject, "actor", token.Actor, "client_id", token.ClientID}
+	if refreshErr != nil {
+		args = append(args, "error", refreshErr)
+	}
+	switch outcome {
+	case "success", "retry":
+		logger.InfoContext(ctx, "oauth token refresh", args...)
+	case "lookup_failed", "mint_failed":
+		logger.ErrorContext(ctx, "oauth token refresh", args...)
+	default:
+		logger.WarnContext(ctx, "oauth token refresh", args...)
+	}
 }
 
 // issue mints access+refresh for a fresh login (new chain).
@@ -378,16 +427,17 @@ func (t *tokenEndpoint) issue(w http.ResponseWriter, attribution Attribution, sc
 
 // issueRotated mints a new access token alongside an already-persisted rotated
 // refresh token.
-func (t *tokenEndpoint) issueRotated(w http.ResponseWriter, attribution Attribution, scope, refreshTok string) {
+func (t *tokenEndpoint) issueRotated(w http.ResponseWriter, attribution Attribution, scope, refreshTok string) bool {
 	if scope == "" {
 		scope = ScopeFull
 	}
 	access, exp, err := t.issuer.Mint(attribution, scope, t.accessTTL)
 	if err != nil {
 		oauthError(w, http.StatusInternalServerError, "server_error", "mint failed")
-		return
+		return false
 	}
 	writeTokenResponse(w, access, refreshTok, scope, exp)
+	return true
 }
 
 func writeTokenResponse(w http.ResponseWriter, access, refresh, scope string, exp time.Time) {

--- a/pkg/openlore/tokenendpoint_test.go
+++ b/pkg/openlore/tokenendpoint_test.go
@@ -1,6 +1,7 @@
 package openlore
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -48,6 +49,9 @@ func TestTokenEndpoint_AuthorizationCodeGrant(t *testing.T) {
 	}
 	if resp.AccessToken == "" || resp.RefreshToken == "" {
 		t.Fatalf("missing tokens in response: %+v", resp)
+	}
+	if resp.ExpiresIn < 3590 || resp.ExpiresIn > 3600 {
+		t.Fatalf("expires_in = %d, want approximately one hour", resp.ExpiresIn)
 	}
 	// The minted access token verifies and carries the right subject.
 	claims, err := s.issuer.Verify(resp.AccessToken)
@@ -124,18 +128,34 @@ func TestTokenEndpoint_RefreshRotation(t *testing.T) {
 	}
 }
 
-func TestTokenEndpoint_RefreshReuseRejected(t *testing.T) {
+func TestTokenEndpoint_RefreshRetryReturnsSameSuccessor(t *testing.T) {
 	s := newTokenTestServer(t, true, "allow")
+	audit := &captureRefreshAudit{}
+	s.tokens.audit = audit
 	code, _ := s.IssueAuthCode("alice", ScopeFull)
 	_, first := postForm(t, s.tokens, url.Values{"grant_type": {"authorization_code"}, "code": {code}})
 
 	// First refresh succeeds (rotates).
-	postForm(t, s.tokens, url.Values{"grant_type": {"refresh_token"}, "refresh_token": {first.RefreshToken}})
-	// Re-using the now-consumed refresh token is rejected.
-	rec, _ := postForm(t, s.tokens, url.Values{"grant_type": {"refresh_token"}, "refresh_token": {first.RefreshToken}})
-	if rec.Code == http.StatusOK {
-		t.Fatalf("reused refresh token should be rejected, got 200")
+	_, second := postForm(t, s.tokens, url.Values{"grant_type": {"refresh_token"}, "refresh_token": {first.RefreshToken}})
+	// An immediate retry succeeds with the already-issued successor rather than
+	// revoking the chain or creating another branch.
+	rec, retry := postForm(t, s.tokens, url.Values{"grant_type": {"refresh_token"}, "refresh_token": {first.RefreshToken}})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("retry status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
+	if retry.RefreshToken != second.RefreshToken {
+		t.Fatalf("retry refresh token = %q, want original successor %q", retry.RefreshToken, second.RefreshToken)
+	}
+	if len(audit.events) != 2 || audit.events[0].Details["outcome"] != "success" || audit.events[1].Details["outcome"] != "retry" {
+		t.Fatalf("refresh audit events = %+v", audit.events)
+	}
+}
+
+type captureRefreshAudit struct{ events []AuditEvent }
+
+func (a *captureRefreshAudit) Record(_ context.Context, event AuditEvent) error {
+	a.events = append(a.events, event)
+	return nil
 }
 
 // With no OIDC issuers configured, WIF is disabled and the jwt-bearer grant is

--- a/pkg/openlore/tokenendpoint_test.go
+++ b/pkg/openlore/tokenendpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -149,6 +150,91 @@ func TestTokenEndpoint_RefreshRetryReturnsSameSuccessor(t *testing.T) {
 	if len(audit.events) != 2 || audit.events[0].Details["outcome"] != "success" || audit.events[1].Details["outcome"] != "retry" {
 		t.Fatalf("refresh audit events = %+v", audit.events)
 	}
+}
+
+func TestTokenEndpoint_ConcurrentRefreshReturnsUsableSuccessor(t *testing.T) {
+	s := newTokenTestServer(t, true, "allow")
+	code, _ := s.IssueAuthCode("alice", ScopeFull)
+	_, first := postForm(t, s.tokens, url.Values{"grant_type": {"authorization_code"}, "code": {code}})
+
+	type result struct {
+		status int
+		body   string
+		token  tokenResponse
+		err    error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for range 2 {
+		go func() {
+			form := url.Values{"grant_type": {"refresh_token"}, "refresh_token": {first.RefreshToken}}
+			req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			ready.Done()
+			<-start
+			rec := httptest.NewRecorder()
+			s.tokens.ServeHTTP(rec, req)
+			var token tokenResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &token)
+			results <- result{status: rec.Code, body: rec.Body.String(), token: token, err: err}
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	firstResult, secondResult := <-results, <-results
+	for i, got := range []result{firstResult, secondResult} {
+		if got.status != http.StatusOK || got.err != nil {
+			t.Fatalf("concurrent refresh %d: status=%d err=%v body=%s", i, got.status, got.err, got.body)
+		}
+	}
+	if firstResult.token.RefreshToken != secondResult.token.RefreshToken {
+		t.Fatalf("concurrent successors differ: %q != %q", firstResult.token.RefreshToken, secondResult.token.RefreshToken)
+	}
+
+	// The shared successor is active, not merely repeated in both responses.
+	rec, next := postForm(t, s.tokens, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {firstResult.token.RefreshToken},
+	})
+	if rec.Code != http.StatusOK || next.RefreshToken == firstResult.token.RefreshToken {
+		t.Fatalf("successor was not usable: status=%d response=%+v body=%s", rec.Code, next, rec.Body.String())
+	}
+}
+
+func TestTokenEndpoint_RefreshAuditUsesCurrentClientAuth(t *testing.T) {
+	s := newTokenTestServer(t, true, "allow")
+	const clientID = "https://chatgpt.com/oauth/client.json"
+	s.tokens.cimd = &fixedCIMDResolver{client: &CIMDClient{ClientID: clientID}}
+	s.tokens.clientAuth = fixedClientAuthenticator{level: AuthPrivateKeyJWTMTLS}
+	audit := &captureRefreshAudit{}
+	s.tokens.audit = audit
+	if err := s.refreshStore.Save(RefreshToken{
+		Token: "refresh", Subject: "alice", ClientID: clientID,
+		ClientAuth: AuthCIMD, Scope: ScopeFull, ChainID: "chain",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec, _ := postForm(t, s.tokens, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {"refresh"},
+		"client_id":     {clientID},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("refresh status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(audit.events) != 1 || audit.events[0].Attribution.ClientAuth != AuthPrivateKeyJWTMTLS {
+		t.Fatalf("refresh audit events = %+v", audit.events)
+	}
+}
+
+type fixedClientAuthenticator struct{ level ClientAuthLevel }
+
+func (a fixedClientAuthenticator) Authenticate(*http.Request, *CIMDClient) (ClientAuthLevel, error) {
+	return a.level, nil
 }
 
 type captureRefreshAudit struct{ events []AuditEvent }


### PR DESCRIPTION
## Summary

- make refresh-token rotation idempotent for 30 seconds so concurrent or retried ChatGPT refresh requests receive the same successor token
- retain chain revocation for refresh-token reuse outside the grace window
- audit and structurally log refresh outcomes without recording token values
- raise the default access-token lifetime from 30 minutes to one hour

## Why

ChatGPT can retry or concurrently issue OAuth refresh requests while reconnecting to an MCP server. OpenLore previously treated the second use immediately as token theft and revoked the entire refresh chain, forcing the user to reauthenticate.

## Verification

- ok  	github.com/aakarim/go-openlore/assets	(cached)
ok  	github.com/aakarim/go-openlore/cmd/openlore	(cached)
ok  	github.com/aakarim/go-openlore/internal/config	(cached)
ok  	github.com/aakarim/go-openlore/internal/httpserver	(cached)
ok  	github.com/aakarim/go-openlore/internal/legal	(cached)
?   	github.com/aakarim/go-openlore/internal/metrics	[no test files]
ok  	github.com/aakarim/go-openlore/internal/passkeys	(cached)
?   	github.com/aakarim/go-openlore/internal/skills	[no test files]
?   	github.com/aakarim/go-openlore/internal/webstyle	[no test files]
ok  	github.com/aakarim/go-openlore/pkg/agentskills	(cached)
ok  	github.com/aakarim/go-openlore/pkg/okf	(cached)
ok  	github.com/aakarim/go-openlore/pkg/openlore	(cached)
ok  	github.com/aakarim/go-openlore/pkg/openlore/meta	(cached)
?   	github.com/aakarim/go-openlore/pkg/openlore/plugin	[no test files]
ok  	github.com/aakarim/go-openlore/pkg/openlore/skillsremote	(cached)
?   	github.com/aakarim/go-openlore/pkg/openlore/validation	[no test files]
?   	github.com/aakarim/go-openlore/pkg/shell	[no test files]
ok  	github.com/aakarim/go-openlore/pkg/shell/cmds	(cached)
ok  	github.com/aakarim/go-openlore/pkg/shell/parser	(cached)
ok  	github.com/aakarim/go-openlore/pkg/vfs	(cached)
- ok  	github.com/aakarim/go-openlore/pkg/openlore	6.756s
- 