### PR TITLE
Folder rules system: Phase 1

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1414,7 +1414,7 @@ func desugarOKFRules(auth *AuthConfig) error {
 			docset.Rules = map[string]rules.RuleSpec{}
 		}
 		if explicit, ok := docset.Rules["okf"]; ok {
-			if !sameLegacyOKFRule(explicit, expected) {
+			if !explicit.Equal(expected) {
 				return fmt.Errorf("docset %q has conflicting okf and rules.okf configuration", name)
 			}
 		} else {
@@ -1433,26 +1433,4 @@ func desugarOKFRules(auth *AuthConfig) error {
 		auth.Docsets[name] = docset
 	}
 	return nil
-}
-
-func sameLegacyOKFRule(a, b rules.RuleSpec) bool {
-	if a.Use != b.Use || a.Default != b.Default || a.IsEnforcing() != b.IsEnforcing() || len(a.Match) != len(b.Match) || len(a.Exclude) != len(b.Exclude) || len(a.With) != len(b.With) {
-		return false
-	}
-	for i := range a.Match {
-		if a.Match[i] != b.Match[i] {
-			return false
-		}
-	}
-	for i := range a.Exclude {
-		if a.Exclude[i] != b.Exclude[i] {
-			return false
-		}
-	}
-	for key, value := range a.With {
-		if fmt.Sprint(value) != fmt.Sprint(b.With[key]) {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aakarim/go-openlore/pkg/rules"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
@@ -62,6 +63,7 @@ type Config struct {
 	// event-bus `hooks` path with middleware on the read/write chains.
 	Shellexec ShellexecConfig
 	Logger    *slog.Logger
+	Rules     RulesConfig
 
 	// Readonly is the global write lock. Default true: the substrate is a
 	// read-only filesystem and no write verbs are available. Set false to
@@ -99,6 +101,10 @@ type Config struct {
 	configFileLoaded   bool
 	embeddedConfigUsed bool
 	warnings           []string
+}
+
+type RulesConfig struct {
+	Growth float64
 }
 
 // Warnings returns non-fatal problems encountered while loading configuration.
@@ -257,11 +263,12 @@ type FilesConfig struct {
 
 // AuthConfig is loaded from lore.json.
 type AuthConfig struct {
-	AllowKeyless    *bool                 `json:"allow_keyless,omitempty"`
-	UnknownIdentity string                `json:"unknown_identity,omitempty"`
-	DefaultCwd      string                `json:"default_cwd,omitempty"`
-	Docsets         map[string]DocsetSpec `json:"docsets"`
-	Roles           map[string]RoleSpec   `json:"roles,omitempty"`
+	AllowKeyless    *bool                     `json:"allow_keyless,omitempty"`
+	UnknownIdentity string                    `json:"unknown_identity,omitempty"`
+	DefaultCwd      string                    `json:"default_cwd,omitempty"`
+	Rules           map[string]rules.RuleSpec `json:"rules,omitempty"`
+	Docsets         map[string]DocsetSpec     `json:"docsets"`
+	Roles           map[string]RoleSpec       `json:"roles,omitempty"`
 	// Default is a legacy authority field retained only for JSON parsing. It is ignored.
 	Default    map[string]string `json:"default,omitempty"`
 	Identities []AuthIdentity    `json:"identities"`
@@ -312,8 +319,9 @@ type JWKSSpec struct {
 
 // DocsetSpec defines a named set of path mappings.
 type DocsetSpec struct {
-	Paths  []PathMapping `json:"paths"`
-	Access DocsetAccess  `json:"access,omitempty"`
+	Paths  []PathMapping             `json:"paths"`
+	Access DocsetAccess              `json:"access,omitempty"`
+	Rules  map[string]rules.RuleSpec `json:"rules,omitempty"`
 	// AgentSkills is ignored. Collections are selected dynamically by xattr.
 	AgentSkills bool `json:"-"`
 	// Aliases are alternate display roots for the first path. They expose the
@@ -503,12 +511,18 @@ type fileConfig struct {
 	Readonly            *bool                  `yaml:"readonly"`
 	WriteConflictPolicy string                 `yaml:"write_conflict_policy"`
 	MaxJobs             int                    `yaml:"max_jobs"`
+	Rules               rulesYAML              `yaml:"rules"`
 	// Tokens + OIDCIssuers are server infrastructure (bearer-token issuance for
 	// the MCP + HTTP API), hence configured here rather than in lore.json.
 	Tokens      *AuthTokensConfig `yaml:"tokens"`
 	OIDCIssuers []OIDCIssuer      `yaml:"oidc_issuers"`
 	Inbox       *inboxYAML        `yaml:"inbox"`
 	Plugins     pluginsYAML       `yaml:"plugins"`
+}
+
+type rulesYAML struct {
+	Growth    *float64 `yaml:"growth"`
+	Tokenizer string   `yaml:"tokenizer"`
 }
 
 type authInfrastructureYAML struct {
@@ -600,6 +614,7 @@ func New(opts ...Option) (Config, error) {
 		Readonly:            true,                           // safe default: read-only substrate
 		WriteConflictPolicy: vfs.DefaultWriteConflictPolicy, // "hash": overwrites are compare-and-swap
 		MaxJobs:             8,                              // bound concurrent async spawn jobs
+		Rules:               RulesConfig{Growth: 1.25},
 		Plugins:             PluginsConfig{Skills: SkillsPluginConfig{RemoteCheckTTL: 60 * time.Second, RemoteTimeout: 3 * time.Second, RemoteMaxBytes: 10 * 1024 * 1024}},
 		Passkeys: PasskeysConfig{
 			Enabled:      true,
@@ -661,6 +676,15 @@ func WithConfigFile(path string) Option {
 		cfg.warnings = append(cfg.warnings, warnings...)
 
 		cfg.configFileLoaded = true
+		if fc.Rules.Tokenizer != "" {
+			return errors.New("rules.tokenizer is not supported yet")
+		}
+		if fc.Rules.Growth != nil {
+			if *fc.Rules.Growth < 1 {
+				return errors.New("rules.growth must be at least 1")
+			}
+			cfg.Rules.Growth = *fc.Rules.Growth
+		}
 
 		if fc.ConfigVersion != "" {
 			cfg.ConfigVersion = fc.ConfigVersion
@@ -1216,6 +1240,9 @@ func LoadAuthConfig(path string) (*AuthConfig, error) {
 // ValidateAuthConfig validates a parsed static authorization policy. Legacy
 // authority fields are deliberately ignored.
 func ValidateAuthConfig(auth *AuthConfig) error {
+	if err := desugarOKFRules(auth); err != nil {
+		return err
+	}
 	if _, ok := auth.Roles["guest"]; ok {
 		return fmt.Errorf("role %q is reserved", "guest")
 	}
@@ -1367,4 +1394,65 @@ func ValidateAuthConfig(auth *AuthConfig) error {
 	}
 
 	return nil
+}
+
+func desugarOKFRules(auth *AuthConfig) error {
+	for name, docset := range auth.Docsets {
+		if docset.OKF == nil {
+			continue
+		}
+		patterns := docset.OKF.Patterns
+		if len(patterns) == 0 {
+			patterns = []string{"*.md"}
+		}
+		matches := make([]string, 0, len(patterns))
+		for _, pattern := range patterns {
+			matches = append(matches, "**/"+pattern)
+		}
+		expected := rules.RuleSpec{Match: matches, Use: "okf", Enforce: docset.OKF.Enforce}
+		if docset.Rules == nil {
+			docset.Rules = map[string]rules.RuleSpec{}
+		}
+		if explicit, ok := docset.Rules["okf"]; ok {
+			if !sameLegacyOKFRule(explicit, expected) {
+				return fmt.Errorf("docset %q has conflicting okf and rules.okf configuration", name)
+			}
+		} else {
+			docset.Rules["okf"] = expected
+		}
+		if _, ok := docset.Rules["okf/bundle"]; !ok {
+			docset.Rules["okf/bundle"] = rules.RuleSpec{Match: []string{"**/*.md"}, Use: "okf/bundle", Enforce: docset.OKF.Enforce}
+		}
+		if _, ok := docset.Rules["link/resolves"]; !ok {
+			docset.Rules["link/resolves"] = rules.RuleSpec{Match: []string{"**/*.md"}, Use: "link/resolves", Enforce: docset.OKF.Enforce}
+		}
+		if _, ok := docset.Rules["link/alias"]; !ok {
+			warn := false
+			docset.Rules["link/alias"] = rules.RuleSpec{Match: []string{"**/*.md"}, Use: "link/alias", Enforce: &warn}
+		}
+		auth.Docsets[name] = docset
+	}
+	return nil
+}
+
+func sameLegacyOKFRule(a, b rules.RuleSpec) bool {
+	if a.Use != b.Use || a.Default != b.Default || a.IsEnforcing() != b.IsEnforcing() || len(a.Match) != len(b.Match) || len(a.Exclude) != len(b.Exclude) || len(a.With) != len(b.With) {
+		return false
+	}
+	for i := range a.Match {
+		if a.Match[i] != b.Match[i] {
+			return false
+		}
+	}
+	for i := range a.Exclude {
+		if a.Exclude[i] != b.Exclude[i] {
+			return false
+		}
+	}
+	for key, value := range a.With {
+		if fmt.Sprint(value) != fmt.Sprint(b.With[key]) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/config/rules_config_test.go
+++ b/internal/config/rules_config_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadAuthConfigRulesAndLegacyOKF(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "lore.json")
+	data := `{"rules":{"size":{"match":["**/*.md"],"use":"size/lines","with":{"max":3}}},"docsets":{"docs":{"paths":["/docs"],"okf":{}}},"identities":[]}`
+	if err := os.WriteFile(file, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	auth, err := LoadAuthConfig(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.Rules["size"].Use != "size/lines" || auth.Docsets["docs"].Rules["okf"].Use != "okf" || auth.Docsets["docs"].Rules["okf/bundle"].Use != "okf/bundle" {
+		t.Fatalf("rules not loaded/desugared: %#v", auth)
+	}
+}
+
+func TestLoadAuthConfigRejectsConflictingLegacyOKFRule(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "lore.json")
+	data := `{"docsets":{"docs":{"paths":["/docs"],"okf":{},"rules":{"okf":{"match":["**/*.txt"],"use":"okf"}}}},"identities":[]}`
+	if err := os.WriteFile(file, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadAuthConfig(file)
+	if err == nil || !strings.Contains(err.Error(), "okf") || !strings.Contains(err.Error(), "rules.okf") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestRulesDeploymentConfig(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "openlore.yml")
+	if err := os.WriteFile(file, []byte("rules:\n  growth: 1.5\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := New(WithConfigFile(file))
+	if err != nil || cfg.Rules.Growth != 1.5 {
+		t.Fatalf("growth=%v err=%v", cfg.Rules.Growth, err)
+	}
+	if err := os.WriteFile(file, []byte("rules:\n  tokenizer: o200k_base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(WithConfigFile(file)); err == nil || !strings.Contains(err.Error(), "not supported yet") {
+		t.Fatalf("error=%v", err)
+	}
+}

--- a/pkg/openlore/config_management.go
+++ b/pkg/openlore/config_management.go
@@ -113,6 +113,9 @@ func (s *Server) validateLiveAuthCandidate(next *config.AuthConfig) error {
 	if !reflect.DeepEqual(current.Docsets, next.Docsets) {
 		return fmt.Errorf("docset configuration requires a server restart")
 	}
+	if !reflect.DeepEqual(current.Rules, next.Rules) {
+		return fmt.Errorf("top-level rule configuration requires a server restart")
+	}
 	return s.validateGrantsFor(next)
 }
 

--- a/pkg/openlore/delegated_identity_test.go
+++ b/pkg/openlore/delegated_identity_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/rules"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"
@@ -269,6 +270,11 @@ func TestLiveAuthRejectsServerDerivedPolicyChanges(t *testing.T) {
 	next.AllowKeyless = &keyless
 	if err := s.validateLiveAuthCandidate(&next); err == nil || !strings.Contains(err.Error(), "restart") {
 		t.Fatalf("posture change accepted: %v", err)
+	}
+	next = *auth
+	next.Rules = map[string]rules.RuleSpec{"limit": {Use: "size/lines", Match: []string{"**"}, With: map[string]any{"max": 10}}}
+	if err := s.validateLiveAuthCandidate(&next); err == nil || !strings.Contains(err.Error(), "restart") {
+		t.Fatalf("top-level rule change accepted: %v", err)
 	}
 }
 

--- a/pkg/openlore/okf_plugin.go
+++ b/pkg/openlore/okf_plugin.go
@@ -1,253 +1,104 @@
 package openlore
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 	"path"
-	"sort"
-	"strings"
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/okf"
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/rules"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
-// The OKF plugin validates Open Knowledge Format documents on write. It is a
-// built-in default plugin (a sibling of shellexec/inbox): it contributes a
-// single admission (pre-commit) middleware that inspects each write's
-// ChangeSet, and for targets matching its patterns (default "*.md") runs
-// okf.Validate on the proposed bytes. A non-conformant document is rejected
-// before it reaches the write log (enforce=true, the default) or logged and let
-// through (enforce=false).
-//
-// Scope is defined on docsets (config.OKFDocsetConfig on a DocsetSpec), never as
-// a global block, so OKF scoping reads the exact same display roots as authz and
-// can't drift from it. A write is governed by the OKF config of the docset that
-// owns its target path — the longest matching display root across all docsets,
-// exactly as grantsForPath resolves grants. A child docset therefore includes a
-// subtree (child carries OKF) or exempts it (child carries none, shadowing a
-// parent's OKF).
-//
-// It only inspects ChangeActionWrite mutations (the only action carrying bytes);
-// mkdir/remove pass straight through. The same okf package backs downstream
-// shell commands (e.g. `kb save`/`kb publish`) so validation is identical on
-// every path.
-//
-// It implements WriteMiddlewareProvider, so registerPlugin wires it into the
-// admission chain.
-
 const defaultOKFPattern = "*.md"
 
+// okfPlugin retains OKF's read-side metadata integration and a compatibility
+// validator shim. Write admission and all validation logic live in rulesPlugin.
 type okfPlugin struct {
 	docsets map[string]config.DocsetSpec
-	logger  *slog.Logger
+	engine  *rules.Engine
 }
 
-// newOKF builds the OKF plugin over the resolved docset set. It resolves the
-// effective OKF config per write from these docsets, so it must be constructed
-// after auth config is loaded (or the unenforced-mode public docset is
-// synthesized).
 func newOKF(docsets map[string]config.DocsetSpec, logger *slog.Logger) *okfPlugin {
-	if logger == nil {
-		logger = slog.Default()
+	auth := &config.AuthConfig{Docsets: make(map[string]config.DocsetSpec, len(docsets))}
+	for name, docset := range docsets {
+		copy := docset
+		if docset.Rules != nil {
+			copy.Rules = make(map[string]rules.RuleSpec, len(docset.Rules))
+			for ruleName, spec := range docset.Rules {
+				copy.Rules[ruleName] = spec
+			}
+		}
+		auth.Docsets[name] = copy
 	}
-	return &okfPlugin{docsets: docsets, logger: logger}
+	_ = config.ValidateAuthConfig(auth)
+	plugin, _ := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, logger)
+	return &okfPlugin{docsets: docsets, engine: plugin.engine}
 }
 
-// anyDocsetHasOKF reports whether at least one docset carries OKF config, so the
-// server can skip registering the plugin (and its per-write cost) entirely when
-// OKF is unused.
 func anyDocsetHasOKF(docsets map[string]config.DocsetSpec) bool {
-	for _, ds := range docsets {
-		if ds.OKF != nil {
+	for _, docset := range docsets {
+		if docset.OKF != nil {
 			return true
 		}
 	}
 	return false
 }
 
-// resolve returns the OKF config of the docset that owns target — the longest
-// matching display root across all docsets, identical to authz's grant
-// resolution. It returns nil when no docset owns the path, or when the owning
-// docset carries no OKF config (a child docset without OKF thus exempts its
-// subtree from a parent docset's OKF). Both cases mean "not validated".
 func (p *okfPlugin) resolve(target string) *config.OKFDocsetConfig {
 	clean := vfs.CleanPath(target)
 	bestLen := -1
 	var best *config.OKFDocsetConfig
-	for _, ds := range p.docsets {
-		okfCfg := ds.OKF
-		for _, pm := range ds.Paths {
-			root := displayPath(pm)
+	for _, docset := range p.docsets {
+		for _, mapping := range docset.Paths {
+			root := displayPath(mapping)
 			if pathWithinRoot(root, clean) && len(root) > bestLen {
-				bestLen = len(root)
-				best = okfCfg
+				bestLen, best = len(root), docset.OKF
 			}
 		}
 	}
 	return best
 }
 
-// matches reports whether target's basename matches any of the patterns (empty
-// patterns default to "*.md").
 func matchesOKFPatterns(target string, patterns []string) bool {
 	if len(patterns) == 0 {
 		patterns = []string{defaultOKFPattern}
 	}
 	base := path.Base(vfs.CleanPath(target))
-	for _, pat := range patterns {
-		if ok, _ := path.Match(pat, base); ok {
+	for _, pattern := range patterns {
+		if matched, _ := path.Match(pattern, base); matched {
 			return true
 		}
 	}
 	return false
 }
 
-// WriteMiddleware implements WriteMiddlewareProvider.
-func (p *okfPlugin) WriteMiddleware() []WriteMiddleware {
-	return []WriteMiddleware{
-		func(next WriteHandler) WriteHandler {
-			return func(ctx context.Context, op WriteOp) (WriteResult, error) {
-				for _, leaf := range op.Leaves() {
-					if leaf.Action == vfs.ChangeActionWrite && leaf.Write != nil {
-						if oc := p.resolve(leaf.Target); oc != nil && matchesOKFPatterns(leaf.Target, oc.Patterns) {
-							if err := okf.Validate(leaf.Target, leaf.Write.Bytes); err != nil {
-								enforce := oc.Enforce == nil || *oc.Enforce
-								if enforce {
-									return WriteResult{}, fmt.Errorf("okf: %s: %w", leaf.Target, err)
-								}
-								p.logger.Warn("okf validation failed (non-enforcing)",
-									"path", leaf.Target, "err", err)
-							}
-						}
-					}
-				}
-				return next(ctx, op)
-			}
-		},
-	}
-}
-
-// MetaExtenders implements MetaExtenderProvider. It contributes a single
-// extender that annotates a `lore meta` record with OKF conformance — but only
-// for documents where OKF actually applies (the owning docset has OKF and the
-// path matches its patterns), so read-side discovery agrees exactly with
-// write-side enforcement. The added field is:
-//
-//	"okf": {"valid": true}                       // conformant
-//	"okf": {"valid": false, "error": "<reason>"} // non-conformant
 func (p *okfPlugin) MetaExtenders() []meta.Extender {
-	return []meta.Extender{
-		func(absPath string, content []byte, _ map[string]any) map[string]any {
-			oc := p.resolve(absPath)
-			if oc == nil || !matchesOKFPatterns(absPath, oc.Patterns) {
-				return nil // OKF does not govern this path
-			}
-			status := map[string]any{"valid": true}
-			if err := okf.Validate(absPath, content); err != nil {
-				status["valid"] = false
-				status["error"] = err.Error()
-			}
-			return map[string]any{"okf": status}
-		},
-	}
-}
-
-// Validators implements ValidatorProvider. The command and filesystem scan are
-// owned by core; the plugin contributes OKF conformance plus OpenLore's
-// operational link and alias-portability checks.
-func (p *okfPlugin) Validators() []validation.Validator {
-	aliasRoots := p.aliasRoots()
-	return []validation.Validator{func(bundle validation.Bundle) []validation.Diagnostic {
-		files := make([]okf.File, 0, len(bundle.Files))
-		for _, file := range bundle.Files {
-			files = append(files, okf.File{Path: file.Path, Content: file.Content})
+	return []meta.Extender{func(absPath string, content []byte, _ map[string]any) map[string]any {
+		cfg := p.resolve(absPath)
+		if cfg == nil || !matchesOKFPatterns(absPath, cfg.Patterns) {
+			return nil
 		}
-		okfDiagnostics := okf.ValidateBundle(files)
-		diagnostics := make([]validation.Diagnostic, 0, len(okfDiagnostics))
-		for _, diagnostic := range okfDiagnostics {
-			diagnostics = append(diagnostics, fromOKFDiagnostic(diagnostic))
+		status := map[string]any{"valid": true}
+		if err := okf.Validate(absPath, content); err != nil {
+			status["valid"], status["error"] = false, err.Error()
 		}
-		for _, file := range bundle.Files {
-			if path.Ext(file.Path) != ".md" {
-				continue
-			}
-			for _, link := range okf.Links(file.Content) {
-				local, ok := okf.LocalLinkPath(link.Destination)
-				if !ok {
-					continue
-				}
-				target := path.Join(path.Dir(file.AbsolutePath), local)
-				if strings.HasPrefix(local, "/") {
-					target = path.Join(bundle.Root, strings.TrimPrefix(local, "/"))
-				}
-				target = vfs.CleanPath(target)
-				if !pathWithinRoot(bundle.Root, target) {
-					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityError,
-						"openlore/link-outside-bundle", fmt.Sprintf("local link %q resolves outside the bundle", link.Destination)))
-				} else if _, err := bundle.FS.Stat(target); err != nil {
-					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityError,
-						"openlore/broken-link", fmt.Sprintf("local link %q does not resolve", link.Destination)))
-				}
-				if aliasRoot(file.AbsolutePath, aliasRoots) != "" {
-					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityWarning,
-						"openlore/alias-referrer", "link originates from an aliased docset path; use a stable checkout path"))
-				}
-				if alias := aliasRoot(target, aliasRoots); alias != "" {
-					diagnostics = append(diagnostics, openLoreDiagnostic(file.Path, link, validation.SeverityWarning,
-						"openlore/alias-target", fmt.Sprintf("link targets aliased docset path %s; it may resolve differently on another machine", alias)))
-				}
-			}
-		}
-		return diagnostics
+		return map[string]any{"okf": status}
 	}}
 }
 
-func (p *okfPlugin) aliasRoots() []string {
-	var roots []string
-	for _, docset := range p.docsets {
-		roots = append(roots, docset.Aliases...)
+// Validators delegates to the same engine used by lore.json admission. It is
+// retained for callers that constructed the historical OKF plugin directly.
+func (p *okfPlugin) Validators() []validation.Validator {
+	if p.engine == nil {
+		return nil
 	}
-	sort.Slice(roots, func(i, j int) bool { return len(roots[i]) > len(roots[j]) })
-	return roots
-}
-
-func aliasRoot(filePath string, roots []string) string {
-	for _, root := range roots {
-		if pathWithinRoot(root, filePath) {
-			return root
-		}
-	}
-	return ""
-}
-
-func openLoreDiagnostic(filePath string, link okf.Link, severity validation.Severity, rule, message string) validation.Diagnostic {
-	return validation.Diagnostic{
-		Path: filePath, Line: link.Line, Column: link.Column,
-		Severity: severity, Rule: rule, Message: message,
-	}
-}
-
-func fromOKFDiagnostic(diagnostic okf.Diagnostic) validation.Diagnostic {
-	return validation.Diagnostic{
-		Path: diagnostic.Path, Line: diagnostic.Line, Column: diagnostic.Column,
-		Severity: validation.Severity(diagnostic.Severity), Rule: diagnostic.Rule, Message: diagnostic.Message,
-	}
-}
-
-// Info implements PluginInfoProvider. The version tracks the newest OKF spec
-// revision the validator targets (OKF v0.2); bundles declaring okf_version
-// "0.1" are still accepted and linted against v0.1 rules.
-func (p *okfPlugin) Info() PluginInfo {
-	return PluginInfo{Name: "okf", Version: "0.2.0"}
+	return []validation.Validator{p.engine.Validator()}
 }
 
 var (
-	_ WriteMiddlewareProvider = (*okfPlugin)(nil)
-	_ MetaExtenderProvider    = (*okfPlugin)(nil)
-	_ ValidatorProvider       = (*okfPlugin)(nil)
-	_ PluginInfoProvider      = (*okfPlugin)(nil)
+	_ MetaExtenderProvider = (*okfPlugin)(nil)
+	_ ValidatorProvider    = (*okfPlugin)(nil)
 )

--- a/pkg/openlore/okf_plugin_test.go
+++ b/pkg/openlore/okf_plugin_test.go
@@ -15,21 +15,15 @@ import (
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
-// runOKF composes the plugin's single admission middleware around a terminal
-// handler that records whether it was reached, and drives one ChangeSet through
-// it. It returns the terminal-reached flag and the chain error.
+// runOKF drives the compatibility plugin's rules engine directly. The legacy
+// plugin no longer owns admission middleware; server admission uses rulesPlugin.
 func runOKF(p *okfPlugin, cs vfs.ChangeSet) (reachedTerminal bool, err error) {
-	mws := p.WriteMiddleware()
-	if len(mws) != 1 {
-		panic("expected exactly one OKF middleware")
+	for _, leaf := range cs.Leaves() {
+		if err := p.engine.AdmitLeaf(context.Background(), leaf, "test", nil); err != nil {
+			return false, err
+		}
 	}
-	terminal := func(ctx context.Context, op WriteOp) (WriteResult, error) {
-		reachedTerminal = true
-		return WriteResult{Hash: "ok"}, nil
-	}
-	h := mws[0](terminal)
-	_, err = h(context.Background(), NewWriteOp(Attribution{}, cs))
-	return reachedTerminal, err
+	return true, nil
 }
 
 const validDoc = "---\ntype: Note\n---\nbody\n"
@@ -229,7 +223,7 @@ func TestOKFPlugin_NestedDocsetExcludesSubtree(t *testing.T) {
 }
 
 func TestOKFPlugin_ImplementsProvider(t *testing.T) {
-	var _ WriteMiddlewareProvider = pluginWith(docsWithOKF())
+	var _ ValidatorProvider = pluginWith(docsWithOKF())
 }
 
 // Guard against an unexpected error type leaking (should be a plain wrapped
@@ -412,7 +406,7 @@ func TestOKFPlugin_ValidateCommandSucceedsForPortableBundle(t *testing.T) {
 	}
 	sh := shell.NewShell(NewDirFS(dir, config.FilesConfig{}))
 	sh.SetCwd("/")
-	sh.SetValidators(pluginWith(docsWithOKF()).Validators())
+	sh.SetValidators(pluginWith(map[string]config.DocsetSpec{"root": docset("/", &config.OKFDocsetConfig{})}).Validators())
 
 	var out, errOut bytes.Buffer
 	if code := sh.ExecPipeline("lore validate", &out, &errOut, nil); code != 0 {
@@ -425,7 +419,7 @@ func TestOKFPlugin_ValidateCommandSucceedsForPortableBundle(t *testing.T) {
 
 func TestRegisterPlugin_ValidateCommandIsCoreAndValidatorsAreSessionLocal(t *testing.T) {
 	withOKF := &Server{}
-	if err := withOKF.registerPlugin(pluginWith(docsWithOKF())); err != nil {
+	if err := withOKF.registerPlugin(pluginWith(map[string]config.DocsetSpec{"root": docset("/", &config.OKFDocsetConfig{})})); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/openlore/plugin_info_test.go
+++ b/pkg/openlore/plugin_info_test.go
@@ -6,15 +6,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/rules"
 )
 
 func TestPluginInfo_BuiltinsReportNameAndVersion(t *testing.T) {
+	rulesPlugin := newTestRulesPlugin(t, rulesAuth(map[string]rules.RuleSpec{"limit": {Match: []string{"**"}, Use: "size/lines", With: map[string]any{"max": 1}}}, nil), nil)
 	cases := []struct {
 		plugin       PluginInfoProvider
 		name, semver string
 	}{
-		{pluginWith(docsWithOKF()), "okf", "0.2.0"},
+		{rulesPlugin, "rules", "0.1.0"},
 		{NewInboxPlugin(), "inbox", "1.0.0"},
 		{&shellexecPlugin{}, "shellexec", "1.0.0"},
 	}
@@ -32,7 +33,7 @@ func TestRegisterPlugin_LogsNameAndVersion(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 	s := &Server{grants: newGrantRegistry(), logger: logger}
 
-	if err := s.registerPlugin(newOKF(map[string]config.DocsetSpec{}, logger)); err != nil {
+	if err := s.registerPlugin(newTestRulesPlugin(t, rulesAuth(map[string]rules.RuleSpec{"limit": {Match: []string{"**"}, Use: "size/lines", With: map[string]any{"max": 1}}}, nil), logger)); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.registerPlugin(NewInboxPlugin()); err != nil {
@@ -40,7 +41,7 @@ func TestRegisterPlugin_LogsNameAndVersion(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, want := range []string{`name=okf`, `version=0.2.0`, `name=inbox`, `version=1.0.0`} {
+	for _, want := range []string{`name=rules`, `version=0.1.0`, `name=inbox`, `version=1.0.0`} {
 		if !strings.Contains(out, want) {
 			t.Errorf("boot log missing %q; got:\n%s", want, out)
 		}

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -1,0 +1,109 @@
+package openlore
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/rules"
+	"github.com/aakarim/go-openlore/pkg/rules/link"
+	"github.com/aakarim/go-openlore/pkg/rules/okfrule"
+	"github.com/aakarim/go-openlore/pkg/rules/size"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type configRuleLayers struct {
+	global  map[string]rules.RuleSpec
+	docsets map[string]config.DocsetSpec
+}
+
+func (s configRuleLayers) LayersFor(_ context.Context, target string) ([]rules.Layer, error) {
+	root, name, docset, ok := owningDocset(s.docsets, target)
+	if !ok {
+		return nil, nil
+	}
+	layers := []rules.Layer{{Origin: "lore.json", Scope: root, Rules: s.global}}
+	if len(docset.Rules) != 0 {
+		layers = append(layers, rules.Layer{Origin: "lore.json#docsets." + name, Scope: root, Rules: docset.Rules})
+	}
+	return layers, nil
+}
+
+func owningDocset(docsets map[string]config.DocsetSpec, target string) (string, string, config.DocsetSpec, bool) {
+	bestRoot, bestName, bestLen := "", "", -1
+	var best config.DocsetSpec
+	for name, docset := range docsets {
+		for _, mapping := range docset.Paths {
+			root := displayPath(mapping)
+			if pathWithinRoot(root, vfs.CleanPath(target)) && len(root) > bestLen {
+				bestRoot, bestName, best, bestLen = root, name, docset, len(root)
+			}
+		}
+	}
+	return bestRoot, bestName, best, bestLen >= 0
+}
+
+type rulesPlugin struct{ engine *rules.Engine }
+
+func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, logger *slog.Logger) (*rulesPlugin, error) {
+	registry := rules.NewRegistry()
+	size.Register(registry)
+	registry.Register(okfrule.Member{})
+	registry.Register(okfrule.Member{Bundle: true})
+	var aliases []string
+	for _, docset := range auth.Docsets {
+		aliases = append(aliases, docset.Aliases...)
+	}
+	registry.Register(link.Member{})
+	registry.Register(link.Member{Alias: true, AliasRoots: aliases})
+	engine := rules.New(rules.Options{Registry: registry, Config: configRuleLayers{global: auth.Rules, docsets: auth.Docsets}, Env: func(string) rules.Env { return rules.Env{Defaults: defaults, Logger: logger} }, Logger: logger})
+	// Compile every configured docset at boot so invalid members, parameters,
+	// and unification conflicts fail before the server begins accepting writes.
+	for _, docset := range auth.Docsets {
+		for _, mapping := range docset.Paths {
+			root := displayPath(mapping)
+			if _, err := engine.Effective(context.Background(), path.Join(root, "__rules_boot_check__.md")); err != nil {
+				return nil, fmt.Errorf("configuring rules: %w", err)
+			}
+		}
+	}
+	return &rulesPlugin{engine: engine}, nil
+}
+
+func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
+	return []WriteMiddleware{func(next WriteHandler) WriteHandler {
+		return func(ctx context.Context, op WriteOp) (WriteResult, error) {
+			for _, leaf := range op.Leaves() {
+				if err := p.engine.AdmitLeaf(ctx, leaf, op.Attribution.String(), nil); err != nil {
+					return WriteResult{}, err
+				}
+			}
+			return next(ctx, op)
+		}
+	}}
+}
+func (p *rulesPlugin) Validators() []validation.Validator {
+	return []validation.Validator{p.engine.Validator()}
+}
+func (p *rulesPlugin) Info() PluginInfo { return PluginInfo{Name: "rules", Version: "0.1.0"} }
+
+func anyConfiguredRules(auth *config.AuthConfig) bool {
+	if len(auth.Rules) != 0 {
+		return true
+	}
+	for _, docset := range auth.Docsets {
+		if len(docset.Rules) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	_ WriteMiddlewareProvider = (*rulesPlugin)(nil)
+	_ ValidatorProvider       = (*rulesPlugin)(nil)
+	_ PluginInfoProvider      = (*rulesPlugin)(nil)
+)

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"sort"
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/rules"
-	"github.com/aakarim/go-openlore/pkg/rules/link"
-	"github.com/aakarim/go-openlore/pkg/rules/okfrule"
-	"github.com/aakarim/go-openlore/pkg/rules/size"
+	_ "github.com/aakarim/go-openlore/pkg/rules/link"
+	_ "github.com/aakarim/go-openlore/pkg/rules/okfrule"
+	_ "github.com/aakarim/go-openlore/pkg/rules/size"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -23,6 +24,19 @@ type configRuleLayers struct {
 func (s configRuleLayers) LayersFor(_ context.Context, target string) ([]rules.Layer, error) {
 	root, name, docset, ok := owningDocset(s.docsets, target)
 	if !ok {
+		var governed []string
+		for docsetName, candidate := range s.docsets {
+			for _, root := range ruleRoots(candidate) {
+				if pathWithinRoot(vfs.CleanPath(target), root) && (hasBundleRule(s.global) || hasBundleRule(candidate.Rules)) {
+					governed = append(governed, docsetName)
+					break
+				}
+			}
+		}
+		if len(governed) != 0 {
+			sort.Strings(governed)
+			return nil, &rules.BundleRootError{Root: vfs.CleanPath(target), Docsets: governed}
+		}
 		return nil, nil
 	}
 	layers := []rules.Layer{{Origin: "lore.json", Scope: root, Rules: s.global}}
@@ -32,12 +46,21 @@ func (s configRuleLayers) LayersFor(_ context.Context, target string) ([]rules.L
 	return layers, nil
 }
 
+func hasBundleRule(specs map[string]rules.RuleSpec) bool {
+	for _, spec := range specs {
+		switch spec.Use {
+		case "okf/bundle", "link/resolves", "link/alias":
+			return true
+		}
+	}
+	return false
+}
+
 func owningDocset(docsets map[string]config.DocsetSpec, target string) (string, string, config.DocsetSpec, bool) {
 	bestRoot, bestName, bestLen := "", "", -1
 	var best config.DocsetSpec
 	for name, docset := range docsets {
-		for _, mapping := range docset.Paths {
-			root := displayPath(mapping)
+		for _, root := range ruleRoots(docset) {
 			if pathWithinRoot(root, vfs.CleanPath(target)) && len(root) > bestLen {
 				bestRoot, bestName, best, bestLen = root, name, docset, len(root)
 			}
@@ -46,20 +69,23 @@ func owningDocset(docsets map[string]config.DocsetSpec, target string) (string, 
 	return bestRoot, bestName, best, bestLen >= 0
 }
 
+func ruleRoots(docset config.DocsetSpec) []string {
+	roots := append([]string(nil), docset.Aliases...)
+	for _, mapping := range docset.Paths {
+		roots = append(roots, displayPath(mapping))
+	}
+	return roots
+}
+
 type rulesPlugin struct{ engine *rules.Engine }
 
 func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, logger *slog.Logger) (*rulesPlugin, error) {
-	registry := rules.NewRegistry()
-	size.Register(registry)
-	registry.Register(okfrule.Member{})
-	registry.Register(okfrule.Member{Bundle: true})
 	var aliases []string
 	for _, docset := range auth.Docsets {
 		aliases = append(aliases, docset.Aliases...)
 	}
-	registry.Register(link.Member{})
-	registry.Register(link.Member{Alias: true, AliasRoots: aliases})
-	engine := rules.New(rules.Options{Registry: registry, Config: configRuleLayers{global: auth.Rules, docsets: auth.Docsets}, Env: func(string) rules.Env { return rules.Env{Defaults: defaults, Logger: logger} }, Logger: logger})
+	sort.Slice(aliases, func(i, j int) bool { return len(aliases[i]) > len(aliases[j]) })
+	engine := rules.New(rules.Options{Registry: rules.DefaultRegistry(), Config: configRuleLayers{global: auth.Rules, docsets: auth.Docsets}, Env: func(string) rules.Env { return rules.Env{Defaults: defaults, Logger: logger, AliasRoots: aliases} }, Logger: logger})
 	// Compile every configured docset at boot so invalid members, parameters,
 	// and unification conflicts fail before the server begins accepting writes.
 	for _, docset := range auth.Docsets {

--- a/pkg/openlore/rules_plugin_test.go
+++ b/pkg/openlore/rules_plugin_test.go
@@ -1,0 +1,101 @@
+package openlore
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/rules"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+func newTestRulesPlugin(t *testing.T, auth *config.AuthConfig, logger *slog.Logger) *rulesPlugin {
+	t.Helper()
+	p, err := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func runRules(p *rulesPlugin, changes ...vfs.Change) (bool, error) {
+	called := false
+	handler := p.WriteMiddleware()[0](func(context.Context, WriteOp) (WriteResult, error) { called = true; return WriteResult{}, nil })
+	_, err := handler(context.Background(), NewWriteOp(Attribution{Principal: "test"}, vfs.ChangeSet{Changes: changes}))
+	return called, err
+}
+
+func rulesAuth(global map[string]rules.RuleSpec, docsetRules map[string]rules.RuleSpec) *config.AuthConfig {
+	return &config.AuthConfig{Rules: global, Docsets: map[string]config.DocsetSpec{
+		"backend": {Paths: []config.PathMapping{{Source: "/backend", Display: "/backend"}}, Rules: docsetRules},
+		"public":  {Paths: []config.PathMapping{{Source: "/public", Display: "/public"}}},
+	}}
+}
+
+func TestRulesPluginSizeScopeMessageAndBatch(t *testing.T) {
+	p := newTestRulesPlugin(t, rulesAuth(map[string]rules.RuleSpec{"doc-size": {Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": 3}}}, nil), nil)
+	called, err := runRules(p,
+		vfs.Change{Target: "/backend/good.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("1\n2\n3\n")}},
+		vfs.Change{Target: "/public/bad.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("1\n2\n3\n4\n")}},
+	)
+	if called || err == nil {
+		t.Fatalf("batch called=%v err=%v", called, err)
+	}
+	message := err.Error()
+	for _, want := range []string{"rules: /public/bad.md: size/lines (doc-size @ lore.json)", "4 lines exceeds the limit of 3 (max: 3)", "cannot grow past 3 lines", "bad-details.md", "add a link to it from bad.md", "override: to raise the limit, edit doc-size in lore.json", "see: lore package doc size/lines"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("message missing %q:\n%s", want, message)
+		}
+	}
+}
+
+func TestRulesPluginPerDocsetAndNonEnforcing(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	warn := false
+	p := newTestRulesPlugin(t, rulesAuth(nil, map[string]rules.RuleSpec{"short": {Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": 1}, Enforce: &warn}}), logger)
+	called, err := runRules(p,
+		vfs.Change{Target: "/public/a.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("1\n2\n")}},
+		vfs.Change{Target: "/backend/a.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("1\n2\n")}},
+	)
+	if err != nil || !called {
+		t.Fatalf("called=%v err=%v", called, err)
+	}
+	if got := logs.String(); !strings.Contains(got, "level=WARN") || !strings.Contains(got, "rule=short") {
+		t.Fatalf("missing warning log: %s", got)
+	}
+}
+
+func TestRulesPluginBundleRulesValidateOnly(t *testing.T) {
+	auth := rulesAuth(nil, map[string]rules.RuleSpec{
+		"format": {Match: []string{"**/*.md"}, Use: "okf"},
+		"links":  {Match: []string{"**/*.md"}, Use: "link/resolves"},
+	})
+	p := newTestRulesPlugin(t, auth, nil)
+	called, err := runRules(p, vfs.Change{Target: "/backend/a.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("---\ntype: Note\n---\n[missing](b.md)\n")}})
+	if err != nil || !called {
+		t.Fatalf("bundle rule affected write: called=%v err=%v", called, err)
+	}
+
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "backend"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "backend", "a.md"), []byte("---\ntype: Note\n---\n[missing](b.md)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewDirFS(dir, config.FilesConfig{})
+	diagnostics, err := validation.Scan(fsys, "/backend", p.Validators()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Rule != "openlore/broken-link" {
+		t.Fatalf("diagnostics=%#v", diagnostics)
+	}
+}

--- a/pkg/openlore/rules_plugin_test.go
+++ b/pkg/openlore/rules_plugin_test.go
@@ -3,6 +3,7 @@ package openlore
 import (
 	"bytes"
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -97,5 +98,134 @@ func TestRulesPluginBundleRulesValidateOnly(t *testing.T) {
 	}
 	if len(diagnostics) != 1 || diagnostics[0].Rule != "openlore/broken-link" {
 		t.Fatalf("diagnostics=%#v", diagnostics)
+	}
+}
+
+func bootRulesServer(t *testing.T, auth *config.AuthConfig, logger *slog.Logger) (*Server, string) {
+	t.Helper()
+	root := t.TempDir()
+	for _, docset := range auth.Docsets {
+		for _, mapping := range docset.Paths {
+			if err := os.MkdirAll(filepath.Join(root, strings.TrimPrefix(mapping.Source, "/")), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	authFile := filepath.Join(t.TempDir(), "lore.json")
+	writeAuthFixture(t, authFile, auth)
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	server, err := NewServer(root, WithReadonly(false), config.WithDataDir(t.TempDir()), config.WithAuthFile(authFile), WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	return server, root
+}
+
+func serverAuth(docsets map[string]config.DocsetSpec, global map[string]rules.RuleSpec) *config.AuthConfig {
+	for name, docset := range docsets {
+		docset.Access = config.DocsetAccess{Allow: map[string]string{"writer": "rw"}}
+		docsets[name] = docset
+	}
+	return &config.AuthConfig{Rules: global, Roles: map[string]config.RoleSpec{"writer": {}}, Docsets: docsets, Identities: []config.AuthIdentity{{Name: "alice", Roles: []string{"writer"}}}}
+}
+
+func admitServer(server *Server, target, content string) error {
+	_, err := server.writeChain()(context.Background(), NewWriteOp(Attribution{Principal: "alice"}, writeCSBytes(target, content)))
+	return err
+}
+
+func TestRulesServerBootAdmissionAndValidateOutput(t *testing.T) {
+	auth := serverAuth(map[string]config.DocsetSpec{"docs": docset("/docs", nil), "public": docset("/public", nil)}, map[string]rules.RuleSpec{
+		"doc-size": {Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": 3}},
+	})
+	server, root := bootRulesServer(t, auth, nil)
+	if len(server.validators) != 1 {
+		t.Fatalf("validators=%d, want 1", len(server.validators))
+	}
+	if err := admitServer(server, "/docs/ok.md", "1\n2\n3\n"); err != nil {
+		t.Fatalf("three-line write: %v", err)
+	}
+	if err := admitServer(server, "/public/too-long.md", "1\n2\n3\n4\n"); err == nil || !strings.Contains(err.Error(), "rules: /public/too-long.md: size/lines (doc-size @ lore.json)") {
+		t.Fatalf("four-line write error=%v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "too-long.md"), []byte("1\n2\n3\n4\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sh := server.buildSessionShell(Identity{IdentityName: "alice"})
+	var out, errOut bytes.Buffer
+	if code := sh.ExecPipeline("lore validate /docs", &out, &errOut, nil); code != 1 {
+		t.Fatalf("exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
+	}
+	for _, want := range []string{"too-long.md:1:1: error [size/lines] 4 lines exceeds the limit of 3 (max: 3)", "see: lore package doc size/lines", "1 error, 0 warnings"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "suggested:") || strings.Contains(out.String(), "override:") {
+		t.Fatalf("validate leaked write guidance:\n%s", out.String())
+	}
+}
+
+func TestRulesServerBootLegacyOKFMessage(t *testing.T) {
+	server, _ := bootRulesServer(t, serverAuth(map[string]config.DocsetSpec{"docs": docset("/docs", &config.OKFDocsetConfig{})}, nil), nil)
+	err := admitServer(server, "/docs/bad.md", invalidDoc)
+	want := "okf: /docs/bad.md: missing YAML frontmatter block (a concept must open with a '---' delimited block)\n  see: lore package doc okf"
+	if err == nil || err.Error() != want {
+		t.Fatalf("error=%q, want %q", err, want)
+	}
+}
+
+func TestRulesServerPerDocsetAndNonEnforcing(t *testing.T) {
+	var logs bytes.Buffer
+	warn := false
+	backend := docset("/backend", nil)
+	backend.Rules = map[string]rules.RuleSpec{
+		"enforced": {Use: "size/lines", Match: []string{"**/*.md"}, With: map[string]any{"max": 2}},
+		"warning":  {Use: "size/lines", Match: []string{"**/*.md"}, With: map[string]any{"max": 1}, Enforce: &warn},
+	}
+	server, _ := bootRulesServer(t, serverAuth(map[string]config.DocsetSpec{"backend": backend, "public": docset("/public", nil)}, nil), slog.New(slog.NewTextHandler(&logs, nil)))
+	if err := admitServer(server, "/public/a.md", "1\n2\n3\n"); err != nil {
+		t.Fatalf("rule escaped docset: %v", err)
+	}
+	if err := admitServer(server, "/backend/a.md", "1\n2\n3\n"); err == nil || !strings.Contains(err.Error(), "size/lines (enforced @ lore.json#docsets.backend)") {
+		t.Fatalf("docset rule did not reject: %v", err)
+	}
+	if err := admitServer(server, "/backend/warn.md", "1\n2\n"); err != nil {
+		t.Fatalf("non-enforcing rule rejected: %v", err)
+	}
+	if got := logs.String(); !strings.Contains(got, "level=WARN") || !strings.Contains(got, "rule=warning") {
+		t.Fatalf("missing non-enforcing warning: %s", got)
+	}
+}
+
+func TestRulesServerBundleAnchor(t *testing.T) {
+	auth := serverAuth(map[string]config.DocsetSpec{
+		"docs": docset("/docs", &config.OKFDocsetConfig{}),
+		"wiki": docset("/wiki", &config.OKFDocsetConfig{}),
+	}, nil)
+	server, root := bootRulesServer(t, auth, nil)
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("root\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{"docs", "wiki"} {
+		if err := os.WriteFile(filepath.Join(root, dir, "a.md"), []byte("---\ntype: Note\n---\n[missing](b.md)\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sh := server.buildSessionShell(Identity{IdentityName: "alice"})
+	var out, errOut bytes.Buffer
+	if code := sh.ExecPipeline("lore validate /", &out, &errOut, nil); code != 1 {
+		t.Fatalf("root exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
+	}
+	if want := "lore validate: / is above docsets docs, wiki with bundle rules; run lore validate per docset"; !strings.Contains(errOut.String(), want) {
+		t.Fatalf("stderr missing %q: %s", want, errOut.String())
+	}
+	out.Reset()
+	errOut.Reset()
+	if code := sh.ExecPipeline("lore validate /docs", &out, &errOut, nil); code != 1 || !strings.Contains(out.String(), "openlore/broken-link") {
+		t.Fatalf("docs exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
 	}
 }

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aakarim/go-openlore/internal/webstyle"
 	"github.com/aakarim/go-openlore/pkg/openlore/meta"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/rules"
 	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/aakarim/go-openlore/pkg/shell/cmds"
 	"github.com/aakarim/go-openlore/pkg/vfs"
@@ -256,9 +257,18 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 			return nil, err
 		}
 	}
-	if anyDocsetHasOKF(s.auth.Docsets) {
-		if err := s.registerPlugin(newOKF(s.auth.Docsets, logger)); err != nil {
+	if anyConfiguredRules(s.auth) {
+		rulesPlugin, err := newRulesPlugin(s.auth, rules.Defaults{Growth: cfg.Rules.Growth}, logger)
+		if err != nil {
 			return nil, err
+		}
+		if err := s.registerPlugin(rulesPlugin); err != nil {
+			return nil, err
+		}
+		// OKF metadata remains owned by the existing adapter; admission and
+		// validation are provided exclusively by the rules engine above.
+		if anyDocsetHasOKF(s.auth.Docsets) {
+			s.metaExtenders = append(s.metaExtenders, newOKF(s.auth.Docsets, logger).MetaExtenders()...)
 		}
 	}
 	if shellPlugin != nil {

--- a/pkg/openlore/validation/validation.go
+++ b/pkg/openlore/validation/validation.go
@@ -25,7 +25,10 @@ type Diagnostic struct {
 	Column   int
 	Severity Severity
 	Rule     string
-	Message  string
+	// Member is the package member that produced the finding. Empty for
+	// third-party validators that do not participate in rules discoverability.
+	Member  string
+	Message string
 }
 
 type File struct {

--- a/pkg/rules/compile.go
+++ b/pkg/rules/compile.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"path"
 	"reflect"
 	"sort"
 	"strings"
@@ -18,30 +19,31 @@ func (e *UnificationError) Error() string {
 	return fmt.Sprintf("rule %q conflicts between %s and %s (different: %s)", e.Rule, e.OuterOrigin, e.InnerOrigin, strings.Join(e.DifferingKeys, ", "))
 }
 
-func Unify(layers []Layer) (map[string]RuleSpec, map[string][]string, error) {
-	specs := map[string]RuleSpec{}
-	origins := map[string][]string{}
+func Unify(layers []Layer) (map[string]UnifiedRule, error) {
+	unified := map[string]UnifiedRule{}
 	for _, layer := range layers {
 		for name, incoming := range layer.Rules {
-			outer, exists := specs[name]
+			outer, exists := unified[name]
 			if !exists {
-				specs[name], origins[name] = incoming, []string{layer.Origin}
+				unified[name] = UnifiedRule{Spec: incoming, Origins: []string{layer.Origin}, Scope: layer.Scope}
 				continue
 			}
-			if outer.Default {
-				specs[name], origins[name] = incoming, append(origins[name], layer.Origin)
+			if outer.Spec.Default {
+				unified[name] = UnifiedRule{Spec: incoming, Origins: append(outer.Origins, layer.Origin), Scope: layer.Scope}
 				continue
 			}
-			if keys := differingKeys(outer, incoming); len(keys) != 0 {
-				return nil, nil, &UnificationError{Rule: name, OuterOrigin: origins[name][len(origins[name])-1], InnerOrigin: layer.Origin, DifferingKeys: keys}
+			if keys := DifferingKeys(outer.Spec, incoming); len(keys) != 0 {
+				return nil, &UnificationError{Rule: name, OuterOrigin: outer.Origins[len(outer.Origins)-1], InnerOrigin: layer.Origin, DifferingKeys: keys}
 			}
-			origins[name] = append(origins[name], layer.Origin)
+			outer.Origins = append(outer.Origins, layer.Origin)
+			unified[name] = outer
 		}
 	}
-	return specs, origins, nil
+	return unified, nil
 }
 
-func differingKeys(a, b RuleSpec) []string {
+// DifferingKeys returns normalized semantic fields that differ between specs.
+func DifferingKeys(a, b RuleSpec) []string {
 	var keys []string
 	if !reflect.DeepEqual(normalizeStrings(a.Match), normalizeStrings(b.Match)) {
 		keys = append(keys, "match")
@@ -71,18 +73,25 @@ func normalizeStrings(v []string) []string {
 	return v
 }
 
-func Compile(reg *Registry, env func(string) Env, specs map[string]RuleSpec, origins map[string][]string, scope string) ([]CompiledRule, error) {
+func Compile(reg *Registry, env func(string) Env, unified map[string]UnifiedRule) ([]CompiledRule, error) {
 	if reg == nil {
 		return nil, fmt.Errorf("rules: nil registry")
 	}
-	names := make([]string, 0, len(specs))
-	for name := range specs {
+	names := make([]string, 0, len(unified))
+	for name := range unified {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 	out := make([]CompiledRule, 0, len(names))
 	for _, name := range names {
-		spec := specs[name]
+		rule := unified[name]
+		spec := rule.Spec
+		if err := validateGlobs(name, "match", spec.Match); err != nil {
+			return nil, err
+		}
+		if err := validateGlobs(name, "exclude", spec.Exclude); err != nil {
+			return nil, err
+		}
 		member, ok := reg.Lookup(spec.Use)
 		if !ok {
 			suffix := ""
@@ -107,9 +116,23 @@ func Compile(reg *Registry, env func(string) Env, specs map[string]RuleSpec, ori
 		if err != nil {
 			return nil, fmt.Errorf("rules.%s.with: %w", name, err)
 		}
-		out = append(out, CompiledRule{Name: name, Spec: spec, Origins: origins[name], Scope: scope, Member: member, Check: check})
+		out = append(out, CompiledRule{Name: name, Spec: spec, Origins: rule.Origins, Scope: rule.Scope, Member: member, Check: check})
 	}
 	return out, nil
+}
+
+func validateGlobs(rule, field string, patterns []string) error {
+	for i, pattern := range patterns {
+		for _, segment := range split(pattern) {
+			if segment == "**" {
+				continue
+			}
+			if _, err := path.Match(segment, ""); err != nil {
+				return fmt.Errorf("rules.%s.%s[%d]: invalid glob %q: %w", rule, field, i, pattern, err)
+			}
+		}
+	}
+	return nil
 }
 
 func validateParams(rule string, with map[string]any, manifest Manifest) error {

--- a/pkg/rules/compile.go
+++ b/pkg/rules/compile.go
@@ -1,0 +1,213 @@
+package rules
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+type UnificationError struct {
+	Rule          string
+	OuterOrigin   string
+	InnerOrigin   string
+	DifferingKeys []string
+}
+
+func (e *UnificationError) Error() string {
+	return fmt.Sprintf("rule %q conflicts between %s and %s (different: %s)", e.Rule, e.OuterOrigin, e.InnerOrigin, strings.Join(e.DifferingKeys, ", "))
+}
+
+func Unify(layers []Layer) (map[string]RuleSpec, map[string][]string, error) {
+	specs := map[string]RuleSpec{}
+	origins := map[string][]string{}
+	for _, layer := range layers {
+		for name, incoming := range layer.Rules {
+			outer, exists := specs[name]
+			if !exists {
+				specs[name], origins[name] = incoming, []string{layer.Origin}
+				continue
+			}
+			if outer.Default {
+				specs[name], origins[name] = incoming, append(origins[name], layer.Origin)
+				continue
+			}
+			if keys := differingKeys(outer, incoming); len(keys) != 0 {
+				return nil, nil, &UnificationError{Rule: name, OuterOrigin: origins[name][len(origins[name])-1], InnerOrigin: layer.Origin, DifferingKeys: keys}
+			}
+			origins[name] = append(origins[name], layer.Origin)
+		}
+	}
+	return specs, origins, nil
+}
+
+func differingKeys(a, b RuleSpec) []string {
+	var keys []string
+	if !reflect.DeepEqual(normalizeStrings(a.Match), normalizeStrings(b.Match)) {
+		keys = append(keys, "match")
+	}
+	if !reflect.DeepEqual(normalizeStrings(a.Exclude), normalizeStrings(b.Exclude)) {
+		keys = append(keys, "exclude")
+	}
+	if a.Use != b.Use {
+		keys = append(keys, "use")
+	}
+	if !reflect.DeepEqual(a.With, b.With) {
+		keys = append(keys, "with")
+	}
+	if a.IsEnforcing() != b.IsEnforcing() {
+		keys = append(keys, "enforce")
+	}
+	if a.Default != b.Default {
+		keys = append(keys, "default")
+	}
+	return keys
+}
+
+func normalizeStrings(v []string) []string {
+	if len(v) == 0 {
+		return nil
+	}
+	return v
+}
+
+func Compile(reg *Registry, env func(string) Env, specs map[string]RuleSpec, origins map[string][]string, scope string) ([]CompiledRule, error) {
+	if reg == nil {
+		return nil, fmt.Errorf("rules: nil registry")
+	}
+	names := make([]string, 0, len(specs))
+	for name := range specs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]CompiledRule, 0, len(names))
+	for _, name := range names {
+		spec := specs[name]
+		member, ok := reg.Lookup(spec.Use)
+		if !ok {
+			suffix := ""
+			if suggestion := reg.Suggest(spec.Use); suggestion != "" {
+				suffix = fmt.Sprintf(" (did you mean %q?)", suggestion)
+			}
+			return nil, fmt.Errorf("rules.%s.use: unknown member %q%s", name, spec.Use, suffix)
+		}
+		with := make(map[string]any, len(spec.With))
+		for key, value := range spec.With {
+			with[key] = value
+		}
+		for _, param := range member.Manifest().Params {
+			if _, ok := with[param.Name]; !ok && param.Default != nil {
+				with[param.Name] = param.Default
+			}
+		}
+		if err := validateParams(name, with, member.Manifest()); err != nil {
+			return nil, err
+		}
+		check, err := member.Compile(with, env(spec.Use))
+		if err != nil {
+			return nil, fmt.Errorf("rules.%s.with: %w", name, err)
+		}
+		out = append(out, CompiledRule{Name: name, Spec: spec, Origins: origins[name], Scope: scope, Member: member, Check: check})
+	}
+	return out, nil
+}
+
+func validateParams(rule string, with map[string]any, manifest Manifest) error {
+	params := map[string]Param{}
+	for _, p := range manifest.Params {
+		params[p.Name] = p
+	}
+	for name, value := range with {
+		p, ok := params[name]
+		if !ok {
+			alternatives := make([]string, 0, len(params))
+			for n := range params {
+				alternatives = append(alternatives, n)
+			}
+			suffix := ""
+			if near := nearest(name, alternatives); near != "" {
+				suffix = fmt.Sprintf(" (did you mean %q?)", near)
+			}
+			return fmt.Errorf("rules.%s.with.%s: unknown parameter for %s%s", rule, name, manifest.Path, suffix)
+		}
+		if !valueHasType(value, p.Type) {
+			return fmt.Errorf("rules.%s.with.%s: expected %s", rule, name, p.Type)
+		}
+	}
+	for _, p := range manifest.Params {
+		if p.Required {
+			if _, ok := with[p.Name]; !ok {
+				return fmt.Errorf("rules.%s.with.%s: required parameter for %s", rule, p.Name, manifest.Path)
+			}
+		}
+	}
+	return nil
+}
+
+func valueHasType(v any, typ ParamType) bool {
+	switch typ {
+	case ParamInteger:
+		_, ok := integer(v)
+		return ok
+	case ParamNumber:
+		_, ok := number(v)
+		return ok
+	case ParamString:
+		_, ok := v.(string)
+		return ok
+	case ParamBool:
+		_, ok := v.(bool)
+		return ok
+	case ParamIntegerOrInitial:
+		if s, ok := v.(string); ok {
+			return s == "initial"
+		}
+		_, ok := integer(v)
+		return ok
+	default:
+		return false
+	}
+}
+
+func integer(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), n == float64(int64(n))
+	case float32:
+		return int64(n), n == float32(int64(n))
+	default:
+		return 0, false
+	}
+}
+
+func number(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+func nearest(got string, values []string) string {
+	best, score := "", 1<<30
+	for _, v := range values {
+		if d := distance(got, v); d < score {
+			best, score = v, d
+		}
+	}
+	if score <= 3 {
+		return best
+	}
+	return ""
+}

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -1,0 +1,263 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type Options struct {
+	Registry *Registry
+	Config   LayerSource
+	Folders  LayerSource
+	Env      func(string) Env
+	Logger   *slog.Logger
+}
+
+type Engine struct{ options Options }
+
+func New(options Options) *Engine { return &Engine{options: options} }
+
+func (e *Engine) Effective(ctx context.Context, target string) ([]CompiledRule, error) {
+	var layers []Layer
+	for _, source := range []LayerSource{e.options.Config, e.options.Folders} {
+		if source == nil {
+			continue
+		}
+		got, err := source.LayersFor(ctx, target)
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, got...)
+	}
+	if len(layers) == 0 {
+		return nil, nil
+	}
+	specs, origins, err := Unify(layers)
+	if err != nil {
+		return nil, err
+	}
+	scope := layers[len(layers)-1].Scope
+	env := e.options.Env
+	if env == nil {
+		env = func(string) Env { return Env{} }
+	}
+	return Compile(e.options.Registry, env, specs, origins, scope)
+}
+
+func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, existing func() ([]byte, bool, error)) error {
+	if leaf.Action != vfs.ChangeActionWrite || leaf.Write == nil {
+		return nil
+	}
+	rules, err := e.Effective(ctx, leaf.Target)
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		if rule.Member.Manifest().Scope != ScopeFile || !matchesAtScope(rule, leaf.Target) {
+			continue
+		}
+		findings, checkErr := rule.Check.Evaluate(ctx, Subject{Mode: ModeAdmit, Path: leaf.Target, Dir: path.Dir(leaf.Target), Content: leaf.Write.Bytes, Existing: existing, Actor: actor})
+		if checkErr != nil {
+			if rule.Spec.IsEnforcing() {
+				return &Rejection{Path: leaf.Target, Rule: rule.Name, Member: rule.Spec.Use, Origin: last(rule.Origins), Err: checkErr}
+			}
+			e.warn(rule, leaf.Target, checkErr.Error())
+			continue
+		}
+		if len(findings) == 0 {
+			continue
+		}
+		if rule.Spec.IsEnforcing() {
+			return &Rejection{Path: leaf.Target, Rule: rule.Name, Member: rule.Spec.Use, Origin: last(rule.Origins), Findings: findings}
+		}
+		for _, finding := range findings {
+			e.warn(rule, leaf.Target, findingText(finding, rule, leaf.Target))
+		}
+	}
+	return nil
+}
+
+func (e *Engine) ValidateFile(ctx context.Context, fsys vfs.FileSystem, bundleRoot, target string, content []byte) []validation.Diagnostic {
+	return e.validateFile(ctx, fsys, bundleRoot, target, content, nil)
+}
+
+func (e *Engine) validateFile(ctx context.Context, fsys vfs.FileSystem, bundleRoot, target string, content []byte, bundle *validation.Bundle) []validation.Diagnostic {
+	rules, err := e.Effective(ctx, target)
+	if err != nil {
+		return []validation.Diagnostic{{Path: relative(bundleRoot, target), Line: 1, Column: 1, Severity: validation.SeverityError, Rule: "rules/config", Message: err.Error()}}
+	}
+	var diagnostics []validation.Diagnostic
+	for _, rule := range rules {
+		if rule.Member.Manifest().Scope == ScopeBundle {
+			if bundle == nil || len(bundle.Files) == 0 || target != bundle.Files[0].AbsolutePath || !bundleMatches(rule, bundle) {
+				continue
+			}
+		} else if !matchesAtScope(rule, target) {
+			continue
+		}
+		findings, checkErr := rule.Check.Evaluate(ctx, Subject{Mode: ModeValidate, Path: target, Dir: path.Dir(target), Content: content, FS: fsys, BundleRoot: bundleRoot, Bundle: bundle})
+		severity := validation.SeverityWarning
+		if rule.Spec.IsEnforcing() {
+			severity = validation.SeverityError
+		}
+		if checkErr != nil {
+			diagnostics = append(diagnostics, validation.Diagnostic{Path: relative(bundleRoot, target), Line: 1, Column: 1, Severity: severity, Rule: rule.Name, Message: checkErr.Error()})
+			continue
+		}
+		for _, finding := range findings {
+			findingSeverity := severity
+			if finding.Warning {
+				findingSeverity = validation.SeverityWarning
+			}
+			p := finding.Path
+			if p == "" {
+				p = target
+			}
+			if strings.HasPrefix(p, "/") {
+				p = relative(bundleRoot, p)
+			}
+			line, column := finding.Line, finding.Column
+			if line == 0 {
+				line = 1
+			}
+			if column == 0 {
+				column = 1
+			}
+			diagnostics = append(diagnostics, validation.Diagnostic{Path: p, Line: line, Column: column, Severity: findingSeverity, Rule: finding.Code, Message: findingText(finding, rule, target)})
+		}
+	}
+	return diagnostics
+}
+
+func (e *Engine) Validator() validation.Validator {
+	return func(bundle validation.Bundle) []validation.Diagnostic {
+		var out []validation.Diagnostic
+		for _, file := range bundle.Files {
+			out = append(out, e.validateFile(context.Background(), bundle.FS, bundle.Root, file.AbsolutePath, file.Content, &bundle)...)
+		}
+		return out
+	}
+}
+
+func (e *Engine) ValidateBundle(ctx context.Context, fsys vfs.FileSystem, root string) ([]validation.Diagnostic, error) {
+	_ = ctx
+	return validation.Scan(fsys, root, e.Validator())
+}
+
+func matchesAtScope(rule CompiledRule, target string) bool {
+	rel, ok := relativeTo(rule.Scope, target)
+	return ok && Matches(rule.Spec, rel)
+}
+
+func bundleMatches(rule CompiledRule, bundle *validation.Bundle) bool {
+	for _, file := range bundle.Files {
+		if matchesAtScope(rule, file.AbsolutePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func relativeTo(root, target string) (string, bool) {
+	root, target = vfs.CleanPath(root), vfs.CleanPath(target)
+	if root == "/" {
+		return strings.TrimPrefix(target, "/"), true
+	}
+	if target == root {
+		return path.Base(target), true
+	}
+	if !strings.HasPrefix(target, root+"/") {
+		return "", false
+	}
+	return strings.TrimPrefix(target, root+"/"), true
+}
+
+func relative(root, target string) string {
+	rel, ok := relativeTo(root, target)
+	if ok {
+		return rel
+	}
+	return target
+}
+func last(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[len(values)-1]
+}
+
+func (e *Engine) warn(rule CompiledRule, target, message string) {
+	if e.options.Logger != nil {
+		e.options.Logger.Warn("rule violation (non-enforcing)", "path", target, "rule", rule.Name, "member", rule.Spec.Use, "message", message)
+	}
+}
+
+type Rejection struct {
+	Path     string
+	Rule     string
+	Member   string
+	Origin   string
+	Findings []Finding
+	Err      error
+}
+
+func (r *Rejection) Error() string {
+	if r.Member == "okf" && r.Err != nil {
+		return fmt.Sprintf("okf: %s: %v", r.Path, r.Err)
+	}
+	if r.Member == "okf" && len(r.Findings) != 0 {
+		return fmt.Sprintf("okf: %s: %s", r.Path, r.Findings[0].Measured)
+	}
+	header := fmt.Sprintf("rules: %s: %s (%s @ %s)", r.Path, r.Member, r.Rule, r.Origin)
+	if r.Err != nil {
+		return header + "\n  " + r.Err.Error()
+	}
+	parts := []string{header}
+	for _, finding := range r.Findings {
+		parts = append(parts, indent(findingText(finding, CompiledRule{Name: r.Rule, Spec: RuleSpec{Use: r.Member}, Origins: []string{r.Origin}}, r.Path)))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func (r *Rejection) Unwrap() error { return r.Err }
+
+func findingText(f Finding, rule CompiledRule, target string) string {
+	limit := f.Limit
+	if limit == "" {
+		limit = "this write cannot proceed under this rule"
+	}
+	remedy := f.Remedy
+	if remedy == "" {
+		remedy = "change the file so it satisfies the rule"
+	}
+	override := f.Override
+	if override == "" {
+		if strings.HasPrefix(rule.Spec.Use, "size/") {
+			override = fmt.Sprintf("to raise the limit, edit %s in %s", rule.Name, last(rule.Origins))
+		} else {
+			override = fmt.Sprintf("edit %s in %s", rule.Name, last(rule.Origins))
+		}
+	}
+	return strings.Join([]string{f.Measured, limit, "suggested: " + remedy, "override: " + override, "see: lore package doc " + rule.Spec.Use}, "\n")
+}
+
+func indent(s string) string { return "  " + strings.ReplaceAll(s, "\n", "\n  ") }
+
+func SortDiagnostics(d []validation.Diagnostic) {
+	sort.SliceStable(d, func(i, j int) bool {
+		if d[i].Path != d[j].Path {
+			return d[i].Path < d[j].Path
+		}
+		if d[i].Line != d[j].Line {
+			return d[i].Line < d[j].Line
+		}
+		return d[i].Rule < d[j].Rule
+	})
+}

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path"
@@ -22,6 +23,18 @@ type Options struct {
 
 type Engine struct{ options Options }
 
+// BundleRootError reports that validation was requested above independently
+// governed docsets. Running bundle rules there would silently choose the wrong
+// configuration boundary.
+type BundleRootError struct {
+	Root    string
+	Docsets []string
+}
+
+func (e *BundleRootError) Error() string {
+	return fmt.Sprintf("%s is above docsets %s with bundle rules; run lore validate per docset", e.Root, strings.Join(e.Docsets, ", "))
+}
+
 func New(options Options) *Engine { return &Engine{options: options} }
 
 func (e *Engine) Effective(ctx context.Context, target string) ([]CompiledRule, error) {
@@ -39,16 +52,15 @@ func (e *Engine) Effective(ctx context.Context, target string) ([]CompiledRule, 
 	if len(layers) == 0 {
 		return nil, nil
 	}
-	specs, origins, err := Unify(layers)
+	unified, err := Unify(layers)
 	if err != nil {
 		return nil, err
 	}
-	scope := layers[len(layers)-1].Scope
 	env := e.options.Env
 	if env == nil {
 		env = func(string) Env { return Env{} }
 	}
-	return Compile(e.options.Registry, env, specs, origins, scope)
+	return Compile(e.options.Registry, env, unified)
 }
 
 func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, existing func() ([]byte, bool, error)) error {
@@ -71,13 +83,21 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 			e.warn(rule, leaf.Target, checkErr.Error())
 			continue
 		}
-		if len(findings) == 0 {
+		var violations []Finding
+		for _, finding := range findings {
+			if finding.Warning {
+				e.warn(rule, leaf.Target, finding.Measured)
+			} else {
+				violations = append(violations, finding)
+			}
+		}
+		if len(violations) == 0 {
 			continue
 		}
 		if rule.Spec.IsEnforcing() {
-			return &Rejection{Path: leaf.Target, Rule: rule.Name, Member: rule.Spec.Use, Origin: last(rule.Origins), Findings: findings}
+			return &Rejection{Path: leaf.Target, Rule: rule.Name, Member: rule.Spec.Use, Origin: last(rule.Origins), Findings: violations}
 		}
-		for _, finding := range findings {
+		for _, finding := range violations {
 			e.warn(rule, leaf.Target, findingText(finding, rule, leaf.Target))
 		}
 	}
@@ -95,11 +115,7 @@ func (e *Engine) validateFile(ctx context.Context, fsys vfs.FileSystem, bundleRo
 	}
 	var diagnostics []validation.Diagnostic
 	for _, rule := range rules {
-		if rule.Member.Manifest().Scope == ScopeBundle {
-			if bundle == nil || len(bundle.Files) == 0 || target != bundle.Files[0].AbsolutePath || !bundleMatches(rule, bundle) {
-				continue
-			}
-		} else if !matchesAtScope(rule, target) {
+		if rule.Member.Manifest().Scope != ScopeFile || !matchesAtScope(rule, target) {
 			continue
 		}
 		findings, checkErr := rule.Check.Evaluate(ctx, Subject{Mode: ModeValidate, Path: target, Dir: path.Dir(target), Content: content, FS: fsys, BundleRoot: bundleRoot, Bundle: bundle})
@@ -108,7 +124,7 @@ func (e *Engine) validateFile(ctx context.Context, fsys vfs.FileSystem, bundleRo
 			severity = validation.SeverityError
 		}
 		if checkErr != nil {
-			diagnostics = append(diagnostics, validation.Diagnostic{Path: relative(bundleRoot, target), Line: 1, Column: 1, Severity: severity, Rule: rule.Name, Message: checkErr.Error()})
+			diagnostics = append(diagnostics, validation.Diagnostic{Path: relative(bundleRoot, target), Line: 1, Column: 1, Severity: severity, Rule: rule.Name, Member: rule.Spec.Use, Message: checkErr.Error()})
 			continue
 		}
 		for _, finding := range findings {
@@ -130,7 +146,7 @@ func (e *Engine) validateFile(ctx context.Context, fsys vfs.FileSystem, bundleRo
 			if column == 0 {
 				column = 1
 			}
-			diagnostics = append(diagnostics, validation.Diagnostic{Path: p, Line: line, Column: column, Severity: findingSeverity, Rule: finding.Code, Message: findingText(finding, rule, target)})
+			diagnostics = append(diagnostics, validation.Diagnostic{Path: p, Line: line, Column: column, Severity: findingSeverity, Rule: finding.Code, Member: rule.Spec.Use, Message: finding.Measured})
 		}
 	}
 	return diagnostics
@@ -139,9 +155,54 @@ func (e *Engine) validateFile(ctx context.Context, fsys vfs.FileSystem, bundleRo
 func (e *Engine) Validator() validation.Validator {
 	return func(bundle validation.Bundle) []validation.Diagnostic {
 		var out []validation.Diagnostic
+		bundleRules, err := e.Effective(context.Background(), bundle.Root)
+		if err != nil {
+			rule := "rules/config"
+			var rootErr *BundleRootError
+			if errors.As(err, &rootErr) {
+				rule = "rules/bundle-root"
+			}
+			return []validation.Diagnostic{{Path: bundle.Root, Line: 1, Column: 1, Severity: validation.SeverityError, Rule: rule, Message: err.Error()}}
+		}
 		for _, file := range bundle.Files {
 			out = append(out, e.validateFile(context.Background(), bundle.FS, bundle.Root, file.AbsolutePath, file.Content, &bundle)...)
 		}
+		for _, rule := range bundleRules {
+			if rule.Member.Manifest().Scope != ScopeBundle || !bundleMatches(rule, &bundle) {
+				continue
+			}
+			findings, checkErr := rule.Check.Evaluate(context.Background(), Subject{Mode: ModeValidate, Path: bundle.Root, Dir: bundle.Root, FS: bundle.FS, BundleRoot: bundle.Root, Bundle: &bundle})
+			severity := validation.SeverityWarning
+			if rule.Spec.IsEnforcing() {
+				severity = validation.SeverityError
+			}
+			if checkErr != nil {
+				out = append(out, validation.Diagnostic{Path: ".", Line: 1, Column: 1, Severity: severity, Rule: rule.Name, Member: rule.Spec.Use, Message: checkErr.Error()})
+				continue
+			}
+			for _, finding := range findings {
+				findingSeverity := severity
+				if finding.Warning {
+					findingSeverity = validation.SeverityWarning
+				}
+				p := finding.Path
+				if p == "" {
+					p = "."
+				}
+				if strings.HasPrefix(p, "/") {
+					p = relative(bundle.Root, p)
+				}
+				line, column := finding.Line, finding.Column
+				if line == 0 {
+					line = 1
+				}
+				if column == 0 {
+					column = 1
+				}
+				out = append(out, validation.Diagnostic{Path: p, Line: line, Column: column, Severity: findingSeverity, Rule: finding.Code, Member: rule.Spec.Use, Message: finding.Measured})
+			}
+		}
+		SortDiagnostics(out)
 		return out
 	}
 }
@@ -209,11 +270,8 @@ type Rejection struct {
 }
 
 func (r *Rejection) Error() string {
-	if r.Member == "okf" && r.Err != nil {
-		return fmt.Sprintf("okf: %s: %v", r.Path, r.Err)
-	}
 	if r.Member == "okf" && len(r.Findings) != 0 {
-		return fmt.Sprintf("okf: %s: %s", r.Path, r.Findings[0].Measured)
+		return fmt.Sprintf("okf: %s: %s\n  see: lore package doc okf", r.Path, r.Findings[0].Measured)
 	}
 	header := fmt.Sprintf("rules: %s: %s (%s @ %s)", r.Path, r.Member, r.Rule, r.Origin)
 	if r.Err != nil {
@@ -229,13 +287,12 @@ func (r *Rejection) Error() string {
 func (r *Rejection) Unwrap() error { return r.Err }
 
 func findingText(f Finding, rule CompiledRule, target string) string {
-	limit := f.Limit
-	if limit == "" {
-		limit = "this write cannot proceed under this rule"
+	lines := []string{f.Measured}
+	if f.Limit != "" {
+		lines = append(lines, f.Limit)
 	}
-	remedy := f.Remedy
-	if remedy == "" {
-		remedy = "change the file so it satisfies the rule"
+	if f.Remedy != "" {
+		lines = append(lines, "suggested: "+f.Remedy)
 	}
 	override := f.Override
 	if override == "" {
@@ -245,7 +302,11 @@ func findingText(f Finding, rule CompiledRule, target string) string {
 			override = fmt.Sprintf("edit %s in %s", rule.Name, last(rule.Origins))
 		}
 	}
-	return strings.Join([]string{f.Measured, limit, "suggested: " + remedy, "override: " + override, "see: lore package doc " + rule.Spec.Use}, "\n")
+	if override != "" {
+		lines = append(lines, "override: "+override)
+	}
+	lines = append(lines, "see: lore package doc "+rule.Spec.Use)
+	return strings.Join(lines, "\n")
 }
 
 func indent(s string) string { return "  " + strings.ReplaceAll(s, "\n", "\n  ") }

--- a/pkg/rules/engine_test.go
+++ b/pkg/rules/engine_test.go
@@ -1,0 +1,66 @@
+package rules
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type testSource []Layer
+
+func (s testSource) LayersFor(context.Context, string) ([]Layer, error) { return s, nil }
+
+type testMember struct {
+	manifest Manifest
+	calls    *int
+}
+
+func (m testMember) Manifest() Manifest { return m.manifest }
+func (m testMember) Compile(map[string]any, Env) (Check, error) {
+	return testCheck{calls: m.calls}, nil
+}
+
+type testCheck struct{ calls *int }
+
+func (c testCheck) Evaluate(context.Context, Subject) ([]Finding, error) {
+	if c.calls != nil {
+		(*c.calls)++
+	}
+	return nil, nil
+}
+func (testCheck) OnRemove(context.Context, string) error       { return nil }
+func (testCheck) OnMove(context.Context, string, string) error { return nil }
+
+func TestAdmitLeafNeverCallsBundleRule(t *testing.T) {
+	calls := 0
+	registry := NewRegistry()
+	registry.Register(testMember{manifest: Manifest{Path: "test/bundle", Kind: KindRule, Scope: ScopeBundle}, calls: &calls})
+	engine := New(Options{Registry: registry, Config: testSource{{Origin: "test", Scope: "/", Rules: map[string]RuleSpec{"bundle": {Match: []string{"**"}, Use: "test/bundle"}}}}})
+	err := engine.AdmitLeaf(context.Background(), vfs.Change{Target: "/a.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("x")}}, "test", nil)
+	if err != nil || calls != 0 {
+		t.Fatalf("err=%v calls=%d", err, calls)
+	}
+}
+
+func TestCompileReportsSuggestionsAndTypes(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(testMember{manifest: Manifest{Path: "size/lines", Kind: KindRule, Scope: ScopeFile, Params: []Param{{Name: "max", Type: ParamInteger, Required: true}}}})
+	compile := func(spec RuleSpec) error {
+		_, err := Compile(registry, func(string) Env { return Env{} }, map[string]RuleSpec{"limit": spec}, map[string][]string{"limit": {"test"}}, "/")
+		return err
+	}
+	if err := compile(RuleSpec{Use: "size/line", With: map[string]any{"max": 3}}); err == nil || !strings.Contains(err.Error(), `did you mean "size/lines"`) {
+		t.Fatalf("unknown member error=%v", err)
+	}
+	if err := compile(RuleSpec{Use: "size/lines", With: map[string]any{"maxx": 3}}); err == nil || !strings.Contains(err.Error(), `did you mean "max"`) {
+		t.Fatalf("unknown param error=%v", err)
+	}
+	if err := compile(RuleSpec{Use: "size/lines", With: map[string]any{"max": "three"}}); err == nil || !strings.Contains(err.Error(), "expected integer") {
+		t.Fatalf("type error=%v", err)
+	}
+	if err := compile(RuleSpec{Use: "size/lines"}); err == nil || !strings.Contains(err.Error(), "required parameter") {
+		t.Fatalf("missing error=%v", err)
+	}
+}

--- a/pkg/rules/engine_test.go
+++ b/pkg/rules/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -15,18 +16,25 @@ func (s testSource) LayersFor(context.Context, string) ([]Layer, error) { return
 type testMember struct {
 	manifest Manifest
 	calls    *int
+	subjects *[]Subject
 }
 
 func (m testMember) Manifest() Manifest { return m.manifest }
 func (m testMember) Compile(map[string]any, Env) (Check, error) {
-	return testCheck{calls: m.calls}, nil
+	return testCheck{calls: m.calls, subjects: m.subjects}, nil
 }
 
-type testCheck struct{ calls *int }
+type testCheck struct {
+	calls    *int
+	subjects *[]Subject
+}
 
-func (c testCheck) Evaluate(context.Context, Subject) ([]Finding, error) {
+func (c testCheck) Evaluate(_ context.Context, subject Subject) ([]Finding, error) {
 	if c.calls != nil {
 		(*c.calls)++
+	}
+	if c.subjects != nil {
+		*c.subjects = append(*c.subjects, subject)
 	}
 	return nil, nil
 }
@@ -44,11 +52,24 @@ func TestAdmitLeafNeverCallsBundleRule(t *testing.T) {
 	}
 }
 
+func TestValidatorCallsBundleRuleOnceAtBundleRoot(t *testing.T) {
+	calls := 0
+	var subjects []Subject
+	registry := NewRegistry()
+	registry.Register(testMember{manifest: Manifest{Path: "test/bundle", Kind: KindRule, Scope: ScopeBundle}, calls: &calls, subjects: &subjects})
+	engine := New(Options{Registry: registry, Config: testSource{{Origin: "test", Scope: "/docs", Rules: map[string]RuleSpec{"bundle": {Match: []string{"**"}, Use: "test/bundle"}}}}})
+	bundle := validation.Bundle{Root: "/docs", Files: []validation.File{{AbsolutePath: "/docs/a.md"}, {AbsolutePath: "/docs/b.md"}}}
+	engine.Validator()(bundle)
+	if calls != 1 || len(subjects) != 1 || subjects[0].Path != bundle.Root {
+		t.Fatalf("calls=%d subjects=%#v", calls, subjects)
+	}
+}
+
 func TestCompileReportsSuggestionsAndTypes(t *testing.T) {
 	registry := NewRegistry()
 	registry.Register(testMember{manifest: Manifest{Path: "size/lines", Kind: KindRule, Scope: ScopeFile, Params: []Param{{Name: "max", Type: ParamInteger, Required: true}}}})
 	compile := func(spec RuleSpec) error {
-		_, err := Compile(registry, func(string) Env { return Env{} }, map[string]RuleSpec{"limit": spec}, map[string][]string{"limit": {"test"}}, "/")
+		_, err := Compile(registry, func(string) Env { return Env{} }, map[string]UnifiedRule{"limit": {Spec: spec, Origins: []string{"test"}, Scope: "/"}})
 		return err
 	}
 	if err := compile(RuleSpec{Use: "size/line", With: map[string]any{"max": 3}}); err == nil || !strings.Contains(err.Error(), `did you mean "size/lines"`) {
@@ -62,5 +83,22 @@ func TestCompileReportsSuggestionsAndTypes(t *testing.T) {
 	}
 	if err := compile(RuleSpec{Use: "size/lines"}); err == nil || !strings.Contains(err.Error(), "required parameter") {
 		t.Fatalf("missing error=%v", err)
+	}
+}
+
+func TestCompileRejectsInvalidGlobs(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(testMember{manifest: Manifest{Path: "test/rule", Kind: KindRule, Scope: ScopeFile}})
+	for _, test := range []struct {
+		field string
+		spec  RuleSpec
+	}{
+		{field: "match", spec: RuleSpec{Use: "test/rule", Match: []string{"docs/["}}},
+		{field: "exclude", spec: RuleSpec{Use: "test/rule", Match: []string{"**"}, Exclude: []string{"docs/["}}},
+	} {
+		_, err := Compile(registry, func(string) Env { return Env{} }, map[string]UnifiedRule{"broken": {Spec: test.spec, Origins: []string{"test"}, Scope: "/"}})
+		if err == nil || !strings.Contains(err.Error(), "rules.broken."+test.field+"[0]: invalid glob") {
+			t.Errorf("%s error=%v", test.field, err)
+		}
 	}
 }

--- a/pkg/rules/link/link.go
+++ b/pkg/rules/link/link.go
@@ -13,8 +13,7 @@ import (
 )
 
 type Member struct {
-	Alias      bool
-	AliasRoots []string
+	Alias bool
 }
 
 func init() {
@@ -28,8 +27,8 @@ func (m Member) Manifest() rules.Manifest {
 	}
 	return rules.Manifest{Path: "link/resolves", Kind: rules.KindRule, Scope: rules.ScopeBundle, Summary: "Require local links to resolve inside the bundle"}
 }
-func (m Member) Compile(_ map[string]any, _ rules.Env) (rules.Check, error) {
-	roots := append([]string(nil), m.AliasRoots...)
+func (m Member) Compile(_ map[string]any, env rules.Env) (rules.Check, error) {
+	roots := append([]string(nil), env.AliasRoots...)
 	sort.Slice(roots, func(i, j int) bool { return len(roots[i]) > len(roots[j]) })
 	return check{alias: m.Alias, aliasRoots: roots}, nil
 }
@@ -40,7 +39,7 @@ type check struct {
 }
 
 func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Finding, error) {
-	if subject.Bundle == nil || len(subject.Bundle.Files) == 0 || subject.Path != subject.Bundle.Files[0].AbsolutePath {
+	if subject.Bundle == nil {
 		return nil, nil
 	}
 	var findings []rules.Finding

--- a/pkg/rules/link/link.go
+++ b/pkg/rules/link/link.go
@@ -1,0 +1,96 @@
+package link
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/aakarim/go-openlore/pkg/okf"
+	"github.com/aakarim/go-openlore/pkg/rules"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type Member struct {
+	Alias      bool
+	AliasRoots []string
+}
+
+func init() {
+	rules.Register(Member{})
+	rules.Register(Member{Alias: true})
+}
+
+func (m Member) Manifest() rules.Manifest {
+	if m.Alias {
+		return rules.Manifest{Path: "link/alias", Kind: rules.KindRule, Scope: rules.ScopeBundle, Summary: "Warn on links involving aliased docset paths"}
+	}
+	return rules.Manifest{Path: "link/resolves", Kind: rules.KindRule, Scope: rules.ScopeBundle, Summary: "Require local links to resolve inside the bundle"}
+}
+func (m Member) Compile(_ map[string]any, _ rules.Env) (rules.Check, error) {
+	roots := append([]string(nil), m.AliasRoots...)
+	sort.Slice(roots, func(i, j int) bool { return len(roots[i]) > len(roots[j]) })
+	return check{alias: m.Alias, aliasRoots: roots}, nil
+}
+
+type check struct {
+	alias      bool
+	aliasRoots []string
+}
+
+func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Finding, error) {
+	if subject.Bundle == nil || len(subject.Bundle.Files) == 0 || subject.Path != subject.Bundle.Files[0].AbsolutePath {
+		return nil, nil
+	}
+	var findings []rules.Finding
+	for _, file := range subject.Bundle.Files {
+		if path.Ext(file.Path) != ".md" {
+			continue
+		}
+		for _, markdownLink := range okf.Links(file.Content) {
+			local, ok := okf.LocalLinkPath(markdownLink.Destination)
+			if !ok {
+				continue
+			}
+			target := path.Join(path.Dir(file.AbsolutePath), local)
+			if strings.HasPrefix(local, "/") {
+				target = path.Join(subject.Bundle.Root, strings.TrimPrefix(local, "/"))
+			}
+			target = vfs.CleanPath(target)
+			if c.alias {
+				if aliasRoot(file.AbsolutePath, c.aliasRoots) != "" {
+					findings = append(findings, finding(file.Path, markdownLink, "openlore/alias-referrer", "link originates from an aliased docset path; use a stable checkout path"))
+				}
+				if alias := aliasRoot(target, c.aliasRoots); alias != "" {
+					findings = append(findings, finding(file.Path, markdownLink, "openlore/alias-target", fmt.Sprintf("link targets aliased docset path %s; it may resolve differently on another machine", alias)))
+				}
+				continue
+			}
+			if !within(subject.Bundle.Root, target) {
+				findings = append(findings, finding(file.Path, markdownLink, "openlore/link-outside-bundle", fmt.Sprintf("local link %q resolves outside the bundle", markdownLink.Destination)))
+			} else if _, err := subject.Bundle.FS.Stat(target); err != nil {
+				findings = append(findings, finding(file.Path, markdownLink, "openlore/broken-link", fmt.Sprintf("local link %q does not resolve", markdownLink.Destination)))
+			}
+		}
+	}
+	return findings, nil
+}
+func (check) OnRemove(context.Context, string) error       { return nil }
+func (check) OnMove(context.Context, string, string) error { return nil }
+
+func finding(file string, l okf.Link, code, message string) rules.Finding {
+	return rules.Finding{Code: code, Path: file, Line: l.Line, Column: l.Column, Measured: message}
+}
+func within(root, target string) bool {
+	root, target = vfs.CleanPath(root), vfs.CleanPath(target)
+	return root == "/" || target == root || strings.HasPrefix(target, root+"/")
+}
+func aliasRoot(target string, roots []string) string {
+	for _, root := range roots {
+		if within(root, target) {
+			return root
+		}
+	}
+	return ""
+}

--- a/pkg/rules/match.go
+++ b/pkg/rules/match.go
@@ -1,0 +1,53 @@
+package rules
+
+import (
+	"path"
+	"strings"
+)
+
+func Matches(spec RuleSpec, rel string) bool {
+	rel = strings.Trim(strings.ReplaceAll(rel, "\\", "/"), "/")
+	matched := false
+	for _, pattern := range spec.Match {
+		if glob(pattern, rel) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+	for _, pattern := range spec.Exclude {
+		if glob(pattern, rel) {
+			return false
+		}
+	}
+	return true
+}
+
+func glob(pattern, name string) bool {
+	p, n := split(pattern), split(name)
+	var walk func(int, int) bool
+	walk = func(i, j int) bool {
+		if i == len(p) {
+			return j == len(n)
+		}
+		if p[i] == "**" {
+			return walk(i+1, j) || (j < len(n) && walk(i, j+1))
+		}
+		if j == len(n) {
+			return false
+		}
+		ok, err := path.Match(p[i], n[j])
+		return err == nil && ok && walk(i+1, j+1)
+	}
+	return walk(0, 0)
+}
+
+func split(s string) []string {
+	s = strings.Trim(strings.ReplaceAll(s, "\\", "/"), "/")
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "/")
+}

--- a/pkg/rules/okfrule/okf.go
+++ b/pkg/rules/okfrule/okf.go
@@ -2,6 +2,7 @@ package okfrule
 
 import (
 	"context"
+	"path"
 
 	"github.com/aakarim/go-openlore/pkg/okf"
 	"github.com/aakarim/go-openlore/pkg/rules"
@@ -29,18 +30,18 @@ type check struct{ bundle bool }
 
 func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Finding, error) {
 	if !c.bundle {
+		if subject.Mode == rules.ModeValidate && path.Ext(subject.Path) != ".md" {
+			return nil, nil
+		}
 		if err := okf.Validate(subject.Path, subject.Content); err != nil {
-			if subject.Mode == rules.ModeValidate {
-				if okf.IsReserved(subject.Path) {
-					return nil, nil
-				}
-				return []rules.Finding{{Code: "okf/concept", Measured: err.Error()}}, nil
+			if subject.Mode == rules.ModeValidate && okf.IsReserved(subject.Path) {
+				return nil, nil
 			}
-			return nil, err
+			return []rules.Finding{{Code: "okf/concept", Measured: err.Error()}}, nil
 		}
 		return nil, nil
 	}
-	if subject.Bundle == nil || len(subject.Bundle.Files) == 0 || subject.Path != subject.Bundle.Files[0].AbsolutePath {
+	if subject.Bundle == nil {
 		return nil, nil
 	}
 	files := make([]okf.File, 0, len(subject.Bundle.Files))

--- a/pkg/rules/okfrule/okf.go
+++ b/pkg/rules/okfrule/okf.go
@@ -1,0 +1,60 @@
+package okfrule
+
+import (
+	"context"
+
+	"github.com/aakarim/go-openlore/pkg/okf"
+	"github.com/aakarim/go-openlore/pkg/rules"
+)
+
+type Member struct{ Bundle bool }
+
+func init() {
+	rules.Register(Member{})
+	rules.Register(Member{Bundle: true})
+}
+
+func (m Member) Manifest() rules.Manifest {
+	if m.Bundle {
+		return rules.Manifest{Path: "okf/bundle", Kind: rules.KindRule, Scope: rules.ScopeBundle, Summary: "Validate OKF bundle structure and families"}
+	}
+	return rules.Manifest{Path: "okf", Kind: rules.KindRule, Scope: rules.ScopeFile, Summary: "Validate OKF concept conformance"}
+}
+
+func (m Member) Compile(_ map[string]any, _ rules.Env) (rules.Check, error) {
+	return check{bundle: m.Bundle}, nil
+}
+
+type check struct{ bundle bool }
+
+func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Finding, error) {
+	if !c.bundle {
+		if err := okf.Validate(subject.Path, subject.Content); err != nil {
+			if subject.Mode == rules.ModeValidate {
+				if okf.IsReserved(subject.Path) {
+					return nil, nil
+				}
+				return []rules.Finding{{Code: "okf/concept", Measured: err.Error()}}, nil
+			}
+			return nil, err
+		}
+		return nil, nil
+	}
+	if subject.Bundle == nil || len(subject.Bundle.Files) == 0 || subject.Path != subject.Bundle.Files[0].AbsolutePath {
+		return nil, nil
+	}
+	files := make([]okf.File, 0, len(subject.Bundle.Files))
+	for _, file := range subject.Bundle.Files {
+		files = append(files, okf.File{Path: file.Path, Content: file.Content})
+	}
+	var findings []rules.Finding
+	for _, d := range okf.ValidateBundle(files) {
+		if d.Rule == "okf/concept" {
+			continue
+		}
+		findings = append(findings, rules.Finding{Code: d.Rule, Path: d.Path, Line: d.Line, Column: d.Column, Warning: d.Severity == okf.SeverityWarning, Measured: d.Message})
+	}
+	return findings, nil
+}
+func (check) OnRemove(context.Context, string) error       { return nil }
+func (check) OnMove(context.Context, string, string) error { return nil }

--- a/pkg/rules/registry.go
+++ b/pkg/rules/registry.go
@@ -1,0 +1,90 @@
+package rules
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type Registry struct {
+	mu      sync.RWMutex
+	members map[string]Member
+}
+
+func NewRegistry() *Registry { return &Registry{members: map[string]Member{}} }
+
+var defaultRegistry = NewRegistry()
+
+func DefaultRegistry() *Registry { return defaultRegistry }
+func Register(member Member)     { defaultRegistry.Register(member) }
+
+func (r *Registry) Register(member Member) {
+	if member == nil || member.Manifest().Path == "" {
+		panic("rules: invalid member")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	name := member.Manifest().Path
+	if _, exists := r.members[name]; exists {
+		panic(fmt.Sprintf("rules: member %q already registered", name))
+	}
+	r.members[name] = member
+}
+
+func (r *Registry) Lookup(name string) (Member, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	m, ok := r.members[name]
+	return m, ok
+}
+
+func (r *Registry) All() []Member {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	all := make([]Member, 0, len(r.members))
+	for _, m := range r.members {
+		all = append(all, m)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].Manifest().Path < all[j].Manifest().Path })
+	return all
+}
+
+func (r *Registry) Suggest(name string) string {
+	best, score := "", 1<<30
+	for _, m := range r.All() {
+		if d := distance(name, m.Manifest().Path); d < score {
+			best, score = m.Manifest().Path, d
+		}
+	}
+	if score <= 3 {
+		return best
+	}
+	return ""
+}
+
+func IsStdlib(name string) bool {
+	first := strings.SplitN(name, "/", 2)[0]
+	return first != "" && !strings.Contains(first, ".")
+}
+
+func distance(a, b string) int {
+	d := make([]int, len(b)+1)
+	for i := range d {
+		d[i] = i
+	}
+	for i := 1; i <= len(a); i++ {
+		prev := d[0]
+		d[0] = i
+		for j := 1; j <= len(b); j++ {
+			old := d[j]
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			d[j] = min(d[j]+1, d[j-1]+1, prev+cost)
+			prev = old
+		}
+	}
+	return d[len(b)]
+}

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -1,0 +1,35 @@
+package rules
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMatches(t *testing.T) {
+	spec := RuleSpec{Match: []string{"**/*.md"}, Exclude: []string{"draft-*.md", "private/**"}}
+	for name, want := range map[string]bool{"a.md": true, "docs/a.md": true, "draft-a.md": false, "private/a.md": false, "a.txt": false} {
+		if got := Matches(spec, name); got != want {
+			t.Errorf("Matches(%q)=%v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestUnify(t *testing.T) {
+	a := RuleSpec{Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": 3}}
+	b := a
+	specs, origins, err := Unify([]Layer{{Origin: "outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Rules: map[string]RuleSpec{"a": b}}})
+	if err != nil || len(specs) != 1 || len(origins["a"]) != 2 {
+		t.Fatalf("identical unification: %v %#v", err, specs)
+	}
+	b.With = map[string]any{"max": 4}
+	_, _, err = Unify([]Layer{{Origin: "outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Rules: map[string]RuleSpec{"a": b}}})
+	var conflict *UnificationError
+	if !errors.As(err, &conflict) || conflict.OuterOrigin != "outer" || conflict.InnerOrigin != "inner" {
+		t.Fatalf("conflict = %#v, %v", conflict, err)
+	}
+	a.Default = true
+	specs, _, err = Unify([]Layer{{Origin: "outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Rules: map[string]RuleSpec{"a": b}}})
+	if err != nil || specs["a"].With["max"] != 4 {
+		t.Fatalf("default replacement: %v %#v", err, specs)
+	}
+}

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -17,19 +17,19 @@ func TestMatches(t *testing.T) {
 func TestUnify(t *testing.T) {
 	a := RuleSpec{Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": 3}}
 	b := a
-	specs, origins, err := Unify([]Layer{{Origin: "outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Rules: map[string]RuleSpec{"a": b}}})
-	if err != nil || len(specs) != 1 || len(origins["a"]) != 2 {
-		t.Fatalf("identical unification: %v %#v", err, specs)
+	unified, err := Unify([]Layer{{Origin: "outer", Scope: "/outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Scope: "/inner", Rules: map[string]RuleSpec{"a": b}}})
+	if err != nil || len(unified) != 1 || len(unified["a"].Origins) != 2 || unified["a"].Scope != "/outer" {
+		t.Fatalf("identical unification: %v %#v", err, unified)
 	}
 	b.With = map[string]any{"max": 4}
-	_, _, err = Unify([]Layer{{Origin: "outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Rules: map[string]RuleSpec{"a": b}}})
+	_, err = Unify([]Layer{{Origin: "outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Rules: map[string]RuleSpec{"a": b}}})
 	var conflict *UnificationError
 	if !errors.As(err, &conflict) || conflict.OuterOrigin != "outer" || conflict.InnerOrigin != "inner" {
 		t.Fatalf("conflict = %#v, %v", conflict, err)
 	}
 	a.Default = true
-	specs, _, err = Unify([]Layer{{Origin: "outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Rules: map[string]RuleSpec{"a": b}}})
-	if err != nil || specs["a"].With["max"] != 4 {
-		t.Fatalf("default replacement: %v %#v", err, specs)
+	unified, err = Unify([]Layer{{Origin: "outer", Scope: "/outer", Rules: map[string]RuleSpec{"a": a}}, {Origin: "inner", Scope: "/inner", Rules: map[string]RuleSpec{"a": b}}})
+	if err != nil || unified["a"].Spec.With["max"] != 4 || unified["a"].Scope != "/inner" {
+		t.Fatalf("default replacement: %v %#v", err, unified)
 	}
 }

--- a/pkg/rules/size/size.go
+++ b/pkg/rules/size/size.go
@@ -1,0 +1,128 @@
+package size
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/aakarim/go-openlore/pkg/rules"
+	"github.com/aakarim/go-openlore/pkg/rules/tokenizer"
+)
+
+type Metric int
+
+const (
+	Kilobytes Metric = iota
+	Lines
+	Tokens
+)
+
+type Rule struct{ Metric Metric }
+
+func Members() []rules.Member { return []rules.Member{Rule{Kilobytes}, Rule{Lines}, Rule{Tokens}} }
+func Register(reg *rules.Registry) {
+	for _, member := range Members() {
+		reg.Register(member)
+	}
+}
+
+func init() { Register(rules.DefaultRegistry()) }
+
+func (r Rule) Manifest() rules.Manifest {
+	path, summary := "size/kilobytes", "Reject writes larger than max kibibytes"
+	if r.Metric == Lines {
+		path, summary = "size/lines", "Reject writes with more than max lines"
+	}
+	if r.Metric == Tokens {
+		path, summary = "size/tokens", "Reject writes with more than max estimated tokens"
+	}
+	return rules.Manifest{Path: path, Kind: rules.KindRule, Scope: rules.ScopeFile, Summary: summary,
+		Params:  []rules.Param{{Name: "max", Type: rules.ParamIntegerOrInitial, Required: true}, {Name: "growth", Type: rules.ParamNumber}},
+		Example: "use: " + path + "\nwith: { max: 60 }"}
+}
+
+func (r Rule) Compile(with map[string]any, _ rules.Env) (rules.Check, error) {
+	if initial, ok := with["max"].(string); ok && initial == "initial" {
+		return nil, fmt.Errorf("max: initial is not supported until folder rules phase 4")
+	}
+	if growth, ok := asNumber(with["growth"]); ok && growth < 1 {
+		return nil, fmt.Errorf("growth must be at least 1")
+	}
+	max, ok := asInteger(with["max"])
+	if !ok || max < 1 {
+		return nil, fmt.Errorf("max must be an integer >= 1")
+	}
+	return check{metric: r.Metric, max: max, member: r.Manifest().Path}, nil
+}
+
+type check struct {
+	metric Metric
+	max    int64
+	member string
+}
+
+func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Finding, error) {
+	measured, unit := c.measure(subject.Content)
+	if measured <= c.max {
+		return nil, nil
+	}
+	base := path.Base(subject.Path)
+	ext := path.Ext(base)
+	sibling := strings.TrimSuffix(base, ext) + "-details" + ext
+	extra := ""
+	if c.metric == Tokens {
+		extra = "; estimate/v1, ≈ bytes/4"
+	}
+	return []rules.Finding{{Code: c.member,
+		Measured: fmt.Sprintf("%d %s exceeds the limit of %d (max: %d%s)", measured, unit, c.max, c.max, extra),
+		Limit:    fmt.Sprintf("this file cannot grow past %d %s under this rule", c.max, unit),
+		Remedy:   fmt.Sprintf("keep %s under %d %s; move the new material into a sibling file such as %s and add a link to it from %s so readers can drill in", base, c.max, unit, sibling, base),
+	}}, nil
+}
+func (check) OnRemove(context.Context, string) error       { return nil }
+func (check) OnMove(context.Context, string, string) error { return nil }
+
+func (c check) measure(content []byte) (int64, string) {
+	switch c.metric {
+	case Kilobytes:
+		return int64((len(content) + 1023) / 1024), "KiB"
+	case Lines:
+		if len(content) == 0 {
+			return 0, "lines"
+		}
+		n := int64(strings.Count(string(content), "\n"))
+		if content[len(content)-1] != '\n' {
+			n++
+		}
+		return n, "lines"
+	default:
+		return int64(tokenizer.Estimate(content)), "tokens"
+	}
+}
+
+func asInteger(value any) (int64, bool) {
+	switch n := value.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), n == float64(int64(n))
+	default:
+		return 0, false
+	}
+}
+
+func asNumber(value any) (float64, bool) {
+	switch n := value.(type) {
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case float64:
+		return n, true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/rules/size/size_test.go
+++ b/pkg/rules/size/size_test.go
@@ -1,0 +1,19 @@
+package size
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aakarim/go-openlore/pkg/rules"
+)
+
+func TestLinesFixedMax(t *testing.T) {
+	check, err := (Rule{Metric: Lines}).Compile(map[string]any{"max": 3}, rules.Env{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings, err := check.Evaluate(context.Background(), rules.Subject{Path: "/docs/a.md", Content: []byte("1\n2\n3\n4\n")})
+	if err != nil || len(findings) != 1 || findings[0].Code != "size/lines" {
+		t.Fatalf("findings=%#v err=%v", findings, err)
+	}
+}

--- a/pkg/rules/tokenizer/estimator.go
+++ b/pkg/rules/tokenizer/estimator.go
@@ -1,0 +1,10 @@
+// Package tokenizer provides the stable Phase 1 token estimator.
+package tokenizer
+
+const Version = "estimate/v1"
+
+type Estimator struct{}
+
+func (Estimator) Name() string                  { return Version }
+func (Estimator) Estimate(content []byte) int64 { return int64((len(content) + 3) / 4) }
+func Estimate(content []byte) int64             { return Estimator{}.Estimate(content) }

--- a/pkg/rules/tokenizer/estimator_test.go
+++ b/pkg/rules/tokenizer/estimator_test.go
@@ -1,0 +1,15 @@
+package tokenizer
+
+import "testing"
+
+func TestEstimator(t *testing.T) {
+	e := Estimator{}
+	if e.Name() != "estimate/v1" {
+		t.Fatal(e.Name())
+	}
+	for n, w := range []int64{0, 1, 1, 1, 1, 2, 2, 2, 2} {
+		if got := e.Estimate(make([]byte, n)); got != w {
+			t.Fatalf("%d bytes=%d want %d", n, got, w)
+		}
+	}
+}

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -63,6 +63,10 @@ type RuleSpec struct {
 
 func (s RuleSpec) IsEnforcing() bool { return s.Enforce == nil || *s.Enforce }
 
+// Equal compares normalized rule semantics. In particular, an omitted enforce
+// value is equal to enforce: true and nil/empty collections are equivalent.
+func (s RuleSpec) Equal(other RuleSpec) bool { return len(DifferingKeys(s, other)) == 0 }
+
 type Defaults struct {
 	Growth float64
 }
@@ -70,6 +74,8 @@ type Defaults struct {
 type Env struct {
 	Defaults Defaults
 	Logger   *slog.Logger
+	// AliasRoots contains configured docset aliases, longest first.
+	AliasRoots []string
 }
 
 type Subject struct {
@@ -93,10 +99,12 @@ const (
 )
 
 type Finding struct {
-	Code     string
-	Path     string
-	Line     int
-	Column   int
+	Code   string
+	Path   string
+	Line   int
+	Column int
+	// Warning never rejects a write and remains a warning during validation,
+	// even when its enclosing rule is enforcing.
 	Warning  bool
 	Measured string
 	Limit    string
@@ -119,6 +127,15 @@ type Layer struct {
 	Origin string
 	Scope  string
 	Rules  map[string]RuleSpec
+}
+
+// UnifiedRule retains the declaring scope while layers are unified. Child
+// declarations may refine a rule, but identical declarations do not move the
+// outer declaration's relative glob root.
+type UnifiedRule struct {
+	Spec    RuleSpec
+	Origins []string
+	Scope   string
 }
 
 type LayerSource interface {

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -1,0 +1,135 @@
+// Package rules implements declarative, layered content rules.
+package rules
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type Kind string
+
+const (
+	KindRule      Kind = "rule"
+	KindHook      Kind = "hook"
+	KindOperation Kind = "operation"
+)
+
+type Scope string
+
+const (
+	ScopeFile   Scope = "file"
+	ScopeBundle Scope = "bundle"
+)
+
+type ParamType string
+
+const (
+	ParamInteger          ParamType = "integer"
+	ParamNumber           ParamType = "number"
+	ParamString           ParamType = "string"
+	ParamBool             ParamType = "boolean"
+	ParamIntegerOrInitial ParamType = "integer|initial"
+)
+
+type Param struct {
+	Name     string
+	Type     ParamType
+	Required bool
+	Default  any
+	Doc      string
+}
+
+type Manifest struct {
+	Path    string
+	Kind    Kind
+	Scope   Scope
+	Summary string
+	Doc     string
+	Params  []Param
+	Example string
+}
+
+type RuleSpec struct {
+	Match   []string       `yaml:"match" json:"match"`
+	Exclude []string       `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+	Use     string         `yaml:"use" json:"use"`
+	With    map[string]any `yaml:"with,omitempty" json:"with,omitempty"`
+	Enforce *bool          `yaml:"enforce,omitempty" json:"enforce,omitempty"`
+	Default bool           `yaml:"default,omitempty" json:"default,omitempty"`
+}
+
+func (s RuleSpec) IsEnforcing() bool { return s.Enforce == nil || *s.Enforce }
+
+type Defaults struct {
+	Growth float64
+}
+
+type Env struct {
+	Defaults Defaults
+	Logger   *slog.Logger
+}
+
+type Subject struct {
+	Mode       Mode
+	Path       string
+	Dir        string
+	Content    []byte
+	Existing   func() ([]byte, bool, error)
+	Commit     string
+	Actor      string
+	FS         vfs.FileSystem
+	BundleRoot string
+	Bundle     *validation.Bundle
+}
+
+type Mode int
+
+const (
+	ModeAdmit Mode = iota
+	ModeValidate
+)
+
+type Finding struct {
+	Code     string
+	Path     string
+	Line     int
+	Column   int
+	Warning  bool
+	Measured string
+	Limit    string
+	Remedy   string
+	Override string
+}
+
+type Check interface {
+	Evaluate(context.Context, Subject) ([]Finding, error)
+	OnRemove(context.Context, string) error
+	OnMove(context.Context, string, string) error
+}
+
+type Member interface {
+	Manifest() Manifest
+	Compile(with map[string]any, env Env) (Check, error)
+}
+
+type Layer struct {
+	Origin string
+	Scope  string
+	Rules  map[string]RuleSpec
+}
+
+type LayerSource interface {
+	LayersFor(context.Context, string) ([]Layer, error)
+}
+
+type CompiledRule struct {
+	Name    string
+	Spec    RuleSpec
+	Origins []string
+	Scope   string
+	Member  Member
+	Check   Check
+}

--- a/pkg/shell/cmds/lore_validate.go
+++ b/pkg/shell/cmds/lore_validate.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
@@ -44,13 +45,29 @@ func cmdLoreValidate(ctx CmdContext, args []string, w io.Writer, errW io.Writer,
 		return 1
 	}
 	errors, warnings := 0, 0
+	members := map[string]bool{}
 	for _, diagnostic := range diagnostics {
+		if diagnostic.Rule == "rules/bundle-root" {
+			fmt.Fprintf(errW, "lore validate: %s\n", diagnostic.Message)
+			return 1
+		}
 		fmt.Fprintln(w, validation.FormatDiagnostic(diagnostic))
+		if diagnostic.Member != "" {
+			members[diagnostic.Member] = true
+		}
 		if diagnostic.Severity == validation.SeverityError {
 			errors++
 		} else {
 			warnings++
 		}
+	}
+	memberNames := make([]string, 0, len(members))
+	for member := range members {
+		memberNames = append(memberNames, member)
+	}
+	sort.Strings(memberNames)
+	for _, member := range memberNames {
+		fmt.Fprintf(w, "see: lore package doc %s\n", member)
 	}
 	fmt.Fprintf(w, "%d %s, %d %s\n", errors, countLabel(errors, "error"), warnings, countLabel(warnings, "warning"))
 	if errors > 0 {


### PR DESCRIPTION
## Summary

- add the layered rules registry, compiler, matcher, unification, admission, and validation engine
- add fixed-max size rules, the estimate/v1 tokenizer, and OKF/link adapters with file vs bundle scope
- support top-level and per-docset rules in lore.json, including legacy OKF desugaring and conflict detection
- wire rules into write admission and lore validate while retaining existing OKF metadata behavior
- add openlore.yml rules.growth defaults and reserve unsupported tokenizer configuration

Phase 2 discoverability, Phase 3 .lore/config.yaml files, and Phase 4 persistent initial-size baselines remain out of scope.

## Behavior change

Legacy `okf.enforce: false` now makes the complete OKF rule family (`okf`, `okf/bundle`, and `link/resolves`) report warnings rather than errors. This intentionally preserves a single enforcement switch for the family.

## Verification

- `nix --extra-experimental-features 'nix-command flakes' develop .#default -c sh -c 'go test ./... && go vet ./... && go build ./...'`