### PR TITLE
feat(browser): identity header with permission-settings dropdown

### DIFF
--- a/internal/passkeys/browser.go
+++ b/internal/passkeys/browser.go
@@ -31,6 +31,24 @@ type FileHistoryEntry struct {
 
 type FileHistoryProvider func(identity, filePath string) ([]FileHistoryEntry, error)
 
+// PermissionsPath is the settings page where a principal manages which
+// delegate identities have access to what. The lore browser's identity menu
+// links here; pkg/openlore mounts the handler at the same path.
+const PermissionsPath = "/settings/permissions"
+
+// identityMenuCSS styles the signed-in identity button and its dropdown,
+// shared by the directory and file views.
+const identityMenuCSS = `.identity-menu{position:relative;flex:none}.identity-button{display:flex;align-items:center;gap:.4rem;max-width:13rem;height:2rem;padding:0 .7rem;border:1px solid #30363d;border-radius:999px;background:#21262d;color:#c9d1d9;font:inherit;font-size:.85rem;cursor:pointer}.identity-button:hover{background:#30363d;color:#f0f6fc}.identity-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.identity-caret{flex:none;color:#8b949e;font-size:.6rem}.identity-dropdown{position:absolute;top:calc(100% + .4rem);right:0;z-index:20;min-width:14rem;padding:.4rem;border:1px solid #30363d;border-radius:8px;background:#161b22;box-shadow:0 12px 32px rgba(0,0,0,.5)}.identity-dropdown[hidden]{display:none}.identity-signed-in{margin-bottom:.35rem;padding:.5rem .6rem;border-bottom:1px solid #21262d;color:#8b949e;font-size:.75rem}.identity-signed-in strong{display:block;margin-top:.15rem;overflow-wrap:anywhere;color:#f0f6fc;font-size:.85rem}.identity-dropdown a{display:block;padding:.5rem .6rem;border-radius:6px;color:#c9d1d9;font-size:.85rem;text-decoration:none}.identity-dropdown a:hover{background:#21262d;color:#f0f6fc;text-decoration:none}`
+
+// identityMenuScript toggles the dropdown and closes it on outside click or
+// Escape.
+const identityMenuScript = `<script>(()=>{const button=document.getElementById('identity-button');const dropdown=document.getElementById('identity-dropdown');function close(){dropdown.hidden=true;button.setAttribute('aria-expanded','false')}button.addEventListener('click',event=>{event.stopPropagation();if(dropdown.hidden){dropdown.hidden=false;button.setAttribute('aria-expanded','true')}else{close()}});document.addEventListener('click',event=>{if(!dropdown.hidden&&!dropdown.contains(event.target))close()});document.addEventListener('keydown',event=>{if(event.key==='Escape'&&!dropdown.hidden)close()})})()</script>`
+
+func identityMenuHTML(identity string) string {
+	name := html.EscapeString(identity)
+	return fmt.Sprintf(`<div class="identity-menu"><button type="button" class="identity-button" id="identity-button" aria-haspopup="menu" aria-expanded="false" aria-controls="identity-dropdown" title="Signed in as %s"><span class="identity-name">%s</span><span class="identity-caret" aria-hidden="true">▾</span></button><div class="identity-dropdown" id="identity-dropdown" hidden role="menu"><div class="identity-signed-in">Signed in as<strong>%s</strong></div><a role="menuitem" href="%s">Permission settings</a></div></div>`, name, name, name, PermissionsPath)
+}
+
 // LoreBrowserHandler serves an authenticated web browser over the filesystem.
 // Unauthenticated requests are redirected to the passkey login page.
 //
@@ -80,7 +98,7 @@ func (p *Passkeys) LoreBrowserHandler(fsForIdentity func(identity string) vfs.Fi
 		}
 
 		if info.Dir {
-			p.renderDir(w, fsys, lorePath, fsPath)
+			p.renderDir(w, fsys, lorePath, fsPath, session.Identity)
 			return
 		}
 
@@ -102,7 +120,7 @@ func (p *Passkeys) LoreBrowserHandler(fsForIdentity func(identity string) vfs.Fi
 					}
 				}
 			}
