### PR TITLE
build: copy only binary into container image

### DIFF
--- a/railpack-plan.json
+++ b/railpack-plan.json
@@ -13,7 +13,7 @@
     "inputs": [
       {
         "include": [
-          "."
+          "out"
         ],
         "step": "build"
       }


### PR DESCRIPTION
## Summary

- restrict the Railpack deploy layer to the compiled `out` binary
- exclude the repository source and example configuration files from runtime images
- retain the existing runtime base and external `openlore.yml` startup path

## Verification

- built the image locally with Railpack frontend v0.37.0 using BuildKit v0.32.2
- verified `/app` contains only the executable `out`
- ran `/app/out version` successfully from the resulting linux/amd64 image
- confirmed the image command remains `./out --config /var/lib/openlore/config/openlore.yml`
