### PR TITLE
teach: short interactive router that fetches guides over SSH

### DIFF
--- a/assets/skills/teach.md
+++ b/assets/skills/teach.md
@@ -58,264 +58,42 @@ Then ask the initial question again (options A and B).
    cat /docs/README.md  # read a file
    help                 # full command list
    ```
-4. Offer to install OpenLore access as a skill in their agent harness and add
-   the `AGENTS.md` pointer — follow "Onboarding Agents (Agent Types)" below.
+4. Offer to onboard their agents. The server carries its own instructions —
+   fetch and follow them:
+   ```bash
+   ssh -p 2222 <address> openlore-skill  # portable Agent Skills file
+   ssh -p 2222 <address> agents          # AGENTS.md snippet
+   ```
 5. Finish with a short ✅ plain-language summary of what now works.
 
 ## If they choose A — set up a new Lore server
 
-Refer them to the `setup` skill. It creates and locally verifies a deployable
-OpenLore project, one question at a time:
+The `setup` skill creates and locally verifies a deployable OpenLore project,
+one question at a time. Fetch it and follow it now:
 
 ```bash
-ssh openlore.sh setup | <agent-cli>
+ssh openlore.sh setup
 ```
 
-If you are the agent helping them right now, fetch the instructions yourself
-with `ssh openlore.sh setup` (or `ssh -p <port> <this-server> setup`) and
-follow them. Then stop here — the `setup` skill takes over, and `onboarding`
-and `deploy` continue after it.
-
-Everything below this line is reference material for that local-only case.
-Never act on it, summarize it, or offer it as a plan until the person chooses
-option A and explicitly asks for a quick, keyless, local-only server without
-the guided setup. Then walk them through it one step at a time.
-
-### Quick Start
-
-1. Install OpenLore:
-   ```bash
-   go install github.com/aakarim/go-openlore/cmd/openlore@latest
-   ```
-
-2. Serve your docs directory:
-   ```bash
-   openlore ./docs
-   ```
-
-3. Connect and explore:
-   ```bash
-   ssh -p 2222 localhost
-   ```
-
-Run this way, OpenLore serves the directory you pass on the command line and
-runs keyless (any client can connect) — no config file needed.
-
-### Embedding Docs into a Binary
-
-The real power of OpenLore is baking your docs into a single binary that anyone
-can run.
-
-1. Clone or fork the repo:
-   ```bash
-   git clone https://github.com/aakarim/go-openlore
-   cd go-openlore
-   ```
-
-2. Replace the bundled docs with yours. `assets/lore/` ships with OpenLore's
-   own default docs (`getting-started.md`, `commands.md`, …). Remove those and
-   drop your own markdown in:
-   ```bash
-   rm -rf assets/lore/*
-   cp -r /path/to/your/docs/* assets/lore/
-   ```
-   Whatever lives under `assets/lore/` is what the built binary serves at `/`.
-
-3. Replace the bundled config. **Important:** `assets/config/openlore.yml`
-   ships configured for the public `openlore.sh` deployment — it sets
-   `auth_file: ./lore.json`, mounts published folders, and enables `openlore.sh`
-   passkeys. If you build with it unchanged, the binary fails on startup with
-   `loading auth config: open ./lore.json: no such file or directory`.
-
-   Overwrite it with a minimal config for your own build:
-   ```bash
-   cat > assets/config/openlore.yml <<'YAML'
-   version: "1"
-   port: 2222
-   http_port: 8080
-   default_cwd: /
-
-   files:
-     allowed: ["*.md", "*.txt", "*.yml", "*.json"]
-     ignore: [".git", "node_modules", ".env"]
-   YAML
-   ```
-   With no `auth_file` set, the server runs keyless and serves your embedded
-   docs out of the box. Add `auth_file: ./lore.json` only once you actually ship
-   a `lore.json` (see "Setting Up Access Control").
-
-4. Build the binary:
-   ```bash
-   go build -o my-lore ./cmd/openlore
-   ```
-
-5. Run it — it contains everything:
-   ```bash
-   ./my-lore
-   ssh -p 2222 localhost
-   ```
-   Distribute the binary and anyone who runs it gets an SSH server with your
-   docs. No directory argument is needed: with no path on the command line, the
-   binary serves its embedded `assets/lore/` docs.
-
-### Setting Up Access Control
-
-If you want different agents to have different access, create a `lore.json`
-next to `openlore.yml`. This quick start gives keyless visitors read-only access
-to public docs, reviewers read-only access to backend docs, and engineers
-read/write access to backend docs:
-
-```json
-{
-  "allow_keyless": true,
-  "unknown_identity": "deny",
-  "roles": {
-    "reviewer": {},
-    "engineer": {}
-  },
-  "docsets": {
-    "public": {
-      "paths": ["/docs/public"],
-      "access": {
-        "allow": { "guest": "ro", "reviewer": "ro", "engineer": "rw" }
-      }
-    },
-    "backend": {
-      "paths": ["/docs/backend"],
-      "access": {
-        "allow": { "reviewer": "ro", "engineer": "rw" }
-      }
-    },
-    "engineer-home": {
-      "paths": [{ "homes/engineer": "/home/engineer" }]
-    }
-  },
-  "identities": [
-    {
-      "name": "engineering-agent",
-      "public_key": "ssh-ed25519 AAAA...",
-      "roles": ["engineer", "reviewer"],
-      "home": "engineer-home"
-    }
-  ]
-}
-```
-
-- `roles` declares the role names identities may use. Role names are exact and
-  roles do not inherit from one another.
-- Each docset's `access.allow` maps roles to `ro`, `rw`, or a plugin grant such
-  as `publish`. Grants from multiple roles are combined; a role listed in
-  `access.deny` denies the entire docset and overrides all allows.
-- `guest` is built in. It represents keyless and allowed unknown callers and
-  can only be granted read-only access.
-- An identity may have multiple roles. Its unique `home` docset is implicitly
-  read/write for that identity, so it needs no access entry.
-- A docset without a matching allow is inaccessible. Nested docsets are
-  separate access boundaries, including inside a home.
-
-Enable the file in `openlore.yml`, then start OpenLore normally:
-
-```yaml
-auth_file: ./lore.json
-readonly: false # keep true if no role should be able to write
-```
-
-Set `allow_keyless` to `false` if every SSH connection must present a known
-key. Set `unknown_identity` to `allow` only if unknown keys should receive the
-built-in `guest` role.
-
-### Using the GitHub Action
-
-For automated builds, use the OpenLore GitHub Action:
-
-```yaml
-- uses: aakarim/openlore@v1
-  with:
-    docs-dir: ./docs
-    config: ./openlore.yml
-```
-
-This produces binaries for Linux, macOS, and Windows.
-
-### Setting Up Passkeys (Browser Access for Humans)
-
-Passkeys let humans browse your docs in a web browser using WebAuthn (Face ID,
-Touch ID, security keys).
-
-1. Add to your `openlore.yml`:
-   ```yaml
-   passkeys:
-     enabled: true
-     rp_id: localhost                       # or your domain
-     rp_origins: ["http://localhost:8080"]  # must match the HTTP server origin
-   ```
-
-2. Start the server, connect via SSH, and register:
-   ```bash
-   ssh -p 2222 localhost "passkey register --name 'My Laptop'"
-   ```
-
-3. Open the printed URL in a browser to complete registration.
-
-4. Browse docs at `http://localhost:8080/lore/`.
-
-Run `passkey help` in the SSH shell for all options.
-
-### Exporting Embedded Docs
-
-To extract docs from an existing OpenLore binary:
+Then stop here — the `setup` skill takes over. After it, `onboarding` adds
+identities and `deploy` puts the server on real infrastructure:
 
 ```bash
-openlore export -o ./extracted-docs
+ssh openlore.sh onboarding
+ssh openlore.sh deploy
 ```
 
-## Onboarding Agents (Agent Types)
+## Going further
 
-Once a server runs, install OpenLore access as a **skill** in the agent
-harness, then use `AGENTS.md` to tell future sessions when to reach for it.
-If you are an agent reading this: do these steps now.
+Every guide ships on the server itself. Fetch what the moment needs instead of
+keeping it all in context:
 
-1. **Install the skill.** Fetch the portable Agent Skills file and save it in
-   your harness's skills directory. The directory must be named `openlore` to
-   match the skill's frontmatter name:
-
-   | Harness | Skills location |
-   |---|---|
-   | Amp (project) | `.agents/skills/openlore/SKILL.md` |
-   | Amp (personal) | `~/.config/agents/skills/openlore/SKILL.md` |
-   | Claude Code | `.claude/skills/openlore/SKILL.md` |
-   | headlong / shellm | `.skills/openlore/SKILL.md` (use `agents-shellm` instead, below) |
-
-   ```bash
-   mkdir -p .agents/skills/openlore
-   ssh -p <port> <host> openlore-skill > .agents/skills/openlore/SKILL.md
-   ```
-
-2. **Fill in the server block.** The installed file has a `## Server` section
-   with placeholders. Record the real host, port, key requirements, and the
-   server's top-level layout (run `ssh -p <port> <host> "tree -L 2 /"` once).
-   A skill without its server address is useless.
-
-3. **Add the AGENTS.md pointer.** Append the snippet so sessions that do not
-   scan skills still learn the knowledge base exists and when to use it:
-
-   ```bash
-   ssh -p <port> <host> agents >> AGENTS.md
-   ```
-
-Agent-type-specific variants are named `agents-<type>`:
-
-| Agent type | Command | Output |
-|---|---|---|
-| Any harness with Agent Skills support | `ssh <server> openlore-skill` | Portable `SKILL.md` (steps above) |
-| headlong / shellm | `ssh <server> agents-shellm` | `SKILL.md` with headlong specifics (Docker sandbox caveats, `$OPENLORE_SSH`, trajectory sync) |
-| headlong / shellm (maintenance) | `ssh <server> agents-shellm-housekeeping` | A `SKILL.md` that audits the knowledge base and publishes reports |
-
-Run `skills` on the server to list every instruction command it ships,
-including agent types added by your deployment through `skills_dir`.
+```bash
+ssh <address> skills      # list every guide the server carries
+ssh <address> <name>      # fetch one, e.g. passkeys, upgrade, deploy-fly
+```
 
 ## Wrap up
 
-After any path completes, give a short ✅ plain-language summary and offer the
-next step: `onboarding` to add identities, or `deploy` to put the server on
-real infrastructure.
+After any path completes, give a short ✅ plain-language summary and name the
+next guide to fetch.

--- a/assets/skills/teach.md
+++ b/assets/skills/teach.md
@@ -1,10 +1,13 @@
 # Teach: Get Started with OpenLore
 
-You are welcoming someone to OpenLore and guiding them to the right path. Be
-warm and clear. Use restrained emojis. Ask one question at a time and wait for
-the answer.
+You are running an interactive onboarding conversation. This document is your
+script, not reference material: do not summarize it, do not describe what it
+contains, do not inspect the current directory, and do not propose your own
+plan or menu. Be warm and clear. Use restrained emojis. Ask one question at a
+time and wait for the answer.
 
-Open with:
+Your first reply must be only the welcome and the initial question below, then
+stop and wait for the person's answer. Open with:
 
 > 👋📜 **Welcome to OpenLore!**
 >
@@ -73,8 +76,10 @@ with `ssh openlore.sh setup` (or `ssh -p <port> <this-server> setup`) and
 follow them. Then stop here — the `setup` skill takes over, and `onboarding`
 and `deploy` continue after it.
 
-Only if they explicitly want a quick, keyless, local-only server without the
-guided setup, walk them through the reference below, one step at a time.
+Everything below this line is reference material for that local-only case.
+Never act on it, summarize it, or offer it as a plan until the person chooses
+option A and explicitly asks for a quick, keyless, local-only server without
+the guided setup. Then walk them through it one step at a time.
 
 ### Quick Start
 


### PR DESCRIPTION
## Problem

Piping `teach` into an agent (e.g. Claude Code) didn't start the walkthrough — the agent treated the skill as reference documentation, inspected the working directory, and proposed its own menu instead of opening with the welcome and the A/B/C question. The ~250 lines of inline reference material (keyless quick start, embedding, access control, passkeys) drowned out the script and over-emphasised the read-only keyless mode, which is being de-emphasised.

## Fix

- **Force script-following**: the preamble is an explicit directive — no summarizing, no directory inspection, no self-invented plans; the first reply must be only the welcome and the A/B/C question, then stop and wait.
- **Trim to a router (~320 → 99 lines)**: all inline reference material is gone. Each path now fetches the right guide from the server itself:
  - **A (new server)** → `ssh openlore.sh setup`, then `onboarding` and `deploy`
  - **B (existing server)** → verify, explore, then `openlore-skill` and `agents` for agent onboarding
  - **C (what is it?)** → Simple Technical English explanation, then re-ask
  - **Going further** → `ssh <address> skills` lists every guide; fetch by name (passkeys, upgrade, deploy-fly, …)

## Verification

- Simulated a fresh agent receiving the skill as its only prompt: it replied with exactly the welcome and A/B/C question, nothing else.
- `go test ./internal/skills/... ./pkg/shell/cmds/...` pass.