### PR TITLE
skills: make setup a guided interview

### DIFF
--- a/assets/skills/deploy.md
+++ b/assets/skills/deploy.md
@@ -56,6 +56,7 @@ Every implementation must provide:
    - `writable_dir: /var/lib/openlore/published`
    - `data_dir: /var/lib/openlore/data`
    - `host_key_path: /var/lib/openlore/ssh/openlore_ed25519`
+   - passkeys enabled with public HTTPS RP ID/origin and `/var/lib/openlore/data/passkeys.json`
 7. `openlore.yml`, `lore.json`, the SSH-visible filesystem, server data, and
    host key surviving container and machine replacement supported by that
    provider.
@@ -69,7 +70,6 @@ SSH has no hostname/SNI routing, so standard-port ingress needs a
 dedicated address/listener rather than HTTP hostname routing.
 
 ## Safety and IaC rules
-
 - Use locally authenticated provider CLIs. Never request credentials or private
   keys in chat and never commit secrets.
 - Discover existing resources and state before planning.

--- a/assets/skills/deploy.md
+++ b/assets/skills/deploy.md
@@ -47,9 +47,11 @@ Every implementation must provide:
 3. Valid HTTPS and a reachable MCP endpoint.
 4. Authenticated OpenLore SSH.
 5. A persistent volume mounted at `/var/lib/openlore`.
-6. Root `openlore.yml` deployed separately to
-   `/var/lib/openlore/config/openlore.yml` and started with
-   `./out --config /var/lib/openlore/config/openlore.yml`. It must configure:
+6. Deploy root `openlore.yml` separately at
+   `/var/lib/openlore/config/openlore.yml`. Keep the inherited command/entrypoint,
+   which runs `./out --config /var/lib/openlore/config/openlore.yml`; never
+   override it with an argument array. If required, pass the whole command as
+   one shell string. The config must set:
    - `auth_file: /var/lib/openlore/config/lore.json`
    - `writable_dir: /var/lib/openlore/published`
    - `data_dir: /var/lib/openlore/data`
@@ -58,14 +60,12 @@ Every implementation must provide:
    host key surviving container and machine replacement supported by that
    provider.
 
-Use provider defaults for administrative SSH. Do not install or expose another
-OS SSH daemon merely for OpenLore.
-
-When the provider can configure TCP ingress, prefer public domain port 22
-forwarded to OpenLore port 2222. Do not expose 2222 publicly when that ingress
-exists. If the provider cannot do this, expose the assigned/approved 2222
-endpoint and explicitly suggest an external TCP load balancer or forwarding
-system. Raw SSH has no hostname/SNI routing, so standard-port ingress needs a
+Use provider defaults for administrative SSH; do not add an OS SSH daemon for
+OpenLore.
+When the provider supports TCP ingress, prefer public port 22 forwarded to
+OpenLore 2222 and do not also expose 2222. Otherwise expose the assigned 2222
+endpoint and suggest an external TCP load balancer or forwarding system. Raw
+SSH has no hostname/SNI routing, so standard-port ingress needs a
 dedicated address/listener rather than HTTP hostname routing.
 
 ## Safety and IaC rules

--- a/assets/skills/onboarding.md
+++ b/assets/skills/onboarding.md
@@ -1,61 +1,55 @@
 # Onboard Initial OpenLore Identities
 
-Customize identities, roles, docsets, and initial SSH-visible folders in an
-OpenLore project's local bootstrap state before its first deployment.
+Before its first deployment, customize who can connect and what they can use.
+Open with “👋 Let's add someone to your lore server.” Ask one question at a time
+and wait; explain why it matters, define jargon just in time, and give the
+recommended default. Use restrained emojis, validate quietly, mention only
+failures, and end each identity with a plain-language ✅ summary.
 
 ## Preconditions
 
-1. Work only from a directory containing root `openlore.yml`.
-2. Require `.local/lore.json` and `.local/filesystem`; if `.local` was discarded
-   after deployment, stop. Live administration belongs on the server and this
-   initial-onboarding skill must not recreate local state from guesses.
-3. Inspect `deploy/` for a verified authoritative deployment. If one exists,
-   stop and direct the user to edit the live policy through OpenLore or the
-   provider administrative shell.
-4. Parse and validate the current policy before proposing changes. Never remove
-   or weaken existing access as an incidental side effect.
+Require root `openlore.yml`, `.local/lore.json`, and `.local/filesystem`. If
+`.local` was discarded or `deploy/` records a verified deployment, stop: edit
+the authoritative server instead. Validate current policy before changes; never
+incidentally remove or weaken access.
 
 ## Interview for each identity
 
-Ask for:
+Ask in order, one per turn:
 
-- identity name;
-- an existing SSH public key;
-- home path, defaulting to `/user/<identity>`;
-- roles;
-- additional readable or writable docsets;
-- initial folders or documents.
+- identity name (their OpenLore account name; required, no safe default);
+- SSH public key and matching local private-key path (only used to prove login;
+  never copied or displayed);
+- home folder (default `/user/<identity>`, their private login location);
+- roles (permission bundles; default `agent`);
+- additional knowledge folders and read/write needs (default only shared
+  `/channel/general` through `agent`);
+- initial folders/documents (default a short `README.md` in each empty docset).
 
 Offer the existing `agent` role by default so the identity can write the shared
 `general` docset at `/channel/general`. A unique home docset is implicitly
 writable by its owner. Explain administrator capabilities and require explicit
 confirmation before adding `administrator` or `lore:config:edit`.
 
-Public-key comments are allowed. Validate keys by parsed key material. Detect
-duplicate identity names, keys, homes, role names, path collisions, nested
-docset boundaries, and invalid grants before writing anything. Never access or
-store a private key.
+Validate parsed key material, duplicates, homes, roles, path collisions, nested
+docset boundaries, and grants before writing. Never access or store private keys.
 
 ## Apply coherently
 
-Edit `.local/lore.json` as one validated change and create matching paths under
-`.local/filesystem/`, for example:
+Edit `.local/lore.json` atomically and create matching virtual paths (for example
+`.local/filesystem/user/alice/` and `channel/general/`). Never
+put host keys, signing material, logs, or databases in bootstrap state.
+Put a short `README.md` in every newly created empty docset so its purpose and
+successful visibility are obvious; never overwrite existing content.
 
-```text
-.local/filesystem/user/alice/
-.local/filesystem/channel/general/
-```
-
-Initial files mirror their final OpenLore virtual paths. Do not put generated
-host keys, signing material, audit logs, or runtime databases in `.local`.
-
-Use OpenLore's policy validation and existing identity/role commands where they
-cover the operation. For policy structures those commands do not create, make a
-minimal JSON edit, validate the complete result, and preserve stable formatting.
+Use OpenLore policy validation and commands where applicable; otherwise make a
+minimal JSON edit, validate the whole result, and preserve formatting.
 
 ## Verify locally
 
-Start or restart `.local/compose.yml`, then prove:
+Restart Compose. Refresh only this project's `.local/known_hosts` entry if the
+host key changed; extend `.local/ssh_config` for the key with strict checking.
+Quietly connect directly and prove:
 
 1. the new public key resolves to the intended identity;
 2. login starts in the intended home;
@@ -64,5 +58,9 @@ Start or restart `.local/compose.yml`, then prove:
 5. changes survive a container restart.
 
 Remove only disposable verification files. Report the exact SSH command and
-the resulting identity, home, roles, and grants. `.local` is gitignored, so do
-not offer to commit its policy or filesystem contents.
+finish with a friendly ✅ summary of the identity, home, roles, visible folders,
+and what read/write means in practice. Give a ready-to-run terminal command and
+an example that reads the new home `README.md`. `.local` is gitignored, so do
+not offer to commit its policy or filesystem contents. Ask whether to add
+another identity; if not, offer to continue with “run deploy” or later via
+`ssh openlore.sh deploy | <agent-cli>`.

--- a/assets/skills/setup.md
+++ b/assets/skills/setup.md
@@ -1,8 +1,12 @@
 # Set Up an OpenLore Project
 
-Create a new, locally verified OpenLore project that deploys a thin derivative
-of an official OpenLore release. Do not clone, fork, vendor, or add OpenLore as
-a submodule.
+You are installing OpenLore, not merely generating files. Open with “👋 Let's
+set up your lore server.” Interview one question at a time and wait; explain why
+it matters, recommend a default, and define unfamiliar terms just in time. If
+there is no safe default, say why a choice is required. Use restrained emojis.
+Run checks quietly and mention only failures or decisions. After each stage give
+a short ✅ plain-language summary, never “acceptance evidence”. Use an official
+release; do not clone, fork, vendor, or add OpenLore as a submodule.
 
 ## Outcome
 
@@ -18,9 +22,11 @@ Produce one Git repository named from the user's team with this shape:
 └── .local/
     ├── compose.yml
     ├── lore.json
+    ├── known_hosts
+    ├── ssh_config
     ├── filesystem/
-    │   ├── user/onboarding/
-    │   └── channel/general/
+    │   ├── user/onboarding/README.md
+    │   └── channel/general/README.md
     └── runtime.env
 ```
 
@@ -28,41 +34,39 @@ Produce one Git repository named from the user's team with this shape:
 configuration. `.local/` is gitignored bootstrap state. It is never part of the
 image and is never committed.
 
-## 1. Inspect before changing anything
+## 1. Interview and inspect
 
-1. Ask for the team display name, not a project name.
+Ask in order, one per turn, with its reason and default:
+1. Team display name (required to identify its owner; no safe default).
 2. Derive a lowercase slug using letters, numbers, and single hyphens, then
-   suffix it with `-lore` (for example, `Acme Research` becomes
-   `acme-research-lore`). Show the result and allow correction.
-3. Ask where to create it; default to a new child of the current directory.
-4. If the destination exists and is not empty, show what conflicts and require
-   explicit approval before touching it. Never overwrite an existing
-   `openlore.yml`.
-5. Detect Docker Compose or Podman Compose and available ports. Prefer local
-   ports 2222 and 8080, but choose free ports when occupied.
+   suffix `-lore` (`Acme Research` → `acme-research-lore`); allow correction.
+3. Creation location (default: a new child of the current directory).
+4. SSH public key and matching private-key path. Explain that this key identifies
+   their first account; the private key stays put for their SSH client. Default
+   to one key for OpenLore and infrastructure, but offer separate keys.
+
+Silently inspect the destination, Compose tooling, and ports. For a non-empty
+destination show conflicts and require approval; never overwrite `openlore.yml`.
+Prefer Docker then Podman Compose. Default to ports 2222/8080; choose free ones
+when occupied and report them in the stage summary.
 
 ## 2. Select the OpenLore release and SSH key
 
-Find the latest stable semantic tag that actually exists on the public
-`ghcr.io/aakarim/openlore` image. Do not assume a GitHub release has a matching
-container tag. Ignore prereleases unless the user asks for one. If no stable
-container tag exists, explain that and ask whether to use `latest` temporarily
-or stop; never silently substitute it. Confirm the selected version, then
-create this `Containerfile` with an exact base tag:
+Find the latest stable semantic tag that exists on `ghcr.io/aakarim/openlore`;
+do not infer it from GitHub releases. Ignore prereleases unless requested. If
+none exists, explain and ask whether to use `latest` temporarily or stop. Confirm
+the version, then create this `Containerfile`:
 
 ```dockerfile
 FROM ghcr.io/aakarim/openlore:1.2.3
 ```
 
-Do not use `latest`, a range, a Git branch, or a digest-only reference for the
-initial project. The Containerfile only selects the published OpenLore build
-today and remains the extension point for custom packages later. Do not bake
-`openlore.yml`, `lore.json`, or bootstrap files into the image.
+Otherwise never use `latest`, ranges, branches, or digest-only references. The
+Containerfile selects OpenLore and permits later extension. Do not bake config or
+bootstrap state into it.
 
-Ask the user to select an existing SSH public key. Offer separate keys for the
-OpenLore principal and infrastructure administration, but default to using the
-same selected key for both. Never read, copy, print, generate, replace, or
-commit a private key without explicit need and approval.
+Validate the selected public/private key pair by authentication, not by printing
+private material. Never copy, print, generate, replace, or commit a private key.
 
 ## 3. Create tracked configuration
 
@@ -105,74 +109,33 @@ Create `.local/lore.json` with:
 
 - `allow_keyless: false`;
 - unknown identities denied;
-- one `onboarding` identity using the selected public key;
-- a unique writable home docset at `/user/onboarding`;
+- one `onboarding` identity using the selected public key—explain that an
+  identity is the account OpenLore recognizes when that key connects;
+- a unique writable home docset at `/user/onboarding`—explain that a docset is
+  a permission-controlled knowledge folder and this one is their private start;
 - an `administrator` role with `lore:config:edit`;
-- an `agent` role;
+- an `agent` role—explain that roles group permissions;
 - a `general` docset rooted at `/channel/general` granting `agent` `rw`;
 - `onboarding` assigned both `administrator` and `agent`.
 
-Use this shape, substituting the selected public key:
+Use exactly those fields and validate the complete JSON. The `onboarding-home`
+docset has `paths: ["/user/onboarding"]`; `general` has
+`paths: ["/channel/general"]` and grants role `agent` `rw`; the identity has
+`name: "onboarding"`, the selected `public_key`, `home: "onboarding-home"`, and
+roles `["administrator", "agent"]`.
 
-```json
-{
-  "allow_keyless": false,
-  "unknown_identity": "deny",
-  "default_cwd": "/user/onboarding",
-  "roles": {
-    "administrator": {
-      "allow": {
-        "capabilities": ["lore:config:edit"]
-      }
-    },
-    "agent": {}
-  },
-  "docsets": {
-    "onboarding-home": {
-      "paths": ["/user/onboarding"]
-    },
-    "general": {
-      "paths": ["/channel/general"],
-      "access": {
-        "allow": {
-          "agent": "rw"
-        }
-      }
-    }
-  },
-  "identities": [
-    {
-      "name": "onboarding",
-      "public_key": "<selected SSH public key>",
-      "home": "onboarding-home",
-      "roles": ["administrator", "agent"]
-    }
-  ]
-}
-```
-
-Create matching empty directories below `.local/filesystem/`. This directory is
-the initial SSH-visible filesystem. Do not put generated host private keys,
+Create both paths below `.local/filesystem/` and put a short `README.md` in each,
+describing the private onboarding area and shared general area respectively, so
+the first login always has visible content. Do not overwrite user content. This
+is the initial SSH-visible filesystem. Do not put generated host private keys,
 signing keys, audit logs, tokens, or runtime databases in bootstrap state; each
 deployed server creates its own operational state.
 
 ## 5. Create disposable local Compose state
 
-Put `compose.yml` and `runtime.env` inside `.local/`, not at project root. The
-Compose definition must:
-
-- build the root `Containerfile`;
-- mount root `openlore.yml` read-only at
-  `/var/lib/openlore/config/openlore.yml`;
-- mount `.local/lore.json` at `/var/lib/openlore/config/lore.json`;
-- mount `.local/filesystem` at `/var/lib/openlore/published`;
-- use named local volumes for `/var/lib/openlore/data` and
-  `/var/lib/openlore/ssh` so operational state is not bootstrap state;
-- map the free local HTTP and SSH ports recorded in `runtime.env`;
-- run `./out --config /var/lib/openlore/config/openlore.yml` directly.
-
-Use this minimal structure, replacing the Compose project name with the team
-slug:
+Put `compose.yml` and `runtime.env` inside `.local/`. Use this minimal structure,
+replacing the project name with the team slug; its mounts keep config, content,
+data, and host keys outside the image and persistent:
 
 ```yaml
 name: team-lore
@@ -220,14 +183,20 @@ regardless of which local runtime was used.
 
 ## 6. Require local acceptance
 
-Build and start the local server. Setup is not successful until all checks pass:
+Build and start the local server. Capture its host key into
+`.local/known_hosts`, replacing only a stale entry for this loopback host and
+port. Create `.local/ssh_config` with the selected private-key path, `User
+onboarding`, the chosen port, `UserKnownHostsFile`, and strict host-key checking.
+Never disable host-key checking or mutate global `~/.ssh/known_hosts`.
+
+Quietly run all checks; setup is not successful until they pass:
 
 1. HTTP readiness succeeds.
 2. `/mcp` completes an MCP initialization exchange.
-3. The selected key authenticates the `onboarding` identity over OpenLore SSH.
+3. `ssh -F .local/ssh_config lore-local` authenticates `onboarding`.
 4. The SSH session starts at `/user/onboarding`.
-5. A uniquely named disposable document can be written to
-   `/channel/general`, read back, and removed.
+5. Both default READMEs are visible; a unique disposable document can be
+   written to `/channel/general`, read back, and removed.
 6. After restarting the container, authentication, filesystem contents, and
    the SSH host key persist.
 
@@ -237,10 +206,20 @@ authentication or hardcode around a failed check.
 ## 7. Finish reviewably
 
 Initialize Git if needed. Show all tracked files and prove `.local/` is ignored.
-Summarize the selected image version, local URLs, exact SSH command, key used,
-and acceptance evidence. Offer to make an initial commit only after explicit
-approval; never push automatically.
+Finish with a friendly ✅ summary: what was created, what Compose now does
+(builds and keeps the local server running with persistent state), selected
+image version, local URLs, identity/home, ports, and key used. Do not narrate
+successful internal checks. Give these commands for a new terminal:
 
-Tell the user to run `onboarding` for more initial identities or folders and
-`deploy` when the local server is ready. One project represents one
-authoritative deployed server; do not create staging environments.
+```bash
+ssh -F .local/ssh_config lore-local
+ssh -F .local/ssh_config lore-local 'cat /channel/general/README.md'
+```
+
+Offer an initial commit only after explicit approval; never push automatically.
+
+Then ask whether to continue in this session (“run onboarding”) or later with
+`ssh openlore.sh onboarding | <agent-cli>` to add people/folders; deployment is
+similarly “run deploy” or `ssh openlore.sh deploy | <agent-cli>`. Explain that
+setup is complete and onboarding is optional customization. One project is one
+authoritative server; do not create staging environments.

--- a/assets/skills/setup.md
+++ b/assets/skills/setup.md
@@ -94,6 +94,15 @@ mcp:
 api:
   enabled: true
   path: /api
+
+passkeys:
+  enabled: true
+  rp_id: localhost
+  rp_name: "<team display name> Lore"
+  rp_origins: ["http://localhost:<selected HTTP port>"]
+  lore_path: /lore
+  passkeys_file: /var/lib/openlore/data/passkeys.json
+  session_ttl: 24h
 ```
 
 These standard Unix paths are identical locally and remotely. Dynamic policy
@@ -194,7 +203,7 @@ Quietly run all checks; setup is not successful until they pass:
 
 1. HTTP readiness succeeds.
 2. `/mcp` completes an MCP initialization exchange.
-3. The mounted config is active: keyless login fails and
+3. `passkey` is available; the mounted config is active: keyless login fails and
    `ssh -F .local/ssh_config lore-local` authenticates `onboarding`.
 4. The SSH session starts at `/user/onboarding`.
 5. Both default READMEs are visible; a unique disposable document can be

--- a/assets/skills/setup.md
+++ b/assets/skills/setup.md
@@ -6,7 +6,8 @@ it matters, recommend a default, and define unfamiliar terms just in time. If
 there is no safe default, say why a choice is required. Use restrained emojis.
 Run checks quietly and mention only failures or decisions. After each stage give
 a short ✅ plain-language summary, never “acceptance evidence”. Use an official
-release; do not clone, fork, vendor, or add OpenLore as a submodule.
+release; do not clone, fork, vendor, or add OpenLore as a submodule. After fixing
+a failure, summarize its user impact—not a technical postmortem—unless asked.
 
 ## Outcome
 
@@ -135,7 +136,8 @@ deployed server creates its own operational state.
 
 Put `compose.yml` and `runtime.env` inside `.local/`. Use this minimal structure,
 replacing the project name with the team slug; its mounts keep config, content,
-data, and host keys outside the image and persistent:
+data, and host keys outside the image and persistent. Inherit the image command,
+which already loads the mounted config; do not override `command` or `entrypoint`:
 
 ```yaml
 name: team-lore
@@ -145,7 +147,6 @@ services:
       context: ..
       dockerfile: Containerfile
     restart: unless-stopped
-    command: ["./out", "--config", "/var/lib/openlore/config/openlore.yml"]
     ports:
       - "${OPENLORE_SSH_PORT}:2222"
       - "${OPENLORE_HTTP_PORT}:8080"
@@ -193,7 +194,8 @@ Quietly run all checks; setup is not successful until they pass:
 
 1. HTTP readiness succeeds.
 2. `/mcp` completes an MCP initialization exchange.
-3. `ssh -F .local/ssh_config lore-local` authenticates `onboarding`.
+3. The mounted config is active: keyless login fails and
+   `ssh -F .local/ssh_config lore-local` authenticates `onboarding`.
 4. The SSH session starts at `/user/onboarding`.
 5. Both default READMEs are visible; a unique disposable document can be
    written to `/channel/general`, read back, and removed.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -561,7 +561,7 @@ type apiYAML struct {
 }
 
 type passkeysYAML struct {
-	Enabled      bool     `yaml:"enabled"`
+	Enabled      *bool    `yaml:"enabled"`
 	RPID         string   `yaml:"rp_id"`
 	RPName       string   `yaml:"rp_name"`
 	RPOrigins    []string `yaml:"rp_origins"`
@@ -595,7 +595,16 @@ func New(opts ...Option) (Config, error) {
 		WriteConflictPolicy: vfs.DefaultWriteConflictPolicy, // "hash": overwrites are compare-and-swap
 		MaxJobs:             8,                              // bound concurrent async spawn jobs
 		Plugins:             PluginsConfig{Skills: SkillsPluginConfig{RemoteCheckTTL: 60 * time.Second, RemoteTimeout: 3 * time.Second, RemoteMaxBytes: 10 * 1024 * 1024}},
-		Inbox:               InboxConfig{MaxUploadSize: DefaultInboxMaxUploadSize, AllowedTypes: map[string]string{".md": "text/markdown", ".markdown": "text/markdown"}},
+		Passkeys: PasskeysConfig{
+			Enabled:      true,
+			RPID:         "localhost",
+			RPName:       "OpenLore",
+			RPOrigins:    []string{"http://localhost:8080"},
+			LorePath:     "/lore",
+			PasskeysFile: "./config/passkeys.json",
+			SessionTTL:   "24h",
+		},
+		Inbox: InboxConfig{MaxUploadSize: DefaultInboxMaxUploadSize, AllowedTypes: map[string]string{".md": "text/markdown", ".markdown": "text/markdown"}},
 		Files: FilesConfig{
 			Allowed: []string{
 				"*.md", "*.markdown", "*.txt",
@@ -1129,7 +1138,9 @@ func applyPasskeysConfig(cfg *Config, pk *passkeysYAML) {
 	if pk == nil {
 		return
 	}
-	cfg.Passkeys.Enabled = pk.Enabled
+	if pk.Enabled != nil {
+		cfg.Passkeys.Enabled = *pk.Enabled
+	}
 	if pk.RPID != "" {
 		cfg.Passkeys.RPID = pk.RPID
 	}

--- a/internal/config/passkeys_test.go
+++ b/internal/config/passkeys_test.go
@@ -1,0 +1,36 @@
+package config
+
+import "testing"
+
+func TestPasskeysDefaultEnabled(t *testing.T) {
+	cfg, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Passkeys.Enabled {
+		t.Fatal("passkeys must be enabled by default")
+	}
+	if cfg.Passkeys.RPID != "localhost" || len(cfg.Passkeys.RPOrigins) != 1 || cfg.Passkeys.RPOrigins[0] != "http://localhost:8080" {
+		t.Fatalf("passkey defaults = %+v", cfg.Passkeys)
+	}
+}
+
+func TestPasskeysCanBeDisabled(t *testing.T) {
+	cfg, err := New(WithEmbeddedConfig([]byte("passkeys:\n  enabled: false\n"), ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Passkeys.Enabled {
+		t.Fatal("passkeys enabled after explicit disable")
+	}
+}
+
+func TestPasskeysStayEnabledWhenCustomized(t *testing.T) {
+	cfg, err := New(WithEmbeddedConfig([]byte("passkeys:\n  rp_id: lore.example.com\n"), ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Passkeys.Enabled || cfg.Passkeys.RPID != "lore.example.com" {
+		t.Fatalf("custom passkeys = %+v", cfg.Passkeys)
+	}
+}

--- a/openlore.yml.example
+++ b/openlore.yml.example
@@ -128,10 +128,9 @@ host_key_path: .ssh/openlore_ed25519
 
 # ── Passkeys / WebAuthn ───────────────────────────────
 #
-# Enable browser-based passkey authentication for human access
-# to documentation via the HTTP server. When enabled, users can
-# register passkeys from the SSH shell (`passkey` command) and
-# then browse docs at /lore/ in a web browser.
+# Browser passkeys default to enabled for http://localhost:8080. Users can
+# register from SSH (`passkey`) and browse at /lore/. Set `enabled: false` to
+# disable them. For deployment, configure the public HTTPS domain explicitly:
 #
 # passkeys:
 #   enabled: true


### PR DESCRIPTION
## Summary

- turn setup and onboarding into friendly one-question-at-a-time interviews with explained defaults and just-in-time terminology
- keep successful validation quiet while adding plain-language stage summaries, emojis, continuation commands, and ready-to-run local SSH examples
- directly verify local SSH using project-local strict host-key trust, without modifying global `known_hosts`
- seed empty onboarding and general docsets with explanatory `README.md` files
- inherit the official image command instead of overriding its shell entrypoint with an argument array, and verify the mounted auth policy is active
- enable passkeys by default with localhost-safe settings, persistent setup storage, production RP guidance, and an explicit `enabled: false` opt-out
- keep setup shorter (246 → 236 lines), onboarding shorter (68 → 66), and deploy unchanged at 131 lines

## Verification

- `go test ./...`
- `git diff --check`
- added config tests for enabled-by-default, explicit disable, and customization without disabling
- confirmed no modified skill instruction file increased in line count