### PR TITLE
Tolerate invalid config value types at startup

### DIFF
--- a/assets/skills/deploy.md
+++ b/assets/skills/deploy.md
@@ -106,6 +106,23 @@ path (or update the provider's equivalent external config projection), then
 restart OpenLore. Never replace `lore.json` or the SSH-visible filesystem as
 part of continuous deployment.
 
+## Diagnose configuration startup issues
+
+If OpenLore does not start or behaves unexpectedly after configuration changes,
+temporarily add `-debug` to the existing server command, preserving all current
+arguments. For the standard container command, run:
+
+```bash
+./out -debug --config /var/lib/openlore/config/openlore.yml
+```
+
+Inspect the command-line logs for configuration warnings. OpenLore ignores
+individual values with incompatible YAML types, retains the remaining valid
+configuration, and reports each ignored value; malformed YAML syntax can still
+prevent startup. Correct the persistent `openlore.yml`, verify a normal restart,
+then remove `-debug` from the production command. Do not leave debug logging
+enabled after diagnosis.
+
 ## Required production acceptance
 
 Deployment is not verified until all applicable checks pass:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,12 @@ type Config struct {
 	// Track sources for conflict detection.
 	configFileLoaded   bool
 	embeddedConfigUsed bool
+	warnings           []string
+}
+
+// Warnings returns non-fatal problems encountered while loading configuration.
+func (c Config) Warnings() []string {
+	return append([]string(nil), c.warnings...)
 }
 
 type PluginsConfig struct{ Skills SkillsPluginConfig }
@@ -648,10 +654,11 @@ func WithConfigFile(path string) Option {
 			return fmt.Errorf("reading config file: %w", err)
 		}
 
-		var fc fileConfig
-		if err := yaml.Unmarshal(data, &fc); err != nil {
+		fc, warnings, err := decodeFileConfig(data)
+		if err != nil {
 			return fmt.Errorf("parsing config file: %w", err)
 		}
+		cfg.warnings = append(cfg.warnings, warnings...)
 
 		cfg.configFileLoaded = true
 
@@ -770,10 +777,11 @@ func WithEmbeddedConfig(data []byte, motdFallback string) Option {
 		if len(data) > 0 {
 			cfg.embeddedConfigUsed = true
 
-			var fc fileConfig
-			if err := yaml.Unmarshal(data, &fc); err != nil {
+			fc, warnings, err := decodeFileConfig(data)
+			if err != nil {
 				return fmt.Errorf("parsing embedded config: %w", err)
 			}
+			cfg.warnings = append(cfg.warnings, warnings...)
 
 			if fc.ConfigVersion != "" {
 				cfg.ConfigVersion = fc.ConfigVersion
@@ -877,6 +885,24 @@ func WithEmbeddedConfig(data []byte, motdFallback string) Option {
 
 		return nil
 	}
+}
+
+// decodeFileConfig keeps values that YAML can decode while reporting type
+// mismatches for individual values. yaml.v3 populates the rest of the target
+// when it returns a TypeError, which lets a server start with safe defaults for
+// malformed settings instead of rejecting the entire configuration.
+func decodeFileConfig(data []byte) (fileConfig, []string, error) {
+	var fc fileConfig
+	err := yaml.Unmarshal(data, &fc)
+	if err == nil {
+		return fc, nil, nil
+	}
+
+	var typeErr *yaml.TypeError
+	if !errors.As(err, &typeErr) {
+		return fileConfig{}, nil, err
+	}
+	return fc, append([]string(nil), typeErr.Errors...), nil
 }
 
 // WithPort sets the SSH server port.

--- a/internal/config/debug_test.go
+++ b/internal/config/debug_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -29,5 +30,45 @@ func TestDebugConfig(t *testing.T) {
 	embeddedCfg, err := New(WithEmbeddedConfig(data, ""))
 	if err != nil || !embeddedCfg.Debug {
 		t.Fatalf("embedded debug = %t, err = %v", embeddedCfg.Debug, err)
+	}
+}
+
+func TestInvalidValueTypeIsOmitted(t *testing.T) {
+	data := []byte("debug: true\nport: 2323\npasskeys: true\n")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "openlore.yml")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name string
+		load Option
+	}{
+		{name: "file", load: WithConfigFile(path)},
+		{name: "embedded", load: WithEmbeddedConfig(data, "")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := New(tt.load)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if !cfg.Debug || cfg.Port != 2323 {
+				t.Fatalf("valid settings were not retained: debug=%t port=%d", cfg.Debug, cfg.Port)
+			}
+			if !cfg.Passkeys.Enabled || cfg.Passkeys.RPID != "localhost" {
+				t.Fatalf("invalid passkeys setting changed defaults: %+v", cfg.Passkeys)
+			}
+			warnings := cfg.Warnings()
+			if len(warnings) != 1 || !strings.Contains(warnings[0], "cannot unmarshal !!bool `true` into config.passkeysYAML") {
+				t.Fatalf("warnings = %q", warnings)
+			}
+		})
+	}
+}
+
+func TestInvalidYAMLSyntaxStillFails(t *testing.T) {
+	if _, err := New(WithEmbeddedConfig([]byte("passkeys: [\n"), "")); err == nil {
+		t.Fatal("invalid YAML syntax was accepted")
 	}
 }

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -168,6 +168,9 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 			logger = slog.Default()
 		}
 	}
+	for _, warning := range cfg.Warnings() {
+		logger.Warn("ignoring invalid configuration value", "error", warning)
+	}
 
 	s := &Server{
 		config: cfg,

--- a/pkg/openlore/server_seams_test.go
+++ b/pkg/openlore/server_seams_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -129,6 +131,25 @@ func TestUnsupportedShellUsageIsLoggedOnlyInDebugMode(t *testing.T) {
 				t.Fatalf("unknown-command arguments leaked into logs:\n%s", got)
 			}
 		})
+	}
+}
+
+func TestNewServerWarnsForInvalidConfigurationValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "openlore.yml")
+	if err := os.WriteFile(path, []byte("passkeys: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+
+	if _, err := NewServer("", WithConfigFile(path), WithLogger(logger)); err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	got := logs.String()
+	if !strings.Contains(got, `"level":"WARN"`) ||
+		!strings.Contains(got, `"msg":"ignoring invalid configuration value"`) ||
+		!strings.Contains(got, "passkeysYAML") {
+		t.Fatalf("warning log = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- retain valid OpenLore settings when another YAML value has the wrong type
- leave malformed settings at their safe defaults and emit startup warnings
- preserve fatal errors for malformed YAML syntax that cannot be recovered reliably
- keep `--debug` as an explicit override that enables debug behavior and debug-level logging
- document temporarily adding `-debug` during deployment troubleshooting and removing it afterward

## Example
A config containing `passkeys: true` now starts the server, ignores that invalid value, and logs a warning rather than rejecting the whole configuration.

## Testing
- `go test ./...`
- `go test ./assets ./cmd/openlore`