### PR TITLE
test: enforce VFS preconditions in test doubles

### DIFF
--- a/pkg/openlore/server_seams_test.go
+++ b/pkg/openlore/server_seams_test.go
@@ -78,8 +78,8 @@ func TestNewServerWithRootFS_WriteLogLive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CommitChangeSet: %v", err)
 	}
-	if res.Hash != "h:/x" {
-		t.Fatalf("hash = %q, want h:/x", res.Hash)
+	if res.Hash != wlHash([]byte("x")) {
+		t.Fatalf("hash = %q, want SHA-256 of committed bytes", res.Hash)
 	}
 	if got := fs.order(); len(got) != 1 || got[0] != "/x" {
 		t.Fatalf("applied = %v, want [/x]", got)
@@ -176,7 +176,7 @@ func TestRegisterPlugin_WriteMiddlewareGatesLaterWrite(t *testing.T) {
 
 	// An ungated write commits.
 	res, err := chain(context.Background(), NewWriteOp(Attribution{Principal: "a"}, writeCS("/ok")))
-	if err != nil || res.Hash != "h:/ok" {
+	if err != nil || res.Hash != wlHash([]byte("x")) {
 		t.Fatalf("ungated write: h=%q err=%v", res.Hash, err)
 	}
 	if got := fs.order(); len(got) != 1 || got[0] != "/ok" {
@@ -221,7 +221,7 @@ func TestRegisterPlugin_PostCommitFiresAfterConstruction(t *testing.T) {
 	if infos[0].Attribution.Principal != "alice" || infos[0].Attribution.Extra["approver"] != "bob" {
 		t.Fatalf("attribution = %+v", infos[0].Attribution)
 	}
-	if infos[0].Hash != "h:/x" || infos[0].ChangeSet.Target != "/x" {
+	if infos[0].Hash != wlHash([]byte("x")) || infos[0].ChangeSet.Target != "/x" {
 		t.Fatalf("commit info = %+v", infos[0])
 	}
 }
@@ -245,8 +245,8 @@ func TestCommitChangeSet_SkipsAdmission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CommitChangeSet must skip admission and commit: %v", err)
 	}
-	if res.Hash != "h:/x" {
-		t.Fatalf("hash = %q, want h:/x", res.Hash)
+	if res.Hash != wlHash([]byte("x")) {
+		t.Fatalf("hash = %q, want SHA-256 of committed bytes", res.Hash)
 	}
 	if got := fs.order(); len(got) != 1 || got[0] != "/x" {
 		t.Fatalf("applied = %v, want [/x]", got)

--- a/pkg/openlore/writelog_test.go
+++ b/pkg/openlore/writelog_test.go
@@ -2,10 +2,16 @@ package openlore
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,34 +20,231 @@ import (
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
-// wlRecordingFS is a minimal WritableFS that records applied write targets in
-// order and returns a deterministic hash. A per-target error can be programmed.
+// wlRecordingFS is a small in-memory WritableFS that records applied write
+// targets in order. It enforces the same write and whole-tree preconditions as
+// a real substrate. A per-target error can be programmed.
 type wlRecordingFS struct {
 	mu      sync.Mutex
 	applied []string
 	errFor  map[string]error
+	nodes   map[string]*vfs.FileInfo
 }
 
-func (f *wlRecordingFS) Stat(string) (*vfs.FileInfo, error)     { return nil, errors.New("no") }
-func (f *wlRecordingFS) ReadDir(string) ([]vfs.FileInfo, error) { return nil, errors.New("no") }
-func (f *wlRecordingFS) ReadFile(string) ([]byte, error)        { return nil, errors.New("no") }
-func (f *wlRecordingFS) SetWriteable() error                    { return nil }
-func (f *wlRecordingFS) SetReadonly() error                     { return nil }
-func (f *wlRecordingFS) Mkdir(string) error                     { return nil }
-func (f *wlRecordingFS) MkdirAll(string) error                  { return nil }
-func (f *wlRecordingFS) Remove(string) error                    { return nil }
-func (f *wlRecordingFS) RemoveAll(string, vfs.RemoveOpts) error { return nil }
+func (f *wlRecordingFS) ensureNodesLocked() {
+	if f.nodes == nil {
+		f.nodes = map[string]*vfs.FileInfo{
+			"/": {FileName: "/", FilePath: "/", Dir: true},
+		}
+	}
+}
 
-func (f *wlRecordingFS) WriteFileAtomic(name string, _ []byte, _ vfs.WriteOpts) (string, error) {
+func (f *wlRecordingFS) Stat(name string) (*vfs.FileInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureNodesLocked()
+	info, ok := f.nodes[vfs.CleanPath(name)]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	copy := *info
+	copy.Content = append([]byte(nil), info.Content...)
+	return &copy, nil
+}
+
+func (f *wlRecordingFS) ReadDir(name string) ([]vfs.FileInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureNodesLocked()
+	clean := vfs.CleanPath(name)
+	info, ok := f.nodes[clean]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	if !info.Dir {
+		return nil, vfs.ErrNotDirectory(clean)
+	}
+	var children []vfs.FileInfo
+	for candidate, child := range f.nodes {
+		if candidate != clean && path.Dir(candidate) == clean {
+			copy := *child
+			copy.Content = append([]byte(nil), child.Content...)
+			children = append(children, copy)
+		}
+	}
+	sort.Slice(children, func(i, j int) bool { return children[i].FileName < children[j].FileName })
+	return children, nil
+}
+
+func (f *wlRecordingFS) ReadFile(name string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureNodesLocked()
+	info, ok := f.nodes[vfs.CleanPath(name)]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	if info.Dir {
+		return nil, vfs.ErrIsDirectory(name)
+	}
+	return append([]byte(nil), info.Content...), nil
+}
+
+func (f *wlRecordingFS) SetWriteable() error { return nil }
+func (f *wlRecordingFS) SetReadonly() error  { return nil }
+
+func (f *wlRecordingFS) Mkdir(name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureNodesLocked()
+	clean := vfs.CleanPath(name)
+	if _, exists := f.nodes[clean]; exists {
+		return fs.ErrExist
+	}
+	parent, ok := f.nodes[path.Dir(clean)]
+	if !ok {
+		return fs.ErrNotExist
+	}
+	if !parent.Dir {
+		return vfs.ErrNotDirectory(path.Dir(clean))
+	}
+	f.nodes[clean] = &vfs.FileInfo{FileName: path.Base(clean), FilePath: clean, Dir: true}
+	return nil
+}
+
+func (f *wlRecordingFS) mkdirAllLocked(name string) error {
+	current := "/"
+	for _, part := range strings.Split(strings.Trim(vfs.CleanPath(name), "/"), "/") {
+		if part == "" {
+			continue
+		}
+		current = path.Join(current, part)
+		if info, ok := f.nodes[current]; ok {
+			if !info.Dir {
+				return vfs.ErrNotDirectory(current)
+			}
+			continue
+		}
+		f.nodes[current] = &vfs.FileInfo{FileName: path.Base(current), FilePath: current, Dir: true}
+	}
+	return nil
+}
+
+func (f *wlRecordingFS) MkdirAll(name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureNodesLocked()
+	return f.mkdirAllLocked(name)
+}
+
+func (f *wlRecordingFS) Remove(name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureNodesLocked()
+	clean := vfs.CleanPath(name)
+	if _, exists := f.nodes[clean]; !exists {
+		return fs.ErrNotExist
+	}
+	for candidate := range f.nodes {
+		if candidate != clean && strings.HasPrefix(candidate, clean+"/") {
+			return errors.New("directory not empty")
+		}
+	}
+	delete(f.nodes, clean)
+	return nil
+}
+
+func (f *wlRecordingFS) RemoveAll(name string, opts vfs.RemoveOpts) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureNodesLocked()
+	clean := vfs.CleanPath(name)
+	if _, exists := f.nodes[clean]; !exists {
+		return fs.ErrNotExist
+	}
+	if opts.Expected != nil && !wlSnapshotsEqual(opts.Expected, f.snapshotLocked(clean)) {
+		return &vfs.TreeStaleError{Path: clean, Detail: "subtree does not match expected snapshot"}
+	}
+	for candidate := range f.nodes {
+		if candidate == clean || strings.HasPrefix(candidate, clean+"/") {
+			delete(f.nodes, candidate)
+		}
+	}
+	return nil
+}
+
+func (f *wlRecordingFS) WriteFileAtomic(name string, data []byte, opts vfs.WriteOpts) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.errFor != nil {
 		if err := f.errFor[name]; err != nil {
 			return "", err
 		}
 	}
-	f.mu.Lock()
-	f.applied = append(f.applied, name)
-	f.mu.Unlock()
-	return "h:" + name, nil
+	f.ensureNodesLocked()
+	clean := vfs.CleanPath(name)
+	current, exists := f.nodes[clean]
+	currentHash := ""
+	if exists && !current.Dir {
+		currentHash = wlHash(current.Content)
+	}
+	if opts.IfNoneMatch && exists {
+		return "", &vfs.PreconditionError{Path: clean, Current: currentHash}
+	}
+	if opts.IfMatch != nil && (!exists || current.Dir || currentHash != *opts.IfMatch) {
+		return "", &vfs.PreconditionError{Path: clean, Current: currentHash}
+	}
+	if err := f.mkdirAllLocked(path.Dir(clean)); err != nil {
+		return "", err
+	}
+	if exists && current.Dir {
+		return "", vfs.ErrIsDirectory(clean)
+	}
+	copy := append([]byte(nil), data...)
+	f.nodes[clean] = &vfs.FileInfo{FileName: path.Base(clean), FilePath: clean, Content: copy, FileSize: int64(len(copy))}
+	f.applied = append(f.applied, clean)
+	return wlHash(copy), nil
+}
+
+func (f *wlRecordingFS) snapshotLocked(root string) *vfs.TreeSnapshot {
+	snapshot := &vfs.TreeSnapshot{Root: root}
+	for candidate, info := range f.nodes {
+		if candidate != root && !strings.HasPrefix(candidate, root+"/") {
+			continue
+		}
+		rel := "."
+		if candidate != root {
+			rel = strings.TrimPrefix(candidate, root+"/")
+		}
+		op := vfs.TreeOp{RelPath: rel, Kind: "dir"}
+		if !info.Dir {
+			op.Kind = "file"
+			op.Hash = wlHash(info.Content)
+			op.Size = int64(len(info.Content))
+		}
+		snapshot.Ops = append(snapshot.Ops, op)
+	}
+	return snapshot
+}
+
+func wlSnapshotsEqual(want, got *vfs.TreeSnapshot) bool {
+	if want.Root != got.Root || len(want.Ops) != len(got.Ops) {
+		return false
+	}
+	wantByPath := make(map[string]vfs.TreeOp, len(want.Ops))
+	for _, op := range want.Ops {
+		wantByPath[op.RelPath] = op
+	}
+	for _, op := range got.Ops {
+		if expected, ok := wantByPath[op.RelPath]; !ok || expected != op {
+			return false
+		}
+	}
+	return true
+}
+
+func wlHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func (f *wlRecordingFS) order() []string {
@@ -86,14 +289,78 @@ func TestWriteLog_AppliesInOrderAndAwaits(t *testing.T) {
 		if err != nil {
 			t.Fatalf("submit %s: %v", p, err)
 		}
-		if h != "h:"+p {
-			t.Fatalf("hash = %q, want h:%s", h, p)
+		if h != wlHash([]byte("x")) {
+			t.Fatalf("hash = %q, want SHA-256 of committed bytes", h)
 		}
 	}
 	got := fs.order()
 	want := []string{"/a", "/b", "/c"}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("apply order = %v, want %v", got, want)
+	}
+}
+
+func TestWriteLogPreservesAndEnforcesWritePreconditions(t *testing.T) {
+	fs := &wlRecordingFS{}
+	l := newWriteLog(fs, nil, nil, 4)
+	defer l.Close(context.Background())
+
+	base, err := l.Submit(context.Background(), Attribution{}, writeCS("/cas"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := "stale"
+	for name, opts := range map[string]vfs.WriteOpts{
+		"IfMatch":     {IfMatch: &stale},
+		"IfNoneMatch": {IfNoneMatch: true},
+	} {
+		cs := vfs.ChangeSet{Target: "/cas", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("lost"), Opts: opts}}
+		_, err := l.Submit(context.Background(), Attribution{}, cs)
+		var precondition *vfs.PreconditionError
+		if !errors.As(err, &precondition) {
+			t.Fatalf("%s: want PreconditionError, got %v", name, err)
+		}
+	}
+	if got, err := fs.ReadFile("/cas"); err != nil || string(got) != "x" {
+		t.Fatalf("failed precondition changed file: content=%q err=%v", got, err)
+	}
+
+	cs := vfs.ChangeSet{Target: "/cas", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("updated"), Opts: vfs.WriteOpts{IfMatch: &base}}}
+	if _, err := l.Submit(context.Background(), Attribution{}, cs); err != nil {
+		t.Fatalf("matching IfMatch: %v", err)
+	}
+}
+
+func TestWriteLogPreservesAndEnforcesRemovePrecondition(t *testing.T) {
+	fs := &wlRecordingFS{}
+	l := newWriteLog(fs, nil, nil, 4)
+	defer l.Close(context.Background())
+
+	if _, err := l.Submit(context.Background(), Attribution{}, vfs.ChangeSet{Target: "/tree", Action: vfs.ChangeActionMkdirAll}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.Submit(context.Background(), Attribution{}, writeCS("/tree/a")); err != nil {
+		t.Fatal(err)
+	}
+	fs.mu.Lock()
+	expected := fs.snapshotLocked("/tree")
+	fs.mu.Unlock()
+	if _, err := l.Submit(context.Background(), Attribution{}, writeCS("/tree/concurrent")); err != nil {
+		t.Fatal(err)
+	}
+
+	cs := vfs.ChangeSet{
+		Target:    "/tree",
+		Action:    vfs.ChangeActionRemoveAll,
+		RemoveAll: &vfs.RemoveAllChange{Opts: vfs.RemoveOpts{Expected: expected}},
+	}
+	_, err := l.Submit(context.Background(), Attribution{}, cs)
+	var stale *vfs.TreeStaleError
+	if !errors.As(err, &stale) {
+		t.Fatalf("want TreeStaleError, got %v", err)
+	}
+	if _, err := fs.Stat("/tree/concurrent"); err != nil {
+		t.Fatalf("stale removal changed tree: %v", err)
 	}
 }
 
@@ -111,12 +378,12 @@ func TestWriteLog_PostCommitRunsWithActorAndDoesNotBlockSubmit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("submit err (post-commit failure must not surface): %v", err)
 	}
-	if h != "h:/a" {
+	if h != wlHash([]byte("x")) {
 		t.Fatalf("hash = %q", h)
 	}
 	select {
 	case info := <-seen:
-		if info.Attribution.Principal != "agent-9" || info.Hash != "h:/a" || info.ChangeSet.Target != "/a" {
+		if info.Attribution.Principal != "agent-9" || info.Hash != wlHash([]byte("x")) || info.ChangeSet.Target != "/a" {
 			t.Fatalf("post-commit info = %+v", info)
 		}
 	case <-time.After(2 * time.Second):
@@ -131,7 +398,7 @@ func TestWriteLog_RecorderFailureDoesNotTurnCommittedWriteIntoFailure(t *testing
 	defer l.Close(context.Background())
 
 	hash, err := l.Submit(context.Background(), Attribution{Principal: "alice"}, writeCS("/committed"))
-	if err != nil || hash != "h:/committed" {
+	if err != nil || hash != wlHash([]byte("x")) {
 		t.Fatalf("durable commit reported hash=%q err=%v", hash, err)
 	}
 	if got := fs.order(); len(got) != 1 || got[0] != "/committed" {

--- a/pkg/shell/cmds/pending_change_test.go
+++ b/pkg/shell/cmds/pending_change_test.go
@@ -2,6 +2,8 @@ package cmds_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"testing"
 
@@ -14,17 +16,29 @@ import (
 // *vfs.PendingChangeError as exit-0 + a Ref line.
 type pendingFS struct {
 	*mapFS
-	ref string
+	ref        string
+	lastChange vfs.ChangeSet
 }
 
-func (p *pendingFS) WriteFileAtomic(path string, _ []byte, _ vfs.WriteOpts) (string, error) {
-	return "", &vfs.PendingChangeError{Ref: p.ref, ChangeSet: vfs.ChangeSet{Target: path, Action: vfs.ChangeActionWrite}}
+func (p *pendingFS) WriteFileAtomic(path string, data []byte, opts vfs.WriteOpts) (string, error) {
+	p.lastChange = vfs.ChangeSet{
+		Target: path,
+		Action: vfs.ChangeActionWrite,
+		Write:  &vfs.WriteChange{Bytes: append([]byte(nil), data...), Opts: opts},
+	}
+	return "", &vfs.PendingChangeError{Ref: p.ref, ChangeSet: p.lastChange}
 }
 func (p *pendingFS) Remove(path string) error {
-	return &vfs.PendingChangeError{Ref: p.ref, ChangeSet: vfs.ChangeSet{Target: path, Action: vfs.ChangeActionRemove}}
+	p.lastChange = vfs.ChangeSet{Target: path, Action: vfs.ChangeActionRemove}
+	return &vfs.PendingChangeError{Ref: p.ref, ChangeSet: p.lastChange}
 }
-func (p *pendingFS) RemoveAll(path string, _ vfs.RemoveOpts) error {
-	return &vfs.PendingChangeError{Ref: p.ref, ChangeSet: vfs.ChangeSet{Target: path, Action: vfs.ChangeActionRemoveAll}}
+func (p *pendingFS) RemoveAll(path string, opts vfs.RemoveOpts) error {
+	p.lastChange = vfs.ChangeSet{
+		Target:    path,
+		Action:    vfs.ChangeActionRemoveAll,
+		RemoveAll: &vfs.RemoveAllChange{Opts: opts},
+	}
+	return &vfs.PendingChangeError{Ref: p.ref, ChangeSet: p.lastChange}
 }
 
 func execPending(fs vfs.WritableFS, cmd string) (string, string, int) {
@@ -44,6 +58,34 @@ func TestWritePendingChangeIsExitZeroWithRef(t *testing.T) {
 	}
 	if !strings.Contains(errOut, "chg-42") || !strings.Contains(errOut, "pending") {
 		t.Fatalf("write pending line missing Ref: %q", errOut)
+	}
+	if fs.lastChange.Write == nil || !fs.lastChange.Write.Opts.IfNoneMatch {
+		t.Fatalf("pending write lost create-only precondition: %+v", fs.lastChange)
+	}
+}
+
+func TestPendingFSRetainsIfMatch(t *testing.T) {
+	fs := &pendingFS{mapFS: testFS(), ref: "chg-43"}
+	base := fs.Files["/docs/notes.txt"].Content
+	sum := sha256.Sum256(base)
+	want := hex.EncodeToString(sum[:])
+
+	_, errOut, code := execPending(fs, "echo replacement > /docs/notes.txt")
+	if code != 0 {
+		t.Fatalf("write: code=%d err=%q", code, errOut)
+	}
+	if fs.lastChange.Write == nil || fs.lastChange.Write.Opts.IfMatch == nil || *fs.lastChange.Write.Opts.IfMatch != want {
+		t.Fatalf("pending write lost IfMatch=%s: %+v", want, fs.lastChange)
+	}
+}
+
+func TestPendingFSRetainsRemoveSnapshot(t *testing.T) {
+	fs := &pendingFS{mapFS: testFS(), ref: "chg-44"}
+	expected := fs.snapshot("/docs/sub")
+
+	_ = fs.RemoveAll("/docs/sub", vfs.RemoveOpts{Expected: expected})
+	if fs.lastChange.RemoveAll == nil || fs.lastChange.RemoveAll.Opts.Expected != expected {
+		t.Fatalf("pending remove lost expected snapshot: %+v", fs.lastChange)
 	}
 }
 

--- a/pkg/shell/cmds/testutil_test.go
+++ b/pkg/shell/cmds/testutil_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -126,11 +127,24 @@ func (m *mapFS) ReadFile(path string) ([]byte, error) {
 func (m *mapFS) SetWriteable() error { m.readonly = false; return nil }
 func (m *mapFS) SetReadonly() error  { m.readonly = true; return nil }
 
-func (m *mapFS) WriteFileAtomic(p string, data []byte, _ vfs.WriteOpts) (string, error) {
+func (m *mapFS) WriteFileAtomic(p string, data []byte, opts vfs.WriteOpts) (string, error) {
 	if m.readonly {
 		return "", vfs.ErrReadOnly
 	}
-	m.AddFile(vfs.CleanPath(p), string(data))
+	clean := vfs.CleanPath(p)
+	current, exists := m.Files[clean]
+	currentHash := ""
+	if exists && !current.Dir {
+		sum := sha256.Sum256(current.Content)
+		currentHash = hex.EncodeToString(sum[:])
+	}
+	if opts.IfNoneMatch && exists {
+		return "", &vfs.PreconditionError{Path: clean, Current: currentHash}
+	}
+	if opts.IfMatch != nil && (!exists || current.Dir || currentHash != *opts.IfMatch) {
+		return "", &vfs.PreconditionError{Path: clean, Current: currentHash}
+	}
+	m.AddFile(clean, string(data))
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:]), nil
 }
@@ -195,13 +209,16 @@ func (m *mapFS) Remove(p string) error {
 	return nil
 }
 
-func (m *mapFS) RemoveAll(p string, _ vfs.RemoveOpts) error {
+func (m *mapFS) RemoveAll(p string, opts vfs.RemoveOpts) error {
 	if m.readonly {
 		return vfs.ErrReadOnly
 	}
 	clean := vfs.CleanPath(p)
 	if _, ok := m.Files[clean]; !ok {
 		return fmt.Errorf("rm: %s: no such file or directory", p)
+	}
+	if opts.Expected != nil && !mapFSSnapshotEqual(opts.Expected, m.snapshot(clean)) {
+		return &vfs.TreeStaleError{Path: clean, Detail: "subtree does not match expected snapshot"}
 	}
 	prefix := clean + "/"
 	for tracked := range m.Files {
@@ -210,6 +227,46 @@ func (m *mapFS) RemoveAll(p string, _ vfs.RemoveOpts) error {
 		}
 	}
 	return nil
+}
+
+func (m *mapFS) snapshot(root string) *vfs.TreeSnapshot {
+	root = vfs.CleanPath(root)
+	snapshot := &vfs.TreeSnapshot{Root: root}
+	prefix := root + "/"
+	for tracked, info := range m.Files {
+		if tracked != root && !strings.HasPrefix(tracked, prefix) {
+			continue
+		}
+		rel := "."
+		if tracked != root {
+			rel = strings.TrimPrefix(tracked, prefix)
+		}
+		op := vfs.TreeOp{RelPath: rel, Kind: "dir"}
+		if !info.Dir {
+			sum := sha256.Sum256(info.Content)
+			op.Kind = "file"
+			op.Hash = hex.EncodeToString(sum[:])
+			op.Size = int64(len(info.Content))
+		}
+		snapshot.Ops = append(snapshot.Ops, op)
+	}
+	return snapshot
+}
+
+func mapFSSnapshotEqual(want, got *vfs.TreeSnapshot) bool {
+	if want.Root != got.Root || len(want.Ops) != len(got.Ops) {
+		return false
+	}
+	wantByPath := make(map[string]vfs.TreeOp, len(want.Ops))
+	for _, op := range want.Ops {
+		wantByPath[op.RelPath] = op
+	}
+	for _, op := range got.Ops {
+		if expected, ok := wantByPath[op.RelPath]; !ok || expected != op {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *mapFS) removeEntry(clean string) {
@@ -291,5 +348,110 @@ func assertExitCode(t *testing.T, fs *mapFS, cmd string, expectedCode int) {
 	_, _, code := execCmd(t, fs, cmd)
 	if code != expectedCode {
 		t.Errorf("%s: exit code %d, want %d", cmd, code, expectedCode)
+	}
+}
+
+func TestMapFSWriteFileAtomicHonorsPreconditions(t *testing.T) {
+	fs := testFS()
+	path := "/docs/notes.txt"
+	before := append([]byte(nil), fs.Files[path].Content...)
+	stale := "stale"
+
+	_, err := fs.WriteFileAtomic(path, []byte("replacement"), vfs.WriteOpts{IfMatch: &stale})
+	var precondition *vfs.PreconditionError
+	if !errors.As(err, &precondition) {
+		t.Fatalf("stale IfMatch: want PreconditionError, got %v", err)
+	}
+	if got := fs.Files[path].Content; !bytes.Equal(got, before) {
+		t.Fatalf("stale IfMatch changed content to %q", got)
+	}
+
+	_, err = fs.WriteFileAtomic(path, []byte("replacement"), vfs.WriteOpts{IfNoneMatch: true})
+	if !errors.As(err, &precondition) {
+		t.Fatalf("IfNoneMatch on existing file: want PreconditionError, got %v", err)
+	}
+
+	sum := sha256.Sum256(before)
+	match := hex.EncodeToString(sum[:])
+	if _, err := fs.WriteFileAtomic(path, []byte("replacement"), vfs.WriteOpts{IfMatch: &match}); err != nil {
+		t.Fatalf("matching IfMatch: %v", err)
+	}
+	if _, err := fs.WriteFileAtomic("/docs/new.txt", []byte("new"), vfs.WriteOpts{IfNoneMatch: true}); err != nil {
+		t.Fatalf("IfNoneMatch on missing file: %v", err)
+	}
+}
+
+func TestMapFSRemoveAllHonorsExpectedSnapshot(t *testing.T) {
+	fs := testFS()
+	expected := fs.snapshot("/docs/sub")
+	fs.AddFile("/docs/sub/concurrent.txt", "concurrent")
+
+	err := fs.RemoveAll("/docs/sub", vfs.RemoveOpts{Expected: expected})
+	var stale *vfs.TreeStaleError
+	if !errors.As(err, &stale) {
+		t.Fatalf("stale snapshot: want TreeStaleError, got %v", err)
+	}
+	if _, ok := fs.Files["/docs/sub/concurrent.txt"]; !ok {
+		t.Fatal("stale snapshot removed the tree")
+	}
+
+	if err := fs.RemoveAll("/docs/sub", vfs.RemoveOpts{Expected: fs.snapshot("/docs/sub")}); err != nil {
+		t.Fatalf("matching snapshot: %v", err)
+	}
+}
+
+type writeRaceFS struct {
+	*mapFS
+	target string
+	raced  bool
+}
+
+func (f *writeRaceFS) WriteFileAtomic(name string, data []byte, opts vfs.WriteOpts) (string, error) {
+	if clean := vfs.CleanPath(name); clean == f.target && !f.raced {
+		f.raced = true
+		f.AddFile(clean, "concurrent")
+	}
+	return f.mapFS.WriteFileAtomic(name, data, opts)
+}
+
+func TestRedirectCarriesIfMatchToWritableFS(t *testing.T) {
+	fs := &writeRaceFS{mapFS: testFS(), target: "/docs/notes.txt"}
+	sh := shell.NewShell(fs)
+	var out, errOut bytes.Buffer
+	code := sh.ExecPipeline("echo replacement > /docs/notes.txt", &out, &errOut, nil)
+
+	if code != 1 || !strings.Contains(errOut.String(), "file changed concurrently") {
+		t.Fatalf("code=%d stderr=%q", code, errOut.String())
+	}
+	if got := string(fs.Files[fs.target].Content); got != "concurrent" {
+		t.Fatalf("concurrent content was overwritten: %q", got)
+	}
+}
+
+type removeRaceFS struct {
+	*mapFS
+	target string
+	raced  bool
+}
+
+func (f *removeRaceFS) RemoveAll(name string, opts vfs.RemoveOpts) error {
+	if clean := vfs.CleanPath(name); clean == f.target && !f.raced {
+		f.raced = true
+		f.AddFile(clean, "concurrent")
+	}
+	return f.mapFS.RemoveAll(name, opts)
+}
+
+func TestMvCarriesSourceSnapshotToWritableFS(t *testing.T) {
+	fs := &removeRaceFS{mapFS: testFS(), target: "/docs/notes.txt"}
+	sh := shell.NewShell(fs)
+	var out, errOut bytes.Buffer
+	code := sh.ExecPipeline("mv /docs/notes.txt /docs/moved.txt", &out, &errOut, nil)
+
+	if code != 1 || !strings.Contains(errOut.String(), "source changed concurrently") {
+		t.Fatalf("code=%d stderr=%q", code, errOut.String())
+	}
+	if got := string(fs.Files[fs.target].Content); got != "concurrent" {
+		t.Fatalf("concurrently changed source was removed or overwritten: %q", got)
 	}
 }

--- a/pkg/vfs/changeset_test.go
+++ b/pkg/vfs/changeset_test.go
@@ -1,6 +1,8 @@
 package vfs
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io/fs"
 	"path"
@@ -182,20 +184,31 @@ func (f *rollbackFS) MkdirAll(target string) error {
 	}
 	return nil
 }
-func (f *rollbackFS) WriteFileAtomic(target string, data []byte, _ WriteOpts) (string, error) {
+func (f *rollbackFS) WriteFileAtomic(target string, data []byte, opts WriteOpts) (string, error) {
 	target = CleanPath(target)
 	if target == f.failTarget && !f.failed {
 		f.failed = true
 		return "", errors.New("injected I/O failure")
 	}
+	existing, exists := f.nodes[target]
+	currentHash := ""
+	if exists && !existing.Dir {
+		currentHash = testContentHash(existing.Content)
+	}
+	if opts.IfNoneMatch && exists {
+		return "", &PreconditionError{Path: target, Current: currentHash}
+	}
+	if opts.IfMatch != nil && (!exists || existing.Dir || currentHash != *opts.IfMatch) {
+		return "", &PreconditionError{Path: target, Current: currentHash}
+	}
 	if err := f.MkdirAll(path.Dir(target)); err != nil {
 		return "", err
 	}
-	if existing := f.nodes[target]; existing != nil && existing.Dir {
+	if existing != nil && existing.Dir {
 		return "", ErrIsDirectory(target)
 	}
 	f.nodes[target] = &FileInfo{FileName: path.Base(target), FilePath: target, Content: append([]byte(nil), data...), FileSize: int64(len(data))}
-	return "hash", nil
+	return testContentHash(data), nil
 }
 func (f *rollbackFS) Remove(target string) error {
 	target = CleanPath(target)
@@ -210,10 +223,13 @@ func (f *rollbackFS) Remove(target string) error {
 	delete(f.nodes, target)
 	return nil
 }
-func (f *rollbackFS) RemoveAll(target string, _ RemoveOpts) error {
+func (f *rollbackFS) RemoveAll(target string, opts RemoveOpts) error {
 	target = CleanPath(target)
 	if _, ok := f.nodes[target]; !ok {
 		return fs.ErrNotExist
+	}
+	if opts.Expected != nil && !testTreeSnapshotsEqual(opts.Expected, f.treeSnapshot(target)) {
+		return &TreeStaleError{Path: target, Detail: "subtree does not match expected snapshot"}
 	}
 	for candidate := range f.nodes {
 		if candidate == target || strings.HasPrefix(candidate, target+"/") {
@@ -221,6 +237,46 @@ func (f *rollbackFS) RemoveAll(target string, _ RemoveOpts) error {
 		}
 	}
 	return nil
+}
+func (f *rollbackFS) treeSnapshot(root string) *TreeSnapshot {
+	root = CleanPath(root)
+	snapshot := &TreeSnapshot{Root: root}
+	for candidate, info := range f.nodes {
+		if candidate != root && !strings.HasPrefix(candidate, root+"/") {
+			continue
+		}
+		rel := "."
+		if candidate != root {
+			rel = strings.TrimPrefix(candidate, root+"/")
+		}
+		op := TreeOp{RelPath: rel, Kind: "dir"}
+		if !info.Dir {
+			op.Kind = "file"
+			op.Hash = testContentHash(info.Content)
+			op.Size = int64(len(info.Content))
+		}
+		snapshot.Ops = append(snapshot.Ops, op)
+	}
+	return snapshot
+}
+func testTreeSnapshotsEqual(want, got *TreeSnapshot) bool {
+	if want.Root != got.Root || len(want.Ops) != len(got.Ops) {
+		return false
+	}
+	wantByPath := make(map[string]TreeOp, len(want.Ops))
+	for _, op := range want.Ops {
+		wantByPath[op.RelPath] = op
+	}
+	for _, op := range got.Ops {
+		if expected, ok := wantByPath[op.RelPath]; !ok || expected != op {
+			return false
+		}
+	}
+	return true
+}
+func testContentHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 func (f *rollbackFS) dump() string {
 	var rows []string
@@ -233,6 +289,39 @@ func (f *rollbackFS) dump() string {
 	}
 	sort.Strings(rows)
 	return strings.Join(rows, "\n")
+}
+
+func TestRollbackFSHonorsPreconditions(t *testing.T) {
+	f := newRollbackFS()
+	base, err := f.WriteFileAtomic("/tree/a.md", []byte("original"), WriteOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleHash := "stale"
+	_, err = f.WriteFileAtomic("/tree/a.md", []byte("lost"), WriteOpts{IfMatch: &staleHash})
+	var precondition *PreconditionError
+	if !errors.As(err, &precondition) {
+		t.Fatalf("stale IfMatch: want PreconditionError, got %v", err)
+	}
+	if got, _ := f.ReadFile("/tree/a.md"); string(got) != "original" {
+		t.Fatalf("stale IfMatch changed content to %q", got)
+	}
+	if _, err := f.WriteFileAtomic("/tree/a.md", []byte("updated"), WriteOpts{IfMatch: &base}); err != nil {
+		t.Fatalf("matching IfMatch: %v", err)
+	}
+
+	expected := f.treeSnapshot("/tree")
+	if _, err := f.WriteFileAtomic("/tree/concurrent.md", []byte("concurrent"), WriteOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	err = f.RemoveAll("/tree", RemoveOpts{Expected: expected})
+	var treeStale *TreeStaleError
+	if !errors.As(err, &treeStale) {
+		t.Fatalf("stale tree snapshot: want TreeStaleError, got %v", err)
+	}
+	if _, err := f.Stat("/tree/concurrent.md"); err != nil {
+		t.Fatalf("stale tree removal mutated state: %v", err)
+	}
 }
 
 func TestCommitChangeSetRollsBackFailedBatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- enforce `IfMatch` and `IfNoneMatch` in stateful writable filesystem doubles
- enforce whole-tree `RemoveOpts.Expected` snapshots without mutating stale trees
- retain write and removal preconditions when changes are deferred as pending
- return real SHA-256 content hashes from the write-log test substrate

## Regression coverage
- inject a concurrent overwrite between a shell redirect's read and commit
- inject source drift between `mv`'s copy and conditional removal
- verify write-log replay preserves both write and recursive-delete preconditions
- cover the batch rollback filesystem's precondition contract

## Testing
- `go test ./...`
- focused precondition tests with `-count=1` across `pkg/shell/cmds`, `pkg/openlore`, and `pkg/vfs`
