### PR TITLE
Add interactive shell tab completion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,19 @@ jobs:
 
       - name: Test
         run: go test -race ./...
+
+  libghostty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Test terminal rendering with libghostty
+        run: make test-libghostty

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test-libghostty
+
+test-libghostty:
+	./scripts/test-libghostty.sh

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3,6 +3,12 @@
 OpenLore implements a bash-like command language over its virtual filesystem.
 Run `help` in a session for the command list available on that server.
 
+Interactive SSH sessions support Tab completion for permitted command names,
+registered `lore` subcommands, and virtual filesystem paths. The first Tab
+extends a shared prefix; a second Tab lists matching candidates in columns.
+Directories retain a trailing `/`, hidden entries appear only after an explicit
+`.`, and candidate layout follows terminal resize events.
+
 ## Filesystem
 
 | Command | Description |

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/go-webauthn/webauthn v0.16.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/pkg/sftp v1.13.10
 	github.com/yuin/goldmark v1.8.4
@@ -53,7 +54,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/internal/libghosttytest/harness.c
+++ b/internal/libghosttytest/harness.c
@@ -1,0 +1,83 @@
+#include <ghostty/vt.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void fail(const char *message) {
+    fprintf(stderr, "libghostty test: %s\n", message);
+    exit(1);
+}
+
+static uint8_t *read_file(const char *path, size_t *length) {
+    FILE *file = fopen(path, "rb");
+    if (file == NULL) fail("could not open transcript");
+    if (fseek(file, 0, SEEK_END) != 0) fail("could not seek transcript");
+    long size = ftell(file);
+    if (size < 0 || fseek(file, 0, SEEK_SET) != 0) fail("could not size transcript");
+    uint8_t *data = malloc((size_t)size);
+    if (data == NULL) fail("could not allocate transcript");
+    if (fread(data, 1, (size_t)size, file) != (size_t)size) fail("could not read transcript");
+    fclose(file);
+    *length = (size_t)size;
+    return data;
+}
+
+static bool contains(const uint8_t *data, size_t length, const char *needle) {
+    size_t needle_length = strlen(needle);
+    if (needle_length > length) return false;
+    for (size_t i = 0; i + needle_length <= length; i++) {
+        if (memcmp(data + i, needle, needle_length) == 0) return true;
+    }
+    return false;
+}
+
+static void verify(const char *path, uint16_t columns, bool resize) {
+    size_t input_length = 0;
+    uint8_t *input = read_file(path, &input_length);
+
+    GhosttyTerminal terminal = NULL;
+    if (ghostty_terminal_new(NULL, &terminal, 80, 24) != GHOSTTY_SUCCESS) {
+        fail("could not create terminal");
+    }
+    if (resize && ghostty_terminal_resize(terminal, columns, 24, 0, 0) != GHOSTTY_SUCCESS) {
+        fail("could not resize terminal");
+    }
+    ghostty_terminal_vt_write(terminal, input, input_length);
+    free(input);
+
+    GhosttyFormatterTerminalOptions options = GHOSTTY_INIT_SIZED(GhosttyFormatterTerminalOptions);
+    options.emit = GHOSTTY_FORMATTER_FORMAT_PLAIN;
+    options.trim = true;
+    GhosttyFormatter formatter = NULL;
+    if (ghostty_formatter_terminal_new(NULL, &formatter, terminal, options) != GHOSTTY_SUCCESS) {
+        fail("could not create formatter");
+    }
+    uint8_t *screen = NULL;
+    size_t screen_length = 0;
+    if (ghostty_formatter_format_alloc(formatter, NULL, &screen, &screen_length) != GHOSTTY_SUCCESS) {
+        fail("could not format terminal");
+    }
+
+    const char *prompt = resize ? "lore:/ $ cat /docs/n" : "lore:/ $ cat /docs/note";
+    if (!contains(screen, screen_length, "notes.md") ||
+        !contains(screen, screen_length, "notebook.md") ||
+        !contains(screen, screen_length, prompt)) {
+        fwrite(screen, 1, screen_length, stderr);
+        fail("completion listing or redrawn prompt missing from terminal screen");
+    }
+
+    ghostty_free(NULL, screen, screen_length);
+    ghostty_formatter_free(formatter);
+    ghostty_terminal_free(terminal);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 3) fail("usage: harness <80-column transcript> <20-column transcript>");
+    verify(argv[1], 80, false);
+    verify(argv[2], 20, true);
+    puts("libghostty terminal rendering: PASS");
+    return 0;
+}

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -663,7 +663,38 @@ func (s *Server) shellHandler(next ssh.Handler) ssh.Handler {
 			return
 		}
 
-		sh.RunInteractive(sess, sess, s.motd, "lore")
+		interactiveOpts := shell.InteractiveOptions{Width: 80}
+		if pty, windowChanges, ok := sess.Pty(); ok {
+			interactiveOpts.Width = pty.Window.Width
+			widthChanges := make(chan int, 1)
+			interactiveOpts.WidthChanges = widthChanges
+			go func() {
+				defer close(widthChanges)
+				for {
+					select {
+					case window, ok := <-windowChanges:
+						if !ok {
+							return
+						}
+						select {
+						case widthChanges <- window.Width:
+						default:
+							select {
+							case <-widthChanges:
+							default:
+							}
+							select {
+							case widthChanges <- window.Width:
+							default:
+							}
+						}
+					case <-sess.Context().Done():
+						return
+					}
+				}
+			}()
+		}
+		sh.RunInteractiveWithOptions(sess, sess, s.motd, "lore", interactiveOpts)
 		sess.Exit(0)
 	}
 }

--- a/pkg/shell/cmds/lore.go
+++ b/pkg/shell/cmds/lore.go
@@ -34,6 +34,16 @@ func RegisterLoreSub(sub LoreSub) {
 	loreSubs[sub.Name] = sub
 }
 
+// LoreSubNames returns the registered lore subcommand names in lexical order.
+func LoreSubNames() []string {
+	names := make([]string, 0, len(loreSubs))
+	for name := range loreSubs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // CmdLore is the `lore` introspection dispatcher. Bare `lore` prints usage and
 // exits 0; an unknown subcommand errors to stderr and exits 1. Subcommands are
 // resolved from the loreSubs registry.

--- a/pkg/shell/cmds/registry.go
+++ b/pkg/shell/cmds/registry.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"io"
+	"sort"
 )
 
 // CmdFunc is the signature for all shell commands.
@@ -111,4 +112,15 @@ func Register(name string, fn CmdFunc) {
 func IsKnown(name string) bool {
 	_, ok := Registry[name]
 	return ok
+}
+
+// Names returns the registered command names in lexical order. Interactive
+// discovery features use this instead of maintaining a second command list.
+func Names() []string {
+	names := make([]string, 0, len(Registry))
+	for name := range Registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/pkg/shell/completion.go
+++ b/pkg/shell/completion.go
@@ -1,0 +1,367 @@
+package shell
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/aakarim/go-openlore/pkg/shell/cmds"
+	"github.com/mattn/go-runewidth"
+)
+
+type completionCandidate struct {
+	value   string
+	display string
+}
+
+type completionResult struct {
+	line       string
+	candidates []completionCandidate
+	finished   bool
+}
+
+type completionToken struct {
+	kind       byte // w=word, c=command separator, r=redirect
+	start, end int
+	value      string
+	quote      byte
+}
+
+// complete returns the edited line and all matching candidates. Completion is
+// intentionally limited to the end of the line: the interactive shell does not
+// otherwise expose cursor movement.
+func (s *Shell) complete(line string) completionResult {
+	tokens := scanCompletionTokens(line)
+	current := completionToken{kind: 'w', start: len(line), end: len(line)}
+	previous := tokens
+	if len(tokens) > 0 && tokens[len(tokens)-1].kind == 'w' && tokens[len(tokens)-1].end == len(line) {
+		current = tokens[len(tokens)-1]
+		previous = tokens[:len(tokens)-1]
+	}
+
+	segmentStart := 0
+	for i, token := range previous {
+		if token.kind == 'c' {
+			segmentStart = i + 1
+		}
+	}
+	segment := previous[segmentStart:]
+	command, args, redirectTarget := completionPosition(segment)
+
+	var candidates []completionCandidate
+	switch {
+	case redirectTarget:
+		candidates = s.pathCandidates(current.value, current.quote)
+	case command == "":
+		candidates = s.commandCandidates(current.value)
+	case command == "lore" && len(args) == 0:
+		candidates = loreSubCandidates(current.value)
+	default:
+		candidates = s.pathCandidates(current.value, current.quote)
+	}
+	if len(candidates) == 0 {
+		return completionResult{line: line}
+	}
+
+	prefix := candidates[0].value
+	for _, candidate := range candidates[1:] {
+		prefix = commonPrefix(prefix, candidate.value)
+	}
+	prefix = printablePrefix(prefix)
+	unique := len(candidates) == 1 && prefix == candidates[0].value
+	replacement := quoteCompletion(prefix, current.quote)
+	if unique && !strings.HasSuffix(prefix, "/") {
+		replacement += " "
+	}
+	return completionResult{
+		line:       line[:current.start] + replacement,
+		candidates: candidates,
+		finished:   unique,
+	}
+}
+
+func (s *Shell) commandCandidates(prefix string) []completionCandidate {
+	names := append(cmds.Names(), "pwd", "exit", "quit")
+	seen := make(map[string]bool, len(names))
+	var candidates []completionCandidate
+	for _, name := range names {
+		if seen[name] || !strings.HasPrefix(name, prefix) || !s.ActionAllowed(cmds.ActionFor(name)) {
+			continue
+		}
+		seen[name] = true
+		candidates = append(candidates, completionCandidate{value: name, display: name})
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].value < candidates[j].value })
+	return candidates
+}
+
+func loreSubCandidates(prefix string) []completionCandidate {
+	var candidates []completionCandidate
+	for _, name := range cmds.LoreSubNames() {
+		if strings.HasPrefix(name, prefix) {
+			candidates = append(candidates, completionCandidate{value: name, display: name})
+		}
+	}
+	return candidates
+}
+
+func (s *Shell) pathCandidates(prefix string, quote byte) []completionCandidate {
+	typedDir, base := splitPathPrefix(prefix)
+	lookupDir := typedDir
+	if quote == 0 && (lookupDir == "~" || strings.HasPrefix(lookupDir, "~/")) {
+		lookupDir = s.expandTilde(lookupDir)
+	}
+	if lookupDir == "" {
+		lookupDir = s.cwd
+	} else {
+		lookupDir = s.Resolve(lookupDir)
+	}
+	entries, err := s.fs.ReadDir(lookupDir)
+	if err != nil {
+		return nil
+	}
+	var candidates []completionCandidate
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.FileName, ".") && !strings.HasPrefix(base, ".") {
+			continue
+		}
+		if !strings.HasPrefix(entry.FileName, base) {
+			continue
+		}
+		value := pathPrefixJoin(typedDir, entry.FileName)
+		display := escapeDisplay(entry.FileName)
+		if entry.Dir {
+			value += "/"
+			display += "/"
+		}
+		candidates = append(candidates, completionCandidate{value: value, display: display})
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].value < candidates[j].value })
+	return candidates
+}
+
+func splitPathPrefix(prefix string) (dir, base string) {
+	i := strings.LastIndexByte(prefix, '/')
+	if i < 0 {
+		return "", prefix
+	}
+	if i == 0 {
+		return "/", prefix[1:]
+	}
+	return prefix[:i], prefix[i+1:]
+}
+
+func pathPrefixJoin(dir, name string) string {
+	switch dir {
+	case "":
+		return name
+	case "/":
+		return "/" + name
+	default:
+		return dir + "/" + name
+	}
+}
+
+func completionPosition(tokens []completionToken) (command string, args []string, redirectTarget bool) {
+	expectRedirect := false
+	for _, token := range tokens {
+		switch token.kind {
+		case 'r':
+			expectRedirect = true
+		case 'w':
+			if expectRedirect {
+				expectRedirect = false
+				continue
+			}
+			if command == "" && isAssignment(token.value) {
+				continue
+			}
+			if command == "" {
+				command = token.value
+			} else {
+				args = append(args, token.value)
+			}
+		}
+	}
+	return command, args, expectRedirect
+}
+
+func isAssignment(word string) bool {
+	i := strings.IndexByte(word, '=')
+	if i <= 0 {
+		return false
+	}
+	for j, r := range word[:i] {
+		if !(r == '_' || unicode.IsLetter(r) || (j > 0 && unicode.IsDigit(r))) {
+			return false
+		}
+	}
+	return true
+}
+
+func scanCompletionTokens(line string) []completionToken {
+	var tokens []completionToken
+	for i := 0; i < len(line); {
+		if line[i] == ' ' || line[i] == '\t' {
+			i++
+			continue
+		}
+		start := i
+		if line[i] == ';' || line[i] == '|' || line[i] == '&' {
+			i++
+			if i < len(line) && line[i] == line[start] {
+				i++
+			} else if line[start] == '|' && i < len(line) && line[i] == '&' {
+				i++
+			}
+			tokens = append(tokens, completionToken{kind: 'c', start: start, end: i})
+			continue
+		}
+		if line[i] == '>' || (line[i] == '2' && i+1 < len(line) && line[i+1] == '>') {
+			if line[i] == '2' {
+				i++
+			}
+			i++
+			if i < len(line) && line[i] == '>' {
+				i++
+			}
+			tokens = append(tokens, completionToken{kind: 'r', start: start, end: i})
+			continue
+		}
+		token := completionToken{kind: 'w', start: start}
+		var value strings.Builder
+		var quote byte
+		for i < len(line) {
+			ch := line[i]
+			if quote == 0 && (ch == ' ' || ch == '\t' || ch == ';' || ch == '|' || ch == '&' || ch == '>') {
+				break
+			}
+			if ch == '\\' && quote != '\'' && i+1 < len(line) {
+				value.WriteByte(line[i+1])
+				i += 2
+				continue
+			}
+			if ch == '\'' || ch == '"' {
+				if quote == 0 {
+					quote = ch
+					if i == start {
+						token.quote = ch
+					}
+					i++
+					continue
+				}
+				if quote == ch {
+					quote = 0
+					i++
+					continue
+				}
+			}
+			value.WriteByte(ch)
+			i++
+		}
+		token.end = i
+		token.value = value.String()
+		tokens = append(tokens, token)
+	}
+	return tokens
+}
+
+func commonPrefix(a, b string) string {
+	i := 0
+	for i < len(a) && i < len(b) && a[i] == b[i] {
+		i++
+	}
+	for i > 0 && i < len(a) && !utf8.RuneStart(a[i]) {
+		i--
+	}
+	return a[:i]
+}
+
+func quoteCompletion(value string, preferred byte) string {
+	switch preferred {
+	case '\'':
+		return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+	case '"':
+		replacer := strings.NewReplacer("\\", "\\\\", "\"", "\\\"", "$", "\\$", "`", "\\`")
+		return "\"" + replacer.Replace(value) + "\""
+	}
+	var result strings.Builder
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune("/_-.~", r) {
+			result.WriteRune(r)
+			continue
+		}
+		result.WriteByte('\\')
+		result.WriteRune(r)
+	}
+	return result.String()
+}
+
+func escapeDisplay(value string) string {
+	var result strings.Builder
+	for _, r := range value {
+		switch r {
+		case '\n':
+			result.WriteString(`\n`)
+		case '\r':
+			result.WriteString(`\r`)
+		case '\t':
+			result.WriteString(`\t`)
+		default:
+			if unicode.IsControl(r) {
+				fmt.Fprintf(&result, `\x%02x`, r)
+			} else {
+				result.WriteRune(r)
+			}
+		}
+	}
+	return result.String()
+}
+
+// printablePrefix prevents a filename discovered from the server-side VFS
+// from injecting control bytes into the user's terminal. Such entries remain
+// visible in the escaped candidate listing but are not inserted automatically.
+func printablePrefix(value string) string {
+	for i, r := range value {
+		if unicode.IsControl(r) {
+			return value[:i]
+		}
+	}
+	return value
+}
+
+func formatCandidateColumns(candidates []completionCandidate, width int) string {
+	if width <= 0 {
+		width = 80
+	}
+	maxWidth := 0
+	for _, candidate := range candidates {
+		if w := runewidth.StringWidth(candidate.display); w > maxWidth {
+			maxWidth = w
+		}
+	}
+	columnWidth := maxWidth + 2
+	columns := width / columnWidth
+	if columns < 1 {
+		columns = 1
+	}
+	rows := (len(candidates) + columns - 1) / columns
+	var result strings.Builder
+	for row := 0; row < rows; row++ {
+		for col := 0; col < columns; col++ {
+			i := col*rows + row
+			if i >= len(candidates) {
+				continue
+			}
+			text := candidates[i].display
+			result.WriteString(text)
+			if col+1 < columns && i+rows < len(candidates) {
+				result.WriteString(strings.Repeat(" ", columnWidth-runewidth.StringWidth(text)))
+			}
+		}
+		result.WriteString("\r\n")
+	}
+	return result.String()
+}

--- a/pkg/shell/completion_test.go
+++ b/pkg/shell/completion_test.go
@@ -1,0 +1,239 @@
+package shell
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type completionFS struct {
+	dirs map[string][]vfs.FileInfo
+}
+
+func (f completionFS) Stat(name string) (*vfs.FileInfo, error) {
+	name = path.Clean(name)
+	if _, ok := f.dirs[name]; ok {
+		return &vfs.FileInfo{FileName: path.Base(name), FilePath: name, Dir: true}, nil
+	}
+	for dir, entries := range f.dirs {
+		for _, entry := range entries {
+			if path.Join(dir, entry.FileName) == name {
+				copy := entry
+				return &copy, nil
+			}
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (f completionFS) ReadDir(name string) ([]vfs.FileInfo, error) {
+	entries, ok := f.dirs[path.Clean(name)]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return append([]vfs.FileInfo(nil), entries...), nil
+}
+
+func (f completionFS) ReadFile(string) ([]byte, error) { return nil, errors.New("not found") }
+
+func testCompletionFS() completionFS {
+	return completionFS{dirs: map[string][]vfs.FileInfo{
+		"/": {
+			{FileName: "docs", FilePath: "/docs", Dir: true},
+			{FileName: "jobs", FilePath: "/jobs", Dir: true},
+		},
+		"/docs": {
+			{FileName: ".private", FilePath: "/docs/.private"},
+			{FileName: "my file.md", FilePath: "/docs/my file.md"},
+			{FileName: "notes.md", FilePath: "/docs/notes.md"},
+			{FileName: "notebook.md", FilePath: "/docs/notebook.md"},
+			{FileName: "subdir", FilePath: "/docs/subdir", Dir: true},
+		},
+		"/docs/subdir": {},
+		"/jobs":        {},
+	}}
+}
+
+func TestCompleteCommandsAndShellOperators(t *testing.T) {
+	sh := NewShell(testCompletionFS())
+	for _, test := range []struct {
+		line string
+		want string
+	}{
+		{"pw", "pwd "},
+		{"echo ok | pw", "echo ok | pwd "},
+		{"true && pw", "true && pwd "},
+		{"echo ok; pw", "echo ok; pwd "},
+		{"NAME=value pw", "NAME=value pwd "},
+		{"lore docs", "lore docsets "},
+	} {
+		t.Run(test.line, func(t *testing.T) {
+			if got := sh.complete(test.line).line; got != test.want {
+				t.Fatalf("complete(%q) = %q, want %q", test.line, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCompleteCommandsFiltersCapabilities(t *testing.T) {
+	sh := NewShell(testCompletionFS())
+	sh.SetAllowedActions(nil)
+	result := sh.complete("r")
+	for _, candidate := range result.candidates {
+		if candidate.value == "rm" {
+			t.Fatal("read-only completion exposed rm")
+		}
+	}
+}
+
+func TestCompletePaths(t *testing.T) {
+	sh := NewShell(testCompletionFS())
+	sh.SetEnv("HOME", "/docs")
+	for _, test := range []struct {
+		line string
+		want string
+	}{
+		{"cat /docs/my", `cat /docs/my\ file.md `},
+		{`cat "/docs/my`, `cat "/docs/my file.md" `},
+		{"cat /docs/sub", "cat /docs/subdir/"},
+		{"cat ~/my", `cat ~/my\ file.md `},
+		{"echo ok > /docs/my", `echo ok > /docs/my\ file.md `},
+		{"echo ok 2> /docs/my", `echo ok 2> /docs/my\ file.md `},
+	} {
+		t.Run(test.line, func(t *testing.T) {
+			if got := sh.complete(test.line).line; got != test.want {
+				t.Fatalf("complete(%q) = %q, want %q", test.line, got, test.want)
+			}
+		})
+	}
+
+	result := sh.complete("cat /docs/no")
+	if result.line != "cat /docs/note" || len(result.candidates) != 2 {
+		t.Fatalf("common prefix completion = %q (%d candidates)", result.line, len(result.candidates))
+	}
+	for _, candidate := range sh.complete("cat /docs/").candidates {
+		if candidate.value == "/docs/.private" {
+			t.Fatal("completion exposed an implicit hidden entry")
+		}
+	}
+	if got := sh.complete("cat /docs/.").line; got != "cat /docs/.private " {
+		t.Fatalf("explicit hidden completion = %q", got)
+	}
+}
+
+func TestCompletionDisplayEscapesControlsAndUsesUnicodeWidth(t *testing.T) {
+	if got := escapeDisplay("bad\x1b\nname"); got != `bad\x1b\nname` {
+		t.Fatalf("escapeDisplay = %q", got)
+	}
+	candidates := []completionCandidate{
+		{display: "界"}, {display: "a"}, {display: "bb"}, {display: "ccc"},
+	}
+	wide := formatCandidateColumns(candidates, 20)
+	narrow := formatCandidateColumns(candidates, 4)
+	if strings.Count(wide, "\r\n") >= strings.Count(narrow, "\r\n") {
+		t.Fatalf("candidate layout did not adapt to width: wide=%q narrow=%q", wide, narrow)
+	}
+}
+
+func TestCompletionDoesNotInsertControlCharacters(t *testing.T) {
+	fs := completionFS{dirs: map[string][]vfs.FileInfo{
+		"/": {{FileName: "bad\x1bname"}},
+	}}
+	result := NewShell(fs).complete("cat b")
+	if strings.ContainsRune(result.line, '\x1b') || result.finished {
+		t.Fatalf("unsafe completion = %#v", result)
+	}
+	if len(result.candidates) != 1 || result.candidates[0].display != `bad\x1bname` {
+		t.Fatalf("unsafe candidate was not escaped: %#v", result.candidates)
+	}
+}
+
+type scriptedReadWriter struct {
+	reader io.Reader
+	output bytes.Buffer
+}
+
+func (rw *scriptedReadWriter) Read(p []byte) (int, error)  { return rw.reader.Read(p) }
+func (rw *scriptedReadWriter) Write(p []byte) (int, error) { return rw.output.Write(p) }
+
+func TestRunInteractiveTabCompletionAndListing(t *testing.T) {
+	rw := &scriptedReadWriter{reader: strings.NewReader("pw\t\x04")}
+	NewShell(testCompletionFS()).RunInteractive(rw, io.Discard, "", "lore")
+	if !strings.Contains(rw.output.String(), "pwd ") {
+		t.Fatalf("interactive completion output = %q", rw.output.String())
+	}
+
+	rw = &scriptedReadWriter{reader: strings.NewReader("cat /docs/no\t\t\x04")}
+	NewShell(testCompletionFS()).RunInteractive(rw, io.Discard, "", "lore")
+	out := rw.output.String()
+	if !strings.Contains(out, "notebook.md") || !strings.Contains(out, "notes.md") || !strings.Contains(out, "lore:/ $ cat /docs/note") {
+		t.Fatalf("interactive candidate listing output = %q", out)
+	}
+
+	rw = &scriptedReadWriter{reader: strings.NewReader("does-not-exist\t\x04")}
+	NewShell(testCompletionFS()).RunInteractive(rw, io.Discard, "", "lore")
+	if !strings.Contains(rw.output.String(), "\a") {
+		t.Fatalf("missing completion did not ring bell: %q", rw.output.String())
+	}
+}
+
+func TestRunInteractiveConfirmsLargeListing(t *testing.T) {
+	entries := make([]vfs.FileInfo, 101)
+	for i := range entries {
+		entries[i] = vfs.FileInfo{FileName: "file" + string(rune(0x100+i))}
+	}
+	fs := completionFS{dirs: map[string][]vfs.FileInfo{"/": entries}}
+	rw := &scriptedReadWriter{reader: strings.NewReader("cat \t\tn\x04")}
+	NewShell(fs).RunInteractive(rw, io.Discard, "", "lore")
+	if !strings.Contains(rw.output.String(), "Display all 101 possibilities? (y or n)") {
+		t.Fatalf("large completion output = %q", rw.output.String())
+	}
+}
+
+func TestRunInteractiveConsumesWidthChanges(t *testing.T) {
+	changes := make(chan int, 1)
+	changes <- 12
+	close(changes)
+	rw := &scriptedReadWriter{reader: strings.NewReader("cat /docs/no\t\t\x04")}
+	NewShell(testCompletionFS()).RunInteractiveWithOptions(rw, io.Discard, "", "lore", InteractiveOptions{
+		Width:        80,
+		WidthChanges: changes,
+	})
+	if out := rw.output.String(); !strings.Contains(out, "notebook.md\r\nnotes.md\r\n") ||
+		!strings.Contains(out, "\r\x1b[2Klore:/ $ cat /docs/note") {
+		t.Fatalf("resized interactive output was not redrawn: %q", rw.output.String())
+	}
+}
+
+func TestInteractiveExitAfterSeparator(t *testing.T) {
+	rw := &scriptedReadWriter{reader: strings.NewReader("echo ready; exit\r")}
+	NewShell(testCompletionFS()).RunInteractive(rw, io.Discard, "", "lore")
+	if out := rw.output.String(); !strings.Contains(out, "ready") || !strings.HasSuffix(out, "Goodbye!\n") {
+		t.Fatalf("compound exit output = %q", out)
+	}
+}
+
+// TestLibghosttyTranscript writes raw interactive output for the pinned
+// libghostty-vt conformance harness. Ordinary Go test runs skip it.
+func TestLibghosttyTranscript(t *testing.T) {
+	dir := os.Getenv("OPENLORE_LIBGHOSTTY_TRANSCRIPTS")
+	if dir == "" {
+		t.Skip("libghostty transcript output not requested")
+	}
+	for _, width := range []int{80, 20} {
+		rw := &scriptedReadWriter{reader: strings.NewReader("cat /docs/no\t\t")}
+		NewShell(testCompletionFS()).RunInteractiveWithOptions(rw, io.Discard, "", "lore", InteractiveOptions{Width: width})
+		name := filepath.Join(dir, fmt.Sprintf("terminal-%d.bin", width))
+		if err := os.WriteFile(name, rw.output.Bytes(), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
@@ -50,6 +51,7 @@ type Shell struct {
 	configReload         cmds.ConfigReloadBackend
 	history              cmds.HistoryBackend
 	jobs                 cmds.JobBackend
+	exitRequested        bool
 }
 
 // UnsupportedUsage describes a command or shell syntax that OpenLore does not
@@ -212,6 +214,7 @@ func (s *Shell) ExecPipeline(line string, w io.Writer, errW io.Writer, stdin io.
 }
 
 func (s *Shell) execLine(line string, w io.Writer, errW io.Writer, stdin io.Reader) int {
+	s.exitRequested = false
 	line = strings.TrimSpace(line)
 	if line == "" {
 		return 0
@@ -237,6 +240,9 @@ func (s *Shell) execLine(line string, w io.Writer, errW io.Writer, stdin io.Read
 	var exitCode int
 	for _, stmt := range f.Stmts {
 		exitCode = s.execStmt(stmt, w, errW, stdin)
+		if s.exitRequested {
+			break
+		}
 	}
 	return exitCode
 }
@@ -398,6 +404,10 @@ func (s *Shell) execCallInner(call *parser.CallExpr, w io.Writer, errW io.Writer
 
 	if cmdName == "pwd" {
 		fmt.Fprintln(w, s.cwd)
+		return 0
+	}
+	if cmdName == "exit" || cmdName == "quit" {
+		s.exitRequested = true
 		return 0
 	}
 
@@ -724,22 +734,69 @@ func (s *Shell) globExpand(pattern string) []string {
 	return matches
 }
 
-// RunInteractive runs an interactive shell session.
-// rw is used for both reading input and writing output. When running over
-// an SSH session with an allocated PTY, the session's ptyWriter already
-// converts \n to \r\n, so no additional CRLFWriter wrapping is needed.
+// InteractiveOptions describes terminal properties used by the interactive
+// shell. WidthChanges may be nil. Non-positive widths use an 80-column
+// fallback.
+type InteractiveOptions struct {
+	Width        int
+	WidthChanges <-chan int
+}
+
+// RunInteractive runs an interactive shell session with an 80-column terminal.
 func (s *Shell) RunInteractive(rw io.ReadWriter, errW io.Writer, motd string, prompt string) {
+	s.RunInteractiveWithOptions(rw, errW, motd, prompt, InteractiveOptions{Width: 80})
+}
+
+// RunInteractiveWithOptions runs an interactive shell session. rw is used for
+// both reading input and writing output. When running over an SSH session with
+// an allocated PTY, the session's ptyWriter already converts \n to \r\n, so no
+// additional CRLFWriter wrapping is needed.
+func (s *Shell) RunInteractiveWithOptions(rw io.ReadWriter, errW io.Writer, motd string, prompt string, opts InteractiveOptions) {
 	if motd != "" {
 		fmt.Fprintln(rw, motd)
 		fmt.Fprintln(rw, "")
+	}
+	if opts.Width <= 0 {
+		opts.Width = 80
+	}
+	terminalWidth := opts.Width
+	currentWidth := func() int {
+		for opts.WidthChanges != nil {
+			select {
+			case width, ok := <-opts.WidthChanges:
+				if !ok {
+					opts.WidthChanges = nil
+					return terminalWidth
+				}
+				if width > 0 {
+					terminalWidth = width
+				}
+			default:
+				return terminalWidth
+			}
+		}
+		return terminalWidth
 	}
 
 	buf := make([]byte, 0, 4096)
 	tmp := make([]byte, 1)
 	lastWasCR := false
+	var completionLine string
+	var completionCandidates []completionCandidate
+	var confirmCandidates []completionCandidate
 
 	printPrompt := func() {
 		fmt.Fprintf(rw, "%s:%s $ ", prompt, s.cwd)
+	}
+	redraw := func() {
+		fmt.Fprint(rw, "\r\x1b[2K")
+		printPrompt()
+		rw.Write(buf)
+	}
+	listCandidates := func(candidates []completionCandidate) {
+		fmt.Fprint(rw, "\r\n")
+		fmt.Fprint(rw, formatCandidateColumns(candidates, currentWidth()))
+		redraw()
 	}
 
 	printPrompt()
@@ -762,34 +819,100 @@ func (s *Shell) RunInteractive(rw io.ReadWriter, errW io.Writer, motd string, pr
 		}
 		lastWasCR = ch == '\r'
 
+		if confirmCandidates != nil {
+			switch ch {
+			case 'y', 'Y':
+				fmt.Fprint(rw, string(ch))
+				candidates := confirmCandidates
+				confirmCandidates = nil
+				completionLine = ""
+				completionCandidates = nil
+				listCandidates(candidates)
+			case 'n', 'N', 3:
+				if ch != 3 {
+					fmt.Fprint(rw, string(ch))
+				}
+				confirmCandidates = nil
+				completionLine = ""
+				completionCandidates = nil
+				fmt.Fprint(rw, "\r\n")
+				redraw()
+			default:
+				fmt.Fprint(rw, "\a")
+			}
+			continue
+		}
+
 		switch {
 		case ch == 4: // Ctrl-D
 			fmt.Fprintln(rw, "\r\nGoodbye!")
 			return
 		case ch == 3: // Ctrl-C
 			buf = buf[:0]
+			completionLine = ""
+			completionCandidates = nil
 			fmt.Fprint(rw, "\r\n")
 			printPrompt()
 		case ch == 127 || ch == 8: // Backspace
 			if len(buf) > 0 {
-				buf = buf[:len(buf)-1]
-				rw.Write([]byte("\b \b"))
+				_, size := utf8.DecodeLastRune(buf)
+				buf = buf[:len(buf)-size]
+				completionLine = ""
+				completionCandidates = nil
+				redraw()
 			}
 		case ch == '\r' || ch == '\n':
 			fmt.Fprint(rw, "\r\n")
 			line := strings.TrimSpace(string(buf))
 			buf = buf[:0]
+			completionLine = ""
+			completionCandidates = nil
 			if line == "exit" || line == "quit" {
 				fmt.Fprintln(rw, "Goodbye!")
 				return
 			}
 			if line != "" {
+				s.exitRequested = false
 				s.ExecPipeline(line, rw, rw, nil)
+				if s.exitRequested {
+					fmt.Fprintln(rw, "Goodbye!")
+					return
+				}
 			}
 			printPrompt()
-		case ch == '\t': // Tab — ignore
+		case ch == '\t':
+			line := string(buf)
+			if line == completionLine && len(completionCandidates) > 0 {
+				if len(completionCandidates) > 100 {
+					confirmCandidates = completionCandidates
+					fmt.Fprintf(rw, "\r\nDisplay all %d possibilities? (y or n) ", len(confirmCandidates))
+				} else {
+					listCandidates(completionCandidates)
+				}
+				continue
+			}
+			result := s.complete(line)
+			if len(result.candidates) == 0 {
+				completionLine = ""
+				completionCandidates = nil
+				fmt.Fprint(rw, "\a")
+				continue
+			}
+			if result.line != line {
+				buf = append(buf[:0], result.line...)
+				redraw()
+			}
+			if !result.finished {
+				completionLine = string(buf)
+				completionCandidates = result.candidates
+			} else {
+				completionLine = ""
+				completionCandidates = nil
+			}
 		default:
 			buf = append(buf, ch)
+			completionLine = ""
+			completionCandidates = nil
 			rw.Write([]byte{ch})
 		}
 	}

--- a/scripts/test-libghostty.sh
+++ b/scripts/test-libghostty.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly ghostty_revision=4540d499ae463ad7b90f28f6f852f64f844c160f
+readonly cache_root="${XDG_CACHE_HOME:-${HOME}/.cache}/openlore-libghostty"
+readonly ghostty_dir="${GHOSTTY_DIR:-${cache_root}/ghostty-${ghostty_revision}}"
+readonly transcripts="$(mktemp -d)"
+trap 'rm -rf "$transcripts"' EXIT
+
+if ! command -v zig >/dev/null 2>&1 || [[ "$(zig version)" != "0.16.0" ]]; then
+    echo "test-libghostty: Zig 0.16.0 is required" >&2
+    exit 1
+fi
+
+if [[ ! -d "${ghostty_dir}/.git" ]] ||
+    [[ "$(git -C "$ghostty_dir" rev-parse HEAD 2>/dev/null || true)" != "$ghostty_revision" ]]; then
+    rm -rf "$ghostty_dir"
+    mkdir -p "$(dirname "$ghostty_dir")"
+    git init -q "$ghostty_dir"
+    git -C "$ghostty_dir" remote add origin https://github.com/ghostty-org/ghostty.git
+    git -C "$ghostty_dir" fetch -q --depth 1 origin "$ghostty_revision"
+    git -C "$ghostty_dir" checkout -q FETCH_HEAD
+fi
+
+zig build --build-file "${ghostty_dir}/build.zig" \
+    --cache-dir "${ghostty_dir}/.zig-cache" \
+    --global-cache-dir "${cache_root}/zig" \
+    --prefix "${ghostty_dir}/zig-out" \
+    -Demit-lib-vt -Doptimize=ReleaseFast -Dsimd=false
+
+OPENLORE_LIBGHOSTTY_TRANSCRIPTS="$transcripts" \
+    go test ./pkg/shell -run '^TestLibghosttyTranscript$' -count=1
+
+cc -std=c11 -DGHOSTTY_STATIC \
+    -I"${ghostty_dir}/zig-out/include" \
+    internal/libghosttytest/harness.c \
+    "${ghostty_dir}/zig-out/lib/libghostty-vt.a" \
+    -o "${transcripts}/harness"
+
+"${transcripts}/harness" \
+    "${transcripts}/terminal-80.bin" \
+    "${transcripts}/terminal-20.bin"


### PR DESCRIPTION
## Summary
- add capability-filtered completion for commands, registered lore subcommands, and VFS paths
- add common-prefix expansion, double-Tab column listings, quoting, Unicode handling, resize support, and large-list confirmation
- add a pinned libghostty-vt rendering target in required CI alongside focused interactive tests

## Verification
- `go test -race ./...`
- `go vet ./...`
- `make test-libghostty`
- OpenSSH PTY smoke test: `pw<Tab>` completed to `pwd ` and Ctrl-D exited cleanly