### PR TITLE
Tolerate OAuth refresh retries after client backoff

### DIFF
--- a/pkg/openlore/refreshstore.go
+++ b/pkg/openlore/refreshstore.go
@@ -26,7 +26,7 @@ var ErrRefreshStaleRetry = errors.New("stale refresh retry")
 // response was lost, or issue concurrent refreshes during reconnect. Both
 // requests receive the same successor refresh token. Reuse after this window
 // remains a theft signal and revokes the chain.
-const refreshRetryGrace = 30 * time.Second
+const refreshRetryGrace = 2 * time.Minute
 
 // RefreshToken is a stateful, revocable credential. Tokens in the same ChainID
 // descend from one login; rotation issues a new token in the chain and marks

--- a/pkg/openlore/refreshstore_test.go
+++ b/pkg/openlore/refreshstore_test.go
@@ -73,6 +73,26 @@ func TestRefreshStore_ImmediateRetryReturnsSameSuccessor(t *testing.T) {
 	}
 }
 
+func TestRefreshStore_RetryAfterClientBackoffReturnsSameSuccessor(t *testing.T) {
+	rs := testRefreshStore(t)
+	expires := time.Now().Add(time.Hour)
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+		t.Fatal(err)
+	}
+	old := rs.tokens["old"]
+	old.RotatedAt = time.Now().Add(-45 * time.Second)
+	rs.tokens["old"] = old
+
+	rotation, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	if err != nil {
+		t.Fatalf("retry after client backoff: %v", err)
+	}
+	if rotation.Token.Token != "new" || !rotation.Retried {
+		t.Fatalf("retry rotation = %+v", rotation)
+	}
+}
+
 func TestRefreshStore_StaleRetryDoesNotRevokeCurrentChain(t *testing.T) {
 	rs := testRefreshStore(t)
 	expires := time.Now().Add(time.Hour)


### PR DESCRIPTION
## Summary
- extend idempotent refresh-token retry handling from 30 seconds to 2 minutes
- add a regression for a retry after a 45-second client backoff
- retain chain revocation for reuse after the bounded grace period

## Production evidence
At 22:09:48 UTC, the Codex OAuth client rotated a token and sent three immediate retries, all handled idempotently. At 22:10:27 UTC (~39 seconds later), it retried the same predecessor again. The 30-second window classified that request as reuse, revoked the chain, and all subsequent refreshes became `unknown_token`.

Two minutes covers the observed client retry schedule while keeping reuse detection bounded.

## Verification
- `go test ./pkg/openlore`
- `go test -race ./pkg/openlore`
- `go vet ./...`
- `git diff --check`