-			p.renderFile(w, r, lorePath, fsPath, history, historyAvailable)
+			p.renderFile(w, r, lorePath, fsPath, session.Identity, history, historyAvailable)
 			return
 		}
 		if isMarkdown(fsPath) {
@@ -120,7 +138,7 @@ func (p *Passkeys) LoreBrowserHandler(fsForIdentity func(identity string) vfs.Fi
 	})
 }
 
-func (p *Passkeys) renderFile(w http.ResponseWriter, r *http.Request, lorePath, fsPath string, history []FileHistoryEntry, historyAvailable bool) {
+func (p *Passkeys) renderFile(w http.ResponseWriter, r *http.Request, lorePath, fsPath, identity string, history []FileHistoryEntry, historyAvailable bool) {
 	parentURL := lorePath + path.Dir(fsPath)
 	if path.Dir(fsPath) == "/" {
 		parentURL += "/"
@@ -146,8 +164,10 @@ func (p *Passkeys) renderFile(w http.ResponseWriter, r *http.Request, lorePath, 
 	b.WriteString(`<meta name="viewport" content="width=device-width, initial-scale=1">`)
 	b.WriteString(pwaHead(lorePath))
 	fmt.Fprintf(&b, "<title>%s — OpenLore</title>", html.EscapeString(name))
-	b.WriteString(`<style>*{box-sizing:border-box}html,body{height:100%;margin:0}body{display:flex;flex-direction:column;background:#0d1117;color:#c9d1d9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif}.bar{height:3rem;flex:none;display:flex;align-items:center;gap:.65rem;padding:0 .85rem;border-bottom:1px solid #30363d;background:#161b22}.breadcrumbs{display:flex;align-items:center;gap:.5rem;min-width:0;overflow:hidden;white-space:nowrap;font-size:.9rem}.breadcrumbs a{color:#58a6ff;text-decoration:none}.breadcrumbs a:hover{text-decoration:underline}.breadcrumbs span[aria-current=page]{overflow:hidden;text-overflow:ellipsis;color:#c9d1d9}.separator{color:#6e7681}.history-toggle,.close{display:grid;place-items:center;height:2rem;flex:none;border:0;border-radius:6px;background:transparent;color:#8b949e;font:inherit;cursor:pointer}.history-toggle{width:2rem;margin-left:auto}.history-toggle:hover,.close:hover{background:#30363d;color:#f0f6fc}.history-toggle svg{width:1.1rem;height:1.1rem;fill:currentColor}.close{width:2rem;text-decoration:none;font-size:1.35rem;line-height:1}.content{display:flex;min-height:0;flex:1}iframe{min-width:0;flex:1;border:0;background:#fff}.history{width:20rem;flex:none;overflow:auto;border-left:1px solid #30363d;background:#161b22}.history[hidden]{display:none}.history-header{position:sticky;top:0;padding:1rem;border-bottom:1px solid #30363d;background:#161b22}.history-header h2{margin:0;color:#f0f6fc;font-size:.95rem}.history-list{list-style:none;margin:0;padding:0}.history-entry{padding:1rem;border-bottom:1px solid #21262d}.history-action{display:inline-block;margin-bottom:.45rem;padding:.15rem .4rem;border-radius:999px;background:#21262d;color:#79c0ff;font-size:.7rem;font-weight:600;text-transform:uppercase}.history-actor{overflow-wrap:anywhere;color:#f0f6fc;font-size:.85rem}.history-time,.history-hash{display:block;margin-top:.3rem;color:#8b949e;font-size:.75rem}.history-hash{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:SFMono-Regular,Consolas,'Liberation Mono',monospace}.history-empty{padding:1rem;color:#8b949e;font-size:.85rem;line-height:1.5}@media(max-width:700px){.history{position:absolute;z-index:2;top:3rem;right:0;bottom:0;width:min(20rem,88vw);box-shadow:-12px 0 30px rgba(0,0,0,.4)}}</style></head><body>`)
-	fmt.Fprintf(&b, `<nav class="bar" aria-label="File navigation"><div class="breadcrumbs">%s</div><button class="history-toggle" id="history-toggle" type="button" aria-controls="file-history" aria-expanded="true" title="Toggle edit history"><span class="sr-only" hidden>Edit history</span><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.643 3.143.427 1.927A.25.25 0 0 1 .604 1.5H4.75a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L3.31 4.81a5.5 5.5 0 1 1-.08 6.384.75.75 0 1 1 1.21-.888 4 4 0 1 0 .055-4.662L5.57 6.72A.75.75 0 0 1 4.51 7.78L1.643 4.914a1.25 1.25 0 0 1 0-1.77ZM8 4.5a.75.75 0 0 1 .75.75v2.44l1.53.765a.75.75 0 0 1-.67 1.342l-1.945-.973A.75.75 0 0 1 7.25 8.15v-2.9A.75.75 0 0 1 8 4.5Z"/></svg></button><a class="close" href="%s" aria-label="Close file and return to folder" title="Close">×</a></nav>`, crumbs.String(), html.EscapeString(parentURL))
+	b.WriteString(`<style>*{box-sizing:border-box}html,body{height:100%;margin:0}body{display:flex;flex-direction:column;background:#0d1117;color:#c9d1d9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif}.bar{height:3rem;flex:none;display:flex;align-items:center;gap:.65rem;padding:0 .85rem;border-bottom:1px solid #30363d;background:#161b22}.breadcrumbs{display:flex;align-items:center;gap:.5rem;min-width:0;overflow:hidden;white-space:nowrap;font-size:.9rem}.breadcrumbs a{color:#58a6ff;text-decoration:none}.breadcrumbs a:hover{text-decoration:underline}.breadcrumbs span[aria-current=page]{overflow:hidden;text-overflow:ellipsis;color:#c9d1d9}.separator{color:#6e7681}.history-toggle,.close{display:grid;place-items:center;height:2rem;flex:none;border:0;border-radius:6px;background:transparent;color:#8b949e;font:inherit;cursor:pointer}.history-toggle{width:2rem;margin-left:auto}.history-toggle:hover,.close:hover{background:#30363d;color:#f0f6fc}.history-toggle svg{width:1.1rem;height:1.1rem;fill:currentColor}.close{width:2rem;text-decoration:none;font-size:1.35rem;line-height:1}.content{display:flex;min-height:0;flex:1}iframe{min-width:0;flex:1;border:0;background:#fff}.history{width:20rem;flex:none;overflow:auto;border-left:1px solid #30363d;background:#161b22}.history[hidden]{display:none}.history-header{position:sticky;top:0;padding:1rem;border-bottom:1px solid #30363d;background:#161b22}.history-header h2{margin:0;color:#f0f6fc;font-size:.95rem}.history-list{list-style:none;margin:0;padding:0}.history-entry{padding:1rem;border-bottom:1px solid #21262d}.history-action{display:inline-block;margin-bottom:.45rem;padding:.15rem .4rem;border-radius:999px;background:#21262d;color:#79c0ff;font-size:.7rem;font-weight:600;text-transform:uppercase}.history-actor{overflow-wrap:anywhere;color:#f0f6fc;font-size:.85rem}.history-time,.history-hash{display:block;margin-top:.3rem;color:#8b949e;font-size:.75rem}.history-hash{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-family:SFMono-Regular,Consolas,'Liberation Mono',monospace}.history-empty{padding:1rem;color:#8b949e;font-size:.85rem;line-height:1.5}@media(max-width:700px){.history{position:absolute;z-index:2;top:3rem;right:0;bottom:0;width:min(20rem,88vw);box-shadow:-12px 0 30px rgba(0,0,0,.4)}}`)
+	b.WriteString(identityMenuCSS)
+	b.WriteString(`</style></head><body>`)
+	fmt.Fprintf(&b, `<nav class="bar" aria-label="File navigation"><div class="breadcrumbs">%s</div><button class="history-toggle" id="history-toggle" type="button" aria-controls="file-history" aria-expanded="true" title="Toggle edit history"><span class="sr-only" hidden>Edit history</span><svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.643 3.143.427 1.927A.25.25 0 0 1 .604 1.5H4.75a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L3.31 4.81a5.5 5.5 0 1 1-.08 6.384.75.75 0 1 1 1.21-.888 4 4 0 1 0 .055-4.662L5.57 6.72A.75.75 0 0 1 4.51 7.78L1.643 4.914a1.25 1.25 0 0 1 0-1.77ZM8 4.5a.75.75 0 0 1 .75.75v2.44l1.53.765a.75.75 0 0 1-.67 1.342l-1.945-.973A.75.75 0 0 1 7.25 8.15v-2.9A.75.75 0 0 1 8 4.5Z"/></svg></button>%s<a class="close" href="%s" aria-label="Close file and return to folder" title="Close">×</a></nav>`, crumbs.String(), identityMenuHTML(identity), html.EscapeString(parentURL))
 	fmt.Fprintf(&b, `<main class="content"><iframe src="%s" title="%s"></iframe><aside class="history" id="file-history" aria-label="Edit history"><header class="history-header"><h2>Edit history</h2></header>`, html.EscapeString(iframeURL), html.EscapeString(name))
 	if !historyAvailable {
 		b.WriteString(`<p class="history-empty">Edit history is unavailable.</p>`)
@@ -167,6 +187,7 @@ func (p *Passkeys) renderFile(w http.ResponseWriter, r *http.Request, lorePath, 
 		b.WriteString(`</ol>`)
 	}
 	b.WriteString(`</aside></main><script>(()=>{const button=document.getElementById('history-toggle');const history=document.getElementById('file-history');button.addEventListener('click',()=>{const open=button.getAttribute('aria-expanded')==='true';button.setAttribute('aria-expanded',String(!open));history.hidden=open})})()</script>`)
+	b.WriteString(identityMenuScript)
 	b.WriteString(`</body></html>`)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -200,7 +221,7 @@ func renderMarkdown(w http.ResponseWriter, source []byte) error {
 	return err
 }
 
-func (p *Passkeys) renderDir(w http.ResponseWriter, fsys vfs.FileSystem, lorePath, fsPath string) {
+func (p *Passkeys) renderDir(w http.ResponseWriter, fsys vfs.FileSystem, lorePath, fsPath, identity string) {
 	entries, err := fsys.ReadDir(fsPath)
 	if err != nil {
 		http.Error(w, "404 not found", http.StatusNotFound)
@@ -218,11 +239,15 @@ func (p *Passkeys) renderDir(w http.ResponseWriter, fsys vfs.FileSystem, lorePat
 	b.WriteString("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
 	b.WriteString(pwaHead(lorePath))
 	b.WriteString("<title>OpenLore</title><style>")
-	b.WriteString("*{box-sizing:border-box;margin:0;padding:0}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#c9d1d9;padding:2rem;max-width:820px;margin:0 auto}")
+	b.WriteString("*{box-sizing:border-box;margin:0;padding:0}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0d1117;color:#c9d1d9}")
+	b.WriteString(".topbar{display:flex;align-items:center;justify-content:space-between;gap:.75rem;height:3rem;padding:0 .85rem;border-bottom:1px solid #30363d;background:#161b22}.brand{color:#f0f6fc;font-size:.95rem;font-weight:600;text-decoration:none}.brand:hover{text-decoration:none}")
+	b.WriteString(identityMenuCSS)
+	b.WriteString("main{max-width:820px;margin:0 auto;padding:2rem}")
 	b.WriteString("h1{font-size:1.2rem;margin-bottom:1rem;color:#c9d1d9}a{color:#58a6ff;text-decoration:none}a:hover{text-decoration:underline}")
 	b.WriteString("ul{list-style:none}li{padding:0.35rem 0;border-bottom:1px solid #21262d}.entry{display:block;padding:.35rem 0;touch-action:manipulation}.dir{color:#79c0ff}.crumb{color:#8b949e;margin-bottom:1.5rem;font-size:0.9rem}.ios-install{display:none;margin:0 0 1.5rem;padding:.85rem 1rem;border:1px solid #30363d;border-radius:8px;background:#161b22;color:#c9d1d9;font-size:.9rem;line-height:1.45}.ios-install strong{display:block;margin-bottom:.2rem;color:#f0f6fc}.share-icon{display:inline-block;color:#58a6ff;font-size:1.15rem;line-height:1;vertical-align:-.08rem}.action-overlay{position:fixed;inset:0;z-index:10;display:grid;place-items:center;padding:1.25rem;background:rgba(0,0,0,.62)}.action-overlay[hidden]{display:none}.action-sheet{width:min(22rem,100%);padding:1rem;border:1px solid #30363d;border-radius:12px;background:#161b22;box-shadow:0 16px 48px rgba(0,0,0,.45)}.action-name{overflow:hidden;margin-bottom:.25rem;color:#f0f6fc;font-weight:600;text-overflow:ellipsis;white-space:nowrap}.action-hint{margin-bottom:1rem;color:#8b949e;font-size:.8rem}.action-buttons{display:grid;grid-template-columns:repeat(3,1fr);gap:.65rem}.action-buttons button{min-height:2.75rem;border:1px solid #30363d;border-radius:8px;background:#21262d;color:#f0f6fc;font:inherit;cursor:pointer}.action-buttons button:active{background:#30363d}.action-subtext{display:block;margin-top:.15rem;color:#8b949e;font-size:.7rem}.copy-status{min-height:1.2rem;margin-top:.65rem;color:#7ee787;font-size:.8rem;text-align:center}</style></head><body>")
 
-	fmt.Fprintf(&b, "<h1>📜 %s</h1>", html.EscapeString(fsPath))
+	fmt.Fprintf(&b, `<header class="topbar"><a class="brand" href="%s/">📜 OpenLore</a>%s</header><main>`, html.EscapeString(strings.TrimRight(lorePath, "/")), identityMenuHTML(identity))
+	fmt.Fprintf(&b, "<h1>%s</h1>", html.EscapeString(fsPath))
 	b.WriteString(`<aside class="ios-install" id="ios-install" aria-label="Install OpenLore"><strong>Add OpenLore to your Home Screen</strong>In Safari, tap Share <span class="share-icon" aria-hidden="true">□<span style="position:relative;left:-.72em;top:-.28em">↑</span></span>, then tap <b>Add to Home Screen</b>. OpenLore will then launch in its own app window.</aside>`)
 	b.WriteString(`<script>(()=>{const standalone=window.matchMedia('(display-mode: standalone)').matches||navigator.standalone===true;const ua=navigator.userAgent;const ios=/iPad|iPhone|iPod/.test(ua)||(navigator.platform==='MacIntel'&&navigator.maxTouchPoints>1);const safari=/Safari/.test(ua)&&!/CriOS|FxiOS|EdgiOS|OPiOS/.test(ua);if(ios&&safari&&!standalone)document.getElementById('ios-install').style.display='block'})()</script>`)
 
@@ -243,7 +268,7 @@ func (p *Passkeys) renderDir(w http.ResponseWriter, fsys vfs.FileSystem, lorePat
 		}
 	}
 	b.WriteString(`</ul><div class="action-overlay" id="entry-actions" hidden role="dialog" aria-modal="true" aria-labelledby="action-name"><div class="action-sheet"><div class="action-name" id="action-name"></div><div class="action-hint">Double tap to open</div><div class="action-buttons"><button type="button" data-open>Open</button><button type="button" data-copy="url">Copy URL</button><button type="button" data-copy="path">Copy path<span class="action-subtext">Copy for agent</span></button></div><div class="copy-status" id="copy-status" aria-live="polite"></div></div></div>`)
-	b.WriteString(`<script>(()=>{const overlay=document.getElementById('entry-actions');const name=document.getElementById('action-name');const status=document.getElementById('copy-status');let selected=null;let tapTimer=null;function hide(){overlay.hidden=true;status.textContent='';selected=null}function show(link){selected=link;name.textContent=link.textContent;status.textContent='';overlay.hidden=false}async function copy(text,label){try{if(navigator.clipboard&&navigator.clipboard.writeText){await navigator.clipboard.writeText(text)}else{const area=document.createElement('textarea');area.value=text;area.style.position='fixed';area.style.opacity='0';document.body.appendChild(area);area.select();if(!document.execCommand('copy'))throw new Error('copy failed');area.remove()}status.textContent=label+' copied'}catch{status.textContent='Could not copy'}}document.querySelectorAll('.entry').forEach(link=>link.addEventListener('click',event=>{if(event.detail===0)return;event.preventDefault();if(tapTimer&&selected===link){clearTimeout(tapTimer);tapTimer=null;window.location.assign(link.href);return}if(tapTimer)clearTimeout(tapTimer);selected=link;tapTimer=setTimeout(()=>{tapTimer=null;show(link)},275)}));overlay.addEventListener('click',event=>{if(event.target===overlay)hide()});overlay.querySelector('[data-open]').addEventListener('click',()=>{if(selected)window.location.assign(selected.href)});overlay.querySelectorAll('[data-copy]').forEach(button=>button.addEventListener('click',()=>{if(!selected)return;const kind=button.dataset.copy;copy(kind==='url'?selected.href:selected.dataset.path,kind==='url'?'URL':'Path')}));document.addEventListener('keydown',event=>{if(event.key==='Escape'&&!overlay.hidden)hide()})})()</script></body></html>`)
+	b.WriteString(`<script>(()=>{const overlay=document.getElementById('entry-actions');const name=document.getElementById('action-name');const status=document.getElementById('copy-status');let selected=null;let tapTimer=null;function hide(){overlay.hidden=true;status.textContent='';selected=null}function show(link){selected=link;name.textContent=link.textContent;status.textContent='';overlay.hidden=false}async function copy(text,label){try{if(navigator.clipboard&&navigator.clipboard.writeText){await navigator.clipboard.writeText(text)}else{const area=document.createElement('textarea');area.value=text;area.style.position='fixed';area.style.opacity='0';document.body.appendChild(area);area.select();if(!document.execCommand('copy'))throw new Error('copy failed');area.remove()}status.textContent=label+' copied'}catch{status.textContent='Could not copy'}}document.querySelectorAll('.entry').forEach(link=>link.addEventListener('click',event=>{if(event.detail===0)return;event.preventDefault();if(tapTimer&&selected===link){clearTimeout(tapTimer);tapTimer=null;window.location.assign(link.href);return}if(tapTimer)clearTimeout(tapTimer);selected=link;tapTimer=setTimeout(()=>{tapTimer=null;show(link)},275)}));overlay.addEventListener('click',event=>{if(event.target===overlay)hide()});overlay.querySelector('[data-open]').addEventListener('click',()=>{if(selected)window.location.assign(selected.href)});overlay.querySelectorAll('[data-copy]').forEach(button=>button.addEventListener('click',()=>{if(!selected)return;const kind=button.dataset.copy;copy(kind==='url'?selected.href:selected.dataset.path,kind==='url'?'URL':'Path')}));document.addEventListener('keydown',event=>{if(event.key==='Escape'&&!overlay.hidden)hide()})})()</script></main>` + identityMenuScript + `</body></html>`)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(b.String()))

--- a/internal/passkeys/browser_test.go
+++ b/internal/passkeys/browser_test.go
@@ -27,7 +27,7 @@ func TestRenderFileIncludesBreadcrumbsIframeAndParentCloseLink(t *testing.T) {
 	req := httptest.NewRequest("GET", "/lore/guides/setup.md", nil)
 	rec := httptest.NewRecorder()
 
-	pk.renderFile(rec, req, "/lore", "/guides/setup.md", []FileHistoryEntry{{
+	pk.renderFile(rec, req, "/lore", "/guides/setup.md", "adil", []FileHistoryEntry{{
 		Time: time.Date(2026, time.August, 19, 12, 30, 0, 0, time.UTC), Attribution: "adil/claude", Action: "write", Hash: "abc123",
 	}}, true)
 
@@ -49,6 +49,9 @@ func TestRenderFileIncludesBreadcrumbsIframeAndParentCloseLink(t *testing.T) {
 		`datetime="2026-08-19T12:30:00Z"`,
 		`title="abc123">abc123`,
 		`history.hidden=open`,
+		`id="identity-button"`,
+		`<span class="identity-name">adil</span>`,
+		`href="/settings/permissions">Permission settings`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("file view missing %q", want)
@@ -95,7 +98,7 @@ func TestRenderDirUsesSingleTapActionsAndDoubleTapNavigation(t *testing.T) {
 	pk := &Passkeys{}
 	rec := httptest.NewRecorder()
 
-	pk.renderDir(rec, browserTestFS{}, "/lore", "/docs")
+	pk.renderDir(rec, browserTestFS{}, "/lore", "/docs", "adil")
 
 	body := rec.Body.String()
 	for _, want := range []string{
@@ -108,6 +111,10 @@ func TestRenderDirUsesSingleTapActionsAndDoubleTapNavigation(t *testing.T) {
 		`window.location.assign(selected.href)`,
 		`setTimeout(()=>{tapTimer=null;show(link)},275)`,
 		`window.location.assign(link.href)`,
+		`class="brand" href="/lore/"`,
+		`id="identity-button"`,
+		`<span class="identity-name">adil</span>`,
+		`href="/settings/permissions">Permission settings`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("directory view missing %q", want)

--- a/pkg/openlore/settings_permissions.go
+++ b/pkg/openlore/settings_permissions.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	permissionsPath       = "/settings/permissions"
-	permissionsUpdatePath = "/settings/permissions/update"
-	permissionsRemovePath = "/settings/permissions/remove"
+	// permissionsPath is shared with the lore browser's identity menu, which
+	// links here from internal/passkeys.
+	permissionsPath       = passkeys.PermissionsPath
+	permissionsUpdatePath = permissionsPath + "/update"
+	permissionsRemovePath = permissionsPath + "/remove"
 )
 
 type permissionToggle struct {


### PR DESCRIPTION
Adds an identity header to the authenticated lore web view.

## What
- **Directory view**: new full-width top bar with the 📜 OpenLore brand (links to the lore root) on the left and a button showing the signed-in identity on the right.
- **File view**: the identity button sits in the existing navigation bar, next to the history toggle and close button.
- Clicking the identity button opens a dropdown showing who you're signed in as, with a **Permission settings** link to `/settings/permissions` where you manage which delegate identities have access to what. The dropdown closes on outside click or Escape.
- `/settings/permissions` is now a shared constant (`passkeys.PermissionsPath`) referenced by both the browser link and the `pkg/openlore` route registration, so they can't drift apart.

## Tests
- `go test ./internal/passkeys/... ./pkg/openlore/` passes.
- Browser render tests now assert the identity button, identity name, and permission-settings link appear in both the directory and file views.