### PR TITLE
docs(deploy): offer a passkey for the web UI at the end of onboarding

### DIFF
--- a/assets/skills/deploy.md
+++ b/assets/skills/deploy.md
@@ -146,3 +146,42 @@ Only after every required check passes, ask whether to delete `.local`
 entirely. Explain that the server is now authoritative and deletion removes the
 bootstrap/recovery copy. Default to keeping it. Never delete it without an
 explicit affirmative answer.
+
+## Offer a passkey for the web UI
+
+When this deployment is part of the guided onboarding journey (teach → setup →
+onboarding → deploy), finish by offering browser access. Keep it warm and
+clearly optional — declining is fine and they can register one later with the
+`passkeys` guide.
+
+Explain the purpose in a couple of short sentences before asking:
+
+- Everything so far went through SSH, which suits agents. A **passkey** (Face
+  ID, Touch ID, or a security key) signs a person in to the server's web UI
+  from a browser — no password.
+- Signed in, they can read every document their identity can reach at
+  `https://<domain>/lore/`, share a direct link to any document
+  (`https://<domain>/lore/<path>` starts the login flow and returns to the
+  file), and review what their delegated agents may access at
+  `https://<domain>/settings/permissions`.
+
+If they want one, guide them through it one step at a time:
+
+1. Register over SSH against the deployed server, using their identity name
+   from `lore.json` (for example `onboarding`) and a friendly device label:
+
+   ```bash
+   ssh <domain> passkey register --identity onboarding --name "<their device>"
+   ```
+
+2. The command prints a one-time URL that expires in five minutes. Ask them to
+   open it in their browser and approve the prompt (Face ID, Touch ID, or
+   security key). If it expires, rerun the command — nothing is lost.
+3. Confirm together that `https://<domain>/lore/` shows their documents, then
+   mention `passkey list` and `passkey revoke "<label>"` for later management.
+
+Registration needs the `passkeys:` block with the public HTTPS RP ID and origin
+(already part of the required outcome above); if it fails, check that
+configuration first. Close the onboarding journey with a short ✅ plain-language
+summary of everything that now works: the deployed server, who can connect, and
+where to browse.

--- a/assets/skills/passkeys.md
+++ b/assets/skills/passkeys.md
@@ -1,34 +1,48 @@
 # Passkeys — Browser Access for Humans
 
-Register a passkey so humans can browse docs in a web browser via WebAuthn (Face ID, Touch ID, security keys).
+Register a passkey so humans can browse docs in a web browser via WebAuthn
+(Face ID, Touch ID, security keys).
 
 ## Register a passkey
 
 ```bash
-# Full access to all docsets
-ssh openlore.sh passkey register --name "Adil MacBook" --lore agent-full
-
-# Public docs only
-ssh openlore.sh passkey register --name "Guest" --lore default
+ssh <server> passkey register --identity <identity> --name "Adil MacBook"
 ```
 
-The command outputs a one-time URL (expires in 5 minutes). Give it to the human to open in their browser to complete registration.
+`--identity` (required) names an identity from the server's auth config; the
+passkey signs the person in as that identity and inherits exactly its docset
+access. `--name` labels the device (default: "default").
+
+The command outputs a one-time URL (expires in 5 minutes). Give it to the human
+to open in their browser to complete registration. If it expires, rerun the
+command.
 
 ## Manage passkeys
 
 ```bash
 # List all registered passkeys
-ssh openlore.sh passkey list
+ssh <server> passkey list
 
-# Revoke a passkey
-ssh openlore.sh passkey revoke "Guest"
+# Revoke a passkey by device label
+ssh <server> passkey revoke "Adil MacBook"
 ```
 
 ## After registration
 
-The human can browse docs at `https://openlore.sh/lore/`. They can also go directly to a file, e.g. `https://openlore.sh/lore/knowledge/product/data-fabric.md` — if not logged in, the passkey login flow starts automatically and redirects back to the file.
+The human can browse docs at `https://<domain>/lore/`. They can also go
+directly to a file, e.g. `https://<domain>/lore/docs/README.md` — if not logged
+in, the passkey login flow starts automatically and redirects back to the file.
+`https://<domain>/settings/permissions` shows what their delegated identities
+may access.
 
-## Available lore specs
+## Server requirements
 
-- `default` — OpenLore documentation only
-- `agent-full` — all docsets (docs, knowledge, research, pipeline, runbooks, memory)
+Passkeys must be enabled in `openlore.yml` with the server's public HTTPS
+origin:
+
+```yaml
+passkeys:
+  enabled: true
+  rp_id: docs.example.com
+  rp_origins: ["https://docs.example.com"]
+```


### PR DESCRIPTION
Two changes:

**deploy.md** gains a closing stage for deployments that are part of the guided onboarding journey (teach → setup → onboarding → deploy). The agent explains what a passkey is and what the web UI unlocks — reading every reachable document at `https://<domain>/lore/`, sharing direct document links that log the person in and return to the file, reviewing delegated agents at `/settings/permissions` — then asks (clearly optional, friendly), and guides registration step by step: `ssh <domain> passkey register --identity <name> --name "<device>"`, open the one-time URL within five minutes, confirm `/lore/` works, and note `passkey list`/`revoke`. Ends the whole journey with a plain-language ✅ summary.

**passkeys.md** was stale: it documented a `--lore` flag and openlore.sh-specific lore specs (`default`/`agent-full`) that don't exist in the code — `passkey register` requires `--identity` and scopes access by that identity's docset grants ([internal/passkeys/command.go](https://github.com/aakarim/OpenLore/blob/main/internal/passkeys/command.go)). Rewritten generically with the real flags, the delegate-review URL, and the required `passkeys:` server config block.