### PR TITLE
Add persistent HTTP shell sessions and prevent shell panics

### DIFF
--- a/pkg/openlore/mcp_http_api.go
+++ b/pkg/openlore/mcp_http_api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -15,24 +16,27 @@ import (
 // simple REST-style endpoints that any HTTP client can call, while still
 // routing every request through the MCP server's tools.
 //
-// Each request runs on its own short-lived in-process MCP session. The session
-// is connected with the request's context, so the server-side tool handler sees
-// the caller's identity (via auth.TokenInfoFromContext) exactly as the
-// Streamable transport does — identity always flows through the connection
-// context, never through client-supplied tool arguments.
+// Stateless requests run on a short-lived in-process MCP session. Clients that
+// need shell state across commands can create a logical session. Each logical
+// session owns one Shell while all sessions share the same HTTP listener.
 //
 // It mirrors the MCP server's two tools:
 //
 //	POST {prefix}/shell     -> body {"command": "..."} runs the `shell` tool
 //	GET  {prefix}/commands  -> runs the `list_commands` tool
+//	POST {prefix}/sessions  -> creates a persistent logical shell session
+//	POST {prefix}/sessions/{id}/shell -> runs a command in that session
+//	POST {prefix}/sessions/{id}/touch -> extends that session's idle lifetime
+//	DELETE {prefix}/sessions/{id} -> closes that session
 type MCPHTTPAPI struct {
-	server *mcp.Server
+	server   *mcp.Server
+	sessions *httpShellSessions
 }
 
-// NewMCPHTTPAPI returns an API that forwards HTTP requests to the given MCP
-// server's tools, one in-process session per request.
-func NewMCPHTTPAPI(server *mcp.Server) *MCPHTTPAPI {
-	return &MCPHTTPAPI{server: server}
+// NewMCPHTTPAPI returns an API backed by the given MCP server. shellFactory
+// builds identity-scoped shells for persistent logical sessions.
+func NewMCPHTTPAPI(server *mcp.Server, shellFactory func(context.Context) *shell.Shell) *MCPHTTPAPI {
+	return &MCPHTTPAPI{server: server, sessions: newHTTPShellSessions(shellFactory)}
 }
 
 // Handler returns an http.Handler serving the API under the given path prefix
@@ -43,6 +47,10 @@ func (a *MCPHTTPAPI) Handler(prefix string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST "+prefix+"/shell", a.handleShell)
 	mux.HandleFunc("GET "+prefix+"/commands", a.handleListCommands)
+	mux.HandleFunc("POST "+prefix+"/sessions", a.sessions.handleCreate)
+	mux.HandleFunc("POST "+prefix+"/sessions/{id}/shell", a.sessions.handleShell)
+	mux.HandleFunc("POST "+prefix+"/sessions/{id}/touch", a.sessions.handleTouch)
+	mux.HandleFunc("DELETE "+prefix+"/sessions/{id}", a.sessions.handleDelete)
 	return mux
 }
 

--- a/pkg/openlore/mcp_http_api_test.go
+++ b/pkg/openlore/mcp_http_api_test.go
@@ -1,6 +1,7 @@
 package openlore
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/shell"
 )
 
 func newTestAPI(t *testing.T) http.Handler {
@@ -23,7 +25,7 @@ func newTestAPI(t *testing.T) http.Handler {
 	fs := NewDirFS(dir, config.FilesConfig{})
 	server := NewMCPServer(fs)
 
-	api := NewMCPHTTPAPI(server)
+	api := NewMCPHTTPAPI(server, func(context.Context) *shell.Shell { return shell.NewShell(fs) })
 	return api.Handler("/api")
 }
 

--- a/pkg/openlore/mcp_http_sessions.go
+++ b/pkg/openlore/mcp_http_sessions.go
@@ -1,0 +1,226 @@
+package openlore
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aakarim/go-openlore/pkg/shell"
+)
+
+const (
+	defaultHTTPSessionTTL   = 30 * time.Minute
+	maxHTTPSessions         = 256
+	maxHTTPSessionsPerOwner = 64
+)
+
+type httpShellSessions struct {
+	factory func(context.Context) *shell.Shell
+	ttl     time.Duration
+
+	mu       sync.Mutex
+	sessions map[string]*httpShellSession
+}
+
+type httpShellSession struct {
+	mu         sync.Mutex
+	shell      *shell.Shell
+	owner      string
+	clientRef  string
+	createdAt  time.Time
+	lastUsedAt time.Time
+	expiry     *time.Timer
+}
+
+type createSessionRequest struct {
+	ClientRef string `json:"client_ref"`
+}
+
+type createSessionResponse struct {
+	ID                 string    `json:"id"`
+	CreatedAt          time.Time `json:"created_at"`
+	IdleTimeoutSeconds int64     `json:"idle_timeout_seconds"`
+}
+
+func newHTTPShellSessions(factory func(context.Context) *shell.Shell) *httpShellSessions {
+	return &httpShellSessions{
+		factory:  factory,
+		ttl:      defaultHTTPSessionTTL,
+		sessions: make(map[string]*httpShellSession),
+	}
+}
+
+func (s *httpShellSessions) handleCreate(w http.ResponseWriter, r *http.Request) {
+	var req createSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if s.factory == nil {
+		writeAPIError(w, http.StatusNotImplemented, "persistent sessions are unavailable")
+		return
+	}
+
+	id, err := randomHTTPSessionID()
+	if err != nil {
+		writeAPIError(w, http.StatusInternalServerError, "creating session")
+		return
+	}
+	now := time.Now()
+	owner := httpSessionOwner(r.Context())
+	s.mu.Lock()
+	s.pruneExpiredLocked(now)
+	ownerSessions := 0
+	for _, existing := range s.sessions {
+		if existing.owner == owner {
+			ownerSessions++
+		}
+	}
+	if len(s.sessions) >= maxHTTPSessions || ownerSessions >= maxHTTPSessionsPerOwner {
+		s.mu.Unlock()
+		writeAPIError(w, http.StatusTooManyRequests, "too many active sessions")
+		return
+	}
+	session := &httpShellSession{
+		shell:      s.factory(r.Context()),
+		owner:      owner,
+		clientRef:  strings.TrimSpace(req.ClientRef),
+		createdAt:  now,
+		lastUsedAt: now,
+	}
+	s.sessions[id] = session
+	session.expiry = time.AfterFunc(s.ttl, func() { s.expire(id, session) })
+	s.mu.Unlock()
+
+	writeJSON(w, http.StatusCreated, createSessionResponse{
+		ID:                 id,
+		CreatedAt:          now,
+		IdleTimeoutSeconds: int64(s.ttl / time.Second),
+	})
+}
+
+func (s *httpShellSessions) handleShell(w http.ResponseWriter, r *http.Request) {
+	var req shellRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeAPIError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if strings.TrimSpace(req.Command) == "" {
+		writeAPIError(w, http.StatusBadRequest, "command is required")
+		return
+	}
+
+	session := s.get(r.PathValue("id"), httpSessionOwner(r.Context()), time.Now())
+	if session == nil {
+		writeAPIError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	session.mu.Lock()
+	result := executeSessionShell(session.shell, req.Command)
+	session.mu.Unlock()
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *httpShellSessions) handleTouch(w http.ResponseWriter, r *http.Request) {
+	if s.get(r.PathValue("id"), httpSessionOwner(r.Context()), time.Now()) == nil {
+		writeAPIError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *httpShellSessions) handleDelete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	owner := httpSessionOwner(r.Context())
+	s.mu.Lock()
+	session, ok := s.sessions[id]
+	if ok && session.owner == owner {
+		delete(s.sessions, id)
+		session.expiry.Stop()
+	} else {
+		ok = false
+	}
+	s.mu.Unlock()
+	if !ok {
+		writeAPIError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *httpShellSessions) get(id, owner string, now time.Time) *httpShellSession {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneExpiredLocked(now)
+	session := s.sessions[id]
+	if session == nil || session.owner != owner {
+		return nil
+	}
+	session.lastUsedAt = now
+	session.expiry.Reset(s.ttl)
+	return session
+}
+
+func (s *httpShellSessions) pruneExpiredLocked(now time.Time) {
+	for id, session := range s.sessions {
+		if now.Sub(session.lastUsedAt) >= s.ttl {
+			delete(s.sessions, id)
+			session.expiry.Stop()
+		}
+	}
+}
+
+func (s *httpShellSessions) expire(id string, expected *httpShellSession) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session := s.sessions[id]
+	if session != expected {
+		return
+	}
+	remaining := s.ttl - time.Since(session.lastUsedAt)
+	if remaining > 0 {
+		session.expiry.Reset(remaining)
+		return
+	}
+	delete(s.sessions, id)
+}
+
+func httpSessionOwner(ctx context.Context) string {
+	if id, ok := ctx.Value(identityCtxKey{}).(Identity); ok {
+		return strings.Join([]string{
+			id.Principal.Subject,
+			id.IdentityName,
+			id.Attribution.String(),
+			strings.Join(id.Scopes, ","),
+		}, "\x00")
+	}
+	return "anonymous"
+}
+
+func randomHTTPSessionID() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func executeSessionShell(sh *shell.Shell, command string) toolResponse {
+	var stdout, stderr bytes.Buffer
+	exitCode := sh.ExecPipeline(command, &stdout, &stderr, nil)
+	output := stdout.String()
+	if stderr.Len() > 0 {
+		output += "\n" + stderr.String()
+	}
+	if exitCode != 0 {
+		output += fmt.Sprintf("\nexit code: %d", exitCode)
+	}
+	return toolResponse{Output: output}
+}

--- a/pkg/openlore/mcp_http_sessions_test.go
+++ b/pkg/openlore/mcp_http_sessions_test.go
@@ -1,0 +1,145 @@
+package openlore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/shell"
+)
+
+func newSessionTestAPI(t *testing.T) (*MCPHTTPAPI, http.Handler) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/docs", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fs := NewDirFS(dir, config.FilesConfig{})
+	api := NewMCPHTTPAPI(NewMCPServer(fs), func(context.Context) *shell.Shell {
+		return shell.NewShell(fs)
+	})
+	t.Cleanup(func() {
+		api.sessions.mu.Lock()
+		defer api.sessions.mu.Unlock()
+		for _, session := range api.sessions.sessions {
+			session.expiry.Stop()
+		}
+	})
+	return api, api.Handler("/api")
+}
+
+func sessionRequest(t *testing.T, handler http.Handler, identity Identity, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w
+}
+
+func createSession(t *testing.T, handler http.Handler, identity Identity) createSessionResponse {
+	t.Helper()
+	w := sessionRequest(t, handler, identity, http.MethodPost, "/api/sessions", `{"client_ref":"amp-thread-1"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create session status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var response createSessionResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func TestMCPHTTPSessionLifecyclePreservesShellState(t *testing.T) {
+	_, handler := newSessionTestAPI(t)
+	identity := Identity{
+		IdentityName: "adil",
+		Principal:    AuthenticatedPrincipal{Subject: "adil"},
+		Attribution:  Attribution{Principal: "adil"},
+		Scopes:       []string{ScopeFull},
+	}
+	created := createSession(t, handler, identity)
+	if len(created.ID) != 48 {
+		t.Fatalf("session ID length = %d, want 48", len(created.ID))
+	}
+	if created.IdleTimeoutSeconds != int64(defaultHTTPSessionTTL/time.Second) {
+		t.Fatalf("idle timeout = %d, want %d", created.IdleTimeoutSeconds, int64(defaultHTTPSessionTTL/time.Second))
+	}
+	if created.CreatedAt.IsZero() {
+		t.Fatal("created_at is zero")
+	}
+
+	path := "/api/sessions/" + created.ID
+	if w := sessionRequest(t, handler, identity, http.MethodPost, path+"/shell", `{"command":"cd /docs"}`); w.Code != http.StatusOK {
+		t.Fatalf("cd status = %d, body = %s", w.Code, w.Body.String())
+	}
+	w := sessionRequest(t, handler, identity, http.MethodPost, path+"/shell", `{"command":"pwd"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("pwd status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var result toolResponse
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(result.Output); got != "/docs" {
+		t.Fatalf("pwd output = %q, want /docs", got)
+	}
+
+	if w := sessionRequest(t, handler, identity, http.MethodPost, path+"/touch", `{}`); w.Code != http.StatusNoContent {
+		t.Fatalf("touch status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if w := sessionRequest(t, handler, identity, http.MethodDelete, path, ""); w.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if w := sessionRequest(t, handler, identity, http.MethodPost, path+"/shell", `{"command":"pwd"}`); w.Code != http.StatusNotFound {
+		t.Fatalf("shell after delete status = %d, want 404", w.Code)
+	}
+}
+
+func TestMCPHTTPSessionIsBoundToIdentity(t *testing.T) {
+	_, handler := newSessionTestAPI(t)
+	owner := Identity{IdentityName: "owner", Principal: AuthenticatedPrincipal{Subject: "owner"}, Attribution: Attribution{Principal: "owner"}, Scopes: []string{ScopeFull}}
+	other := Identity{IdentityName: "other", Principal: AuthenticatedPrincipal{Subject: "other"}, Attribution: Attribution{Principal: "other"}, Scopes: []string{ScopeFull}}
+	created := createSession(t, handler, owner)
+	path := "/api/sessions/" + created.ID
+
+	if w := sessionRequest(t, handler, other, http.MethodPost, path+"/shell", `{"command":"pwd"}`); w.Code != http.StatusNotFound {
+		t.Fatalf("cross-identity shell status = %d, want 404", w.Code)
+	}
+	if w := sessionRequest(t, handler, other, http.MethodDelete, path, ""); w.Code != http.StatusNotFound {
+		t.Fatalf("cross-identity delete status = %d, want 404", w.Code)
+	}
+}
+
+func TestMCPHTTPSessionExpiresAfterIdleTimeout(t *testing.T) {
+	api, handler := newSessionTestAPI(t)
+	identity := Identity{IdentityName: "adil", Principal: AuthenticatedPrincipal{Subject: "adil"}, Attribution: Attribution{Principal: "adil"}, Scopes: []string{ScopeFull}}
+	created := createSession(t, handler, identity)
+
+	api.sessions.mu.Lock()
+	api.sessions.sessions[created.ID].lastUsedAt = time.Now().Add(-api.sessions.ttl)
+	api.sessions.mu.Unlock()
+
+	path := "/api/sessions/" + created.ID + "/shell"
+	w := sessionRequest(t, handler, identity, http.MethodPost, path, `{"command":"pwd"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expired session status = %d, want 404; body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMCPHTTPSessionRejectsInvalidCreateBody(t *testing.T) {
+	_, handler := newSessionTestAPI(t)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/sessions", bytes.NewBufferString("not json")))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid create status = %d, want 400", w.Code)
+	}
+}

--- a/pkg/openlore/mcp_scoping_test.go
+++ b/pkg/openlore/mcp_scoping_test.go
@@ -44,7 +44,7 @@ func newScopedTestAPI(t *testing.T) http.Handler {
 	s.authorizationStore = fileAuthorizationStore{auth: s.auth}
 
 	server := NewMCPServer(s.merge, withMCPShellFactory(s.shellForContext))
-	return NewMCPHTTPAPI(server).Handler("/api")
+	return NewMCPHTTPAPI(server, s.shellForContext).Handler("/api")
 }
 
 // runShell posts a command to the JSON API and returns the tool output.

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -1508,7 +1508,7 @@ func (s *Server) ListenAndServe() error {
 			// endpoints: POST {path}/shell and GET {path}/commands.
 			if s.config.APIEnabled && s.config.APIPath != "" {
 				apiPath := "/" + strings.Trim(s.config.APIPath, "/")
-				api := NewMCPHTTPAPI(mcpServer)
+				api := NewMCPHTTPAPI(mcpServer, s.shellForContext)
 				httpCfg.ExtraHandlers[apiPath+"/"] = s.authMiddleware(api.Handler(apiPath), !s.config.AllowKeyless)
 				s.logger.Info("HTTP API mounted", "path", apiPath, "http_port", s.config.HTTPPort)
 			}

--- a/pkg/shell/cmds/awk.go
+++ b/pkg/shell/cmds/awk.go
@@ -843,7 +843,7 @@ func (a *awkInterpreter) evalExpr(expr string) string {
 	}
 
 	// Array access: arr[key]
-	if bIdx := strings.Index(expr, "["); bIdx > 0 {
+	if bIdx := strings.Index(expr, "["); bIdx > 0 && strings.HasSuffix(expr, "]") {
 		arrName := expr[:bIdx]
 		key := expr[bIdx+1 : len(expr)-1]
 		key = a.evalExpr(key)

--- a/pkg/shell/cmds/awk_internal_test.go
+++ b/pkg/shell/cmds/awk_internal_test.go
@@ -1,0 +1,11 @@
+package cmds
+
+import "testing"
+
+func TestAwkEvalExprUnclosedBracketIsNotArrayAccess(t *testing.T) {
+	a := &awkInterpreter{}
+	const expr = "^## ["
+	if got := a.evalExpr(expr); got != expr {
+		t.Fatalf("evalExpr(%q) = %q, want unchanged expression", expr, got)
+	}
+}

--- a/pkg/shell/parser/parser.go
+++ b/pkg/shell/parser/parser.go
@@ -623,14 +623,23 @@ func parseWordParts(s string, inDblQuote bool) []WordPart {
 						for i < len(s) && s[i] != '\'' {
 							i++
 						}
+						if i < len(s) {
+							i++
+						}
+						continue
 					} else if s[i] == '"' {
 						i++
 						for i < len(s) && s[i] != '"' {
-							if s[i] == '\\' {
-								i++
+							if s[i] == '\\' && i+1 < len(s) {
+								i += 2
+								continue
 							}
 							i++
 						}
+						if i < len(s) {
+							i++
+						}
+						continue
 					}
 					i++
 				}

--- a/pkg/shell/parser/parser_test.go
+++ b/pkg/shell/parser/parser_test.go
@@ -219,6 +219,7 @@ func TestParseSyntax(t *testing.T) {
 		{"for loop", "for x in a b c; do echo $x; done"},
 		{"while loop", "x=0; while test $x = 0; do echo loop; x=1; done"},
 		{"command substitution", "echo $(echo hello)"},
+		{"quoted command substitution argument", `echo A: $(grep -c "Final (v2)" /docs/file.md)`},
 		{"nested cmd sub", "echo $(echo $(echo deep))"},
 		{"variable assignment", "FOO=bar; echo $FOO"},
 		{"double quotes with var", `echo "hello $WHO"`},
@@ -243,6 +244,19 @@ func TestParseSyntax(t *testing.T) {
 			if len(f.Stmts) == 0 {
 				t.Fatal("no statements parsed")
 			}
+		})
+	}
+}
+
+func TestUnterminatedQuoteInCommandSubstitutionDoesNotPanic(t *testing.T) {
+	inputs := []string{
+		`echo $(grep "unterminated)`,
+		`echo $(grep 'unterminated)`,
+		`echo $(grep "trailing escape\)`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			_, _ = parser.Parse(input)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- add identity-bound logical shell sessions to the JSON HTTP API with create, execute, touch, and delete endpoints
- preserve per-session shell state while multiplexing requests over the existing HTTP server
- expire idle sessions after 30 minutes and cap active sessions globally and per identity
- prevent malformed command substitutions and awk expressions from panicking the server process

## Production evidence
The current `openlore.sh` deployment returns 404 from `POST /api/sessions`, so Amp cannot establish persistent thread sessions. The service journal also shows restarts caused by:
- `pkg/shell/parser/parser.go` slicing past the input after quoted command substitutions
- `pkg/shell/cmds/awk.go` treating an unmatched `[` as array access

Both crash paths now have regressions.

## API
- `POST /api/sessions` with `{ "client_ref": "..." }`
- `POST /api/sessions/{id}/shell` with `{ "command": "..." }`
- `POST /api/sessions/{id}/touch`
- `DELETE /api/sessions/{id}`

The existing stateless `/api/shell` and `/api/commands` endpoints remain unchanged.

## Verification
- `go test ./...`
- `go test -race ./pkg/openlore ./pkg/shell/parser ./pkg/shell/cmds`
- `go vet ./...`
- `git diff --check`

## Deployment / rollback
After merge, build `./cmd/openlore` for Linux amd64, retain the current `/opt/openlore/openlore` as a backup, atomically replace it, restart `openlore.service`, and verify both stateless and session APIs. Rollback is restoring the backup binary and restarting the service.
