### PR TITLE
Implement Phase 3 folder rule configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -291,6 +291,10 @@ type DocsetAccess struct {
 	Deny  []string          `json:"deny,omitempty"`
 }
 
+type DirConfigPermission struct {
+	Edit []string `json:"edit,omitempty"`
+}
+
 // AuthTokensConfig controls the bearer-token issuer for the MCP + HTTP API.
 // It is server infrastructure and loaded from openlore.yml (hence yaml tags).
 type AuthTokensConfig struct {
@@ -322,6 +326,7 @@ type DocsetSpec struct {
 	Paths  []PathMapping             `json:"paths"`
 	Access DocsetAccess              `json:"access,omitempty"`
 	Rules  map[string]rules.RuleSpec `json:"rules,omitempty"`
+	Config *DirConfigPermission      `json:"config,omitempty"`
 	// AgentSkills is ignored. Collections are selected dynamically by xattr.
 	AgentSkills bool `json:"-"`
 	// Aliases are alternate display roots for the first path. They expose the
@@ -1359,6 +1364,16 @@ func ValidateAuthConfig(auth *AuthConfig) error {
 		}
 	}
 	for docset, ds := range auth.Docsets {
+		if ds.Config != nil {
+			if err := validateNames(fmt.Sprintf("docset %q config.edit roles", docset), ds.Config.Edit); err != nil {
+				return err
+			}
+			for _, role := range ds.Config.Edit {
+				if _, ok := auth.Roles[role]; !ok {
+					return fmt.Errorf("docset %q config.edit references unknown role %q", docset, role)
+				}
+			}
+		}
 		for role, grant := range ds.Access.Allow {
 			if grant == "" || strings.TrimSpace(grant) != grant {
 				return fmt.Errorf("docset %q has invalid grant for role %q", docset, role)

--- a/pkg/openlore/authz.go
+++ b/pkg/openlore/authz.go
@@ -2,6 +2,7 @@ package openlore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -416,6 +417,9 @@ func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string
 		return false
 	}
 	if action == vfs.ChangeActionRemoveAll {
+		if !s.canEditDirConfigsInTree(id, p) {
+			return false
+		}
 		for _, candidate := range s.currentAuth().Docsets {
 			for _, pm := range candidate.Paths {
 				root := displayPath(pm)
@@ -448,6 +452,23 @@ func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string
 	return false
 }
 
+func (s *Server) canEditDirConfigsInTree(id Identity, target string) bool {
+	allowed := true
+	err := vfs.WalkDir(s.merge, target, func(candidate string, _ *vfs.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if isDirConfigPath(candidate) && !s.identityHasDirConfigRole(id, candidate) {
+			allowed = false
+		}
+		return nil
+	})
+	if errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	return err == nil && allowed
+}
+
 func (s *Server) identityHasDirConfigRole(id Identity, target string) bool {
 	_, docset, ok := s.mostSpecificDocset(path.Dir(path.Dir(target)))
 	if !ok || docset.Config == nil {
@@ -465,21 +486,6 @@ func (s *Server) identityHasDirConfigRole(id Identity, target string) bool {
 		}
 	}
 	return false
-}
-
-// CanEditDirConfig applies the additional role gate for .lore/config.yaml.
-// Ordinary path authorization remains required as well.
-func (s *Server) CanEditDirConfig(attribution Attribution, target string) bool {
-	id := Identity{
-		IdentityName: attribution.Principal,
-		Principal:    AuthenticatedPrincipal{IdentityName: attribution.Principal},
-		Attribution:  attribution,
-		Scopes:       []string{ScopeFull},
-	}
-	if !s.identityCanWrite(id, vfs.ChangeActionWrite, target) {
-		return false
-	}
-	return true
 }
 
 // readableRoots returns the display roots the identity may read: the display

--- a/pkg/openlore/authz.go
+++ b/pkg/openlore/authz.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"path"
 	"sort"
 	"strings"
 	"syscall"
@@ -411,6 +412,9 @@ func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string
 		return false // token scope ceiling: only full authority may write
 	}
 	p = s.canonicalPath(p)
+	if isDirConfigPath(p) && !s.identityHasDirConfigRole(id, p) {
+		return false
+	}
 	if action == vfs.ChangeActionRemoveAll {
 		for _, candidate := range s.currentAuth().Docsets {
 			for _, pm := range candidate.Paths {
@@ -442,6 +446,40 @@ func (s *Server) identityCanWrite(id Identity, action vfs.ChangeAction, p string
 		}
 	}
 	return false
+}
+
+func (s *Server) identityHasDirConfigRole(id Identity, target string) bool {
+	_, docset, ok := s.mostSpecificDocset(path.Dir(path.Dir(target)))
+	if !ok || docset.Config == nil {
+		return false
+	}
+	policy, err := s.currentPolicy(id)
+	if err != nil {
+		return false
+	}
+	for _, allowed := range docset.Config.Edit {
+		for _, role := range policy.Roles {
+			if role == allowed {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CanEditDirConfig applies the additional role gate for .lore/config.yaml.
+// Ordinary path authorization remains required as well.
+func (s *Server) CanEditDirConfig(attribution Attribution, target string) bool {
+	id := Identity{
+		IdentityName: attribution.Principal,
+		Principal:    AuthenticatedPrincipal{IdentityName: attribution.Principal},
+		Attribution:  attribution,
+		Scopes:       []string{ScopeFull},
+	}
+	if !s.identityCanWrite(id, vfs.ChangeActionWrite, target) {
+		return false
+	}
+	return true
 }
 
 // readableRoots returns the display roots the identity may read: the display

--- a/pkg/openlore/dirfs_config_test.go
+++ b/pkg/openlore/dirfs_config_test.go
@@ -1,0 +1,79 @@
+package openlore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+func TestDirFSExposesOnlyFolderConfig(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "docs", "backend")
+	if err := os.MkdirAll(filepath.Join(dir, ".lore", "xattrs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lore", "config.yaml"), []byte("version: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lore", "xattrs", "self"), []byte("hidden"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := NewDirFS(root, config.FilesConfig{Allowed: []string{"*.md"}}).WithDocsetRoots([]string{"/docs"})
+	if err := d.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := d.ReadFile("/docs/backend/.lore/config.yaml"); err != nil || string(got) != "version: 1\n" {
+		t.Fatalf("ReadFile = %q, %v", got, err)
+	}
+	if _, err := d.Stat("/docs/backend/.lore/config.yaml"); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := d.ReadDir("/docs/backend")
+	if err != nil || len(entries) != 1 || entries[0].FileName != ".lore" || !entries[0].Dir {
+		t.Fatalf("backend entries = %#v, %v", entries, err)
+	}
+	entries, err = d.ReadDir("/docs/backend/.lore")
+	if err != nil || len(entries) != 1 || entries[0].FileName != "config.yaml" {
+		t.Fatalf(".lore entries = %#v, %v", entries, err)
+	}
+	if _, err := d.ReadFile("/docs/backend/.lore/xattrs/self"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("hidden read: %v", err)
+	}
+	if _, err := d.WriteFileAtomic("/docs/backend/.lore/other.yaml", nil, vfs.WriteOpts{}); err == nil {
+		t.Fatal("write under .lore succeeded")
+	}
+	if err := d.Mkdir("/docs/backend/.lore"); err == nil {
+		t.Fatal("mkdir .lore succeeded")
+	}
+	if _, err := d.WriteFileAtomic("/docs/backend/.lore/config.yaml", []byte("version: 1\nrules: {}\n"), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("config write: %v", err)
+	}
+	if err := d.RemoveAll("/docs/backend", vfs.RemoveOpts{}); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("backend remains: %v", err)
+	}
+}
+
+func TestDirFSDoesNotListLoreWithoutConfig(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs", ".lore", "xattrs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d := NewDirFS(root, config.FilesConfig{})
+	entries, err := d.ReadDir("/docs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.FileName == ".lore" {
+			t.Fatal(".lore listed without config.yaml")
+		}
+	}
+}

--- a/pkg/openlore/dirfs_config_test.go
+++ b/pkg/openlore/dirfs_config_test.go
@@ -50,6 +50,19 @@ func TestDirFSExposesOnlyFolderConfig(t *testing.T) {
 	if _, err := d.WriteFileAtomic("/docs/backend/.lore/xattrs/.lore/config.yaml", nil, vfs.WriteOpts{}); err == nil {
 		t.Fatal("nested .lore config path escaped reservation")
 	}
+	nestedLore := filepath.Join(dir, ".lore", "xattrs", ".lore")
+	if err := os.MkdirAll(nestedLore, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedLore, "config.yaml"), []byte("hidden"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Stat("/docs/backend/.lore/xattrs/.lore"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("nested .lore stat exposed package state: %v", err)
+	}
+	if _, err := d.ReadDir("/docs/backend/.lore/xattrs/.lore"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("nested .lore listing exposed package state: %v", err)
+	}
 	if err := d.Mkdir("/docs/backend/.lore"); err == nil {
 		t.Fatal("mkdir .lore succeeded")
 	}

--- a/pkg/openlore/dirfs_config_test.go
+++ b/pkg/openlore/dirfs_config_test.go
@@ -47,6 +47,9 @@ func TestDirFSExposesOnlyFolderConfig(t *testing.T) {
 	if _, err := d.WriteFileAtomic("/docs/backend/.lore/other.yaml", nil, vfs.WriteOpts{}); err == nil {
 		t.Fatal("write under .lore succeeded")
 	}
+	if _, err := d.WriteFileAtomic("/docs/backend/.lore/xattrs/.lore/config.yaml", nil, vfs.WriteOpts{}); err == nil {
+		t.Fatal("nested .lore config path escaped reservation")
+	}
 	if err := d.Mkdir("/docs/backend/.lore"); err == nil {
 		t.Fatal("mkdir .lore succeeded")
 	}

--- a/pkg/openlore/middleware.go
+++ b/pkg/openlore/middleware.go
@@ -45,12 +45,19 @@ func (a Attribution) String() string {
 type WriteOp struct {
 	changeSet   vfs.ChangeSet
 	Attribution Attribution
+	identity    *Identity
 }
 
 // NewWriteOp constructs an immutable admission operation. The changeset is
 // intentionally not exposed: policy middleware must inspect every leaf.
 func NewWriteOp(attribution Attribution, cs vfs.ChangeSet) WriteOp {
 	return WriteOp{changeSet: cloneWriteChangeSet(cs), Attribution: attribution}
+}
+
+func newIdentityWriteOp(identity Identity, cs vfs.ChangeSet) WriteOp {
+	op := NewWriteOp(identity.attribution(), cs)
+	op.identity = &identity
+	return op
 }
 
 // Leaves returns every proposed mutation in execution order.

--- a/pkg/openlore/middleware_fs.go
+++ b/pkg/openlore/middleware_fs.go
@@ -23,7 +23,12 @@ type middlewareFS struct {
 	vfs.FileSystem // read delegation (Stat / ReadDir / ReadFile)
 
 	attribution Attribution
+	identity    *Identity
 	admit       WriteHandler // composed admission chain; terminal handler submits to the log
+}
+
+func newIdentityMiddlewareFS(readView vfs.FileSystem, identity Identity, admit WriteHandler) *middlewareFS {
+	return &middlewareFS{FileSystem: readView, attribution: identity.attribution(), identity: &identity, admit: admit}
 }
 
 // newMiddlewareFS wraps a session read view so its mutations flow through admit.
@@ -37,7 +42,11 @@ func newMiddlewareFS(readView vfs.FileSystem, attribution Attribution, admit Wri
 // hash (empty for non-write actions) or the chain's error. A deferred write
 // surfaces as *vfs.PendingChangeError; a rejected one as the middleware's error.
 func (m *middlewareFS) run(cs vfs.ChangeSet) (string, error) {
-	res, err := m.admit(context.Background(), NewWriteOp(m.attribution, cs))
+	op := NewWriteOp(m.attribution, cs)
+	if m.identity != nil {
+		op = newIdentityWriteOp(*m.identity, cs)
+	}
+	res, err := m.admit(context.Background(), op)
 	return res.Hash, err
 }
 

--- a/pkg/openlore/okf_plugin.go
+++ b/pkg/openlore/okf_plugin.go
@@ -34,7 +34,7 @@ func newOKF(docsets map[string]config.DocsetSpec, logger *slog.Logger) *okfPlugi
 		auth.Docsets[name] = copy
 	}
 	_ = config.ValidateAuthConfig(auth)
-	plugin, _ := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, nil, nil, logger)
+	plugin, _ := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, nil, logger)
 	return &okfPlugin{docsets: docsets, engine: plugin.engine}
 }
 

--- a/pkg/openlore/okf_plugin.go
+++ b/pkg/openlore/okf_plugin.go
@@ -34,7 +34,7 @@ func newOKF(docsets map[string]config.DocsetSpec, logger *slog.Logger) *okfPlugi
 		auth.Docsets[name] = copy
 	}
 	_ = config.ValidateAuthConfig(auth)
-	plugin, _ := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, logger)
+	plugin, _ := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, nil, nil, logger)
 	return &okfPlugin{docsets: docsets, engine: plugin.engine}
 }
 

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -42,15 +42,7 @@ func newFolderRuleLayers(fsys vfs.FileSystem, docsets map[string]config.DocsetSp
 	return &folderRuleLayers{fs: fsys, docsets: docsets, cache: map[string]folderRuleCacheEntry{}}
 }
 
-func (s *folderRuleLayers) LayersFor(ctx context.Context, target string) ([]rules.Layer, error) {
-	dir := path.Dir(vfs.CleanPath(target))
-	if rules.IsDirConfigPath(target) {
-		dir = path.Dir(path.Dir(vfs.CleanPath(target)))
-	} else if s.fs != nil {
-		if info, err := s.fs.Stat(target); err == nil && info.Dir {
-			dir = vfs.CleanPath(target)
-		}
-	}
+func (s *folderRuleLayers) LayersForDir(ctx context.Context, dir string) ([]rules.Layer, error) {
 	return s.layersThrough(ctx, dir, true)
 }
 
@@ -197,17 +189,11 @@ func ruleRoots(docset config.DocsetSpec) []string {
 	return roots
 }
 
-type dirConfigAuthorizer interface {
-	CanEditDirConfig(Attribution, string) bool
-}
-
 type rulesPlugin struct {
-	engine     *rules.Engine
-	authorizer dirConfigAuthorizer
-	reportInfo bool
+	engine *rules.Engine
 }
 
-func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.FileSystem, authorizer dirConfigAuthorizer, logger *slog.Logger) (*rulesPlugin, error) {
+func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.FileSystem, logger *slog.Logger) (*rulesPlugin, error) {
 	var aliases []string
 	for _, docset := range auth.Docsets {
 		aliases = append(aliases, docset.Aliases...)
@@ -231,11 +217,7 @@ func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.F
 		options.Folders = newFolderRuleLayers(fsys, auth.Docsets)
 	}
 	engine := rules.New(options)
-	reportInfo := anyConfiguredRules(auth)
-	for _, docset := range auth.Docsets {
-		reportInfo = reportInfo || docset.Config != nil
-	}
-	return &rulesPlugin{engine: engine, authorizer: authorizer, reportInfo: reportInfo}, nil
+	return &rulesPlugin{engine: engine}, nil
 }
 
 func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
@@ -243,9 +225,6 @@ func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
 		return func(ctx context.Context, op WriteOp) (WriteResult, error) {
 			for _, leaf := range op.Leaves() {
 				if rules.IsDirConfigPath(leaf.Target) {
-					if p.authorizer == nil || !p.authorizer.CanEditDirConfig(op.Attribution, leaf.Target) {
-						return WriteResult{}, os.ErrPermission
-					}
 					if leaf.Action == vfs.ChangeActionWrite && leaf.Write != nil {
 						dir := path.Dir(path.Dir(leaf.Target))
 						if err := p.engine.CheckConfigFile(ctx, dir, leaf.Write.Bytes); err != nil {
@@ -258,11 +237,7 @@ func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
 					return WriteResult{}, err
 				}
 			}
-			result, err := next(ctx, op)
-			if err == nil {
-				p.invalidateChanges(op.Leaves())
-			}
-			return result, err
+			return next(ctx, op)
 		}
 	}}
 }
@@ -288,12 +263,7 @@ func (p *rulesPlugin) PostCommitMiddleware() []PostCommitMiddleware {
 func (p *rulesPlugin) Validators() []validation.Validator {
 	return []validation.Validator{p.engine.Validator()}
 }
-func (p *rulesPlugin) Info() PluginInfo {
-	if !p.reportInfo {
-		return PluginInfo{}
-	}
-	return PluginInfo{Name: "rules", Version: "0.1.0"}
-}
+func (p *rulesPlugin) Info() PluginInfo { return PluginInfo{Name: "rules", Version: "0.1.0"} }
 
 func anyConfiguredRules(auth *config.AuthConfig) bool {
 	if len(auth.Rules) != 0 {

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -26,7 +26,7 @@ type configRuleLayers struct {
 }
 
 type folderRuleCacheEntry struct {
-	layer rules.Layer
+	rules map[string]rules.RuleSpec
 	err   error
 	found bool
 }
@@ -63,10 +63,10 @@ func (s *folderRuleLayers) layersThrough(_ context.Context, dir string, includeD
 	for _, candidate := range dirs {
 		entry := s.load(candidate)
 		if entry.err != nil {
-			return nil, entry.err
+			return nil, fmt.Errorf("%s: %w", path.Join(candidate, ".lore/config.yaml"), entry.err)
 		}
 		if entry.found {
-			layers = append(layers, entry.layer)
+			layers = append(layers, rules.Layer{Origin: path.Join(candidate, ".lore/config.yaml"), Scope: candidate, Rules: entry.rules})
 		}
 	}
 	return layers, nil
@@ -96,34 +96,56 @@ func directoriesFrom(root, dir string) []string {
 }
 
 func (s *folderRuleLayers) load(dir string) folderRuleCacheEntry {
+	canonicalDir := s.canonicalDir(dir)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	entry, ok := s.cache[dir]
+	entry, ok := s.cache[canonicalDir]
 	if ok {
 		return entry
 	}
-	configPath := path.Join(dir, ".lore/config.yaml")
+	configPath := path.Join(canonicalDir, ".lore/config.yaml")
 	content, err := s.fs.ReadFile(configPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			entry = folderRuleCacheEntry{}
 		} else {
-			entry.err = fmt.Errorf("%s: %w", configPath, err)
+			entry.err = err
 		}
 	} else {
 		fileConfig, decodeErr := rules.DecodeFile(content)
 		if decodeErr != nil {
-			entry.err = fmt.Errorf("%s: %w", configPath, decodeErr)
+			entry.err = decodeErr
 		} else {
-			entry = folderRuleCacheEntry{found: true, layer: rules.Layer{Origin: configPath, Scope: dir, Rules: fileConfig.Rules}}
+			entry = folderRuleCacheEntry{found: true, rules: fileConfig.Rules}
 		}
 	}
-	s.cache[dir] = entry
+	s.cache[canonicalDir] = entry
 	return entry
 }
 
-func (s *folderRuleLayers) Invalidate(dir string) {
+func (s *folderRuleLayers) canonicalDir(dir string) string {
 	dir = vfs.CleanPath(dir)
+	bestAlias, target := "", ""
+	for _, docset := range s.docsets {
+		if len(docset.Paths) == 0 {
+			continue
+		}
+		for _, rawAlias := range docset.Aliases {
+			alias := vfs.CleanPath(rawAlias)
+			if pathWithinRoot(alias, dir) && len(alias) > len(bestAlias) {
+				bestAlias = alias
+				target = primaryDisplayPath(docset)
+			}
+		}
+	}
+	if bestAlias == "" {
+		return dir
+	}
+	return replacePathRoot(dir, bestAlias, target)
+}
+
+func (s *folderRuleLayers) Invalidate(dir string) {
+	dir = s.canonicalDir(dir)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for cached := range s.cache {
@@ -240,6 +262,36 @@ func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
 			return next(ctx, op)
 		}
 	}}
+}
+
+// PreApply re-evaluates rules against the serialized filesystem state. This
+// closes the gap between concurrent admission and commit, and deliberately
+// rejects batches whose folder-config mutation would require a projected view.
+func (p *rulesPlugin) PreApply(attribution Attribution, changes vfs.ChangeSet) error {
+	leaves := changes.Leaves()
+	configChanges := 0
+	for _, leaf := range leaves {
+		if rules.IsDirConfigPath(leaf.Target) {
+			configChanges++
+		}
+	}
+	if configChanges != 0 && len(leaves) != 1 {
+		return fmt.Errorf("rules: folder config mutations must be submitted separately")
+	}
+	for _, leaf := range leaves {
+		if rules.IsDirConfigPath(leaf.Target) {
+			if leaf.Action == vfs.ChangeActionWrite && leaf.Write != nil {
+				if err := p.engine.CheckConfigFile(context.Background(), path.Dir(path.Dir(leaf.Target)), leaf.Write.Bytes); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if err := p.engine.AdmitLeaf(context.Background(), leaf, attribution.String(), nil); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (p *rulesPlugin) invalidateChanges(changes []vfs.Change) {

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -2,10 +2,14 @@ package openlore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path"
 	"sort"
+	"strings"
+	"sync"
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
@@ -19,6 +23,122 @@ import (
 type configRuleLayers struct {
 	global  map[string]rules.RuleSpec
 	docsets map[string]config.DocsetSpec
+}
+
+type folderRuleCacheEntry struct {
+	layer rules.Layer
+	err   error
+	found bool
+}
+
+type folderRuleLayers struct {
+	fs      vfs.FileSystem
+	docsets map[string]config.DocsetSpec
+	mu      sync.RWMutex
+	cache   map[string]folderRuleCacheEntry
+}
+
+func newFolderRuleLayers(fsys vfs.FileSystem, docsets map[string]config.DocsetSpec) *folderRuleLayers {
+	return &folderRuleLayers{fs: fsys, docsets: docsets, cache: map[string]folderRuleCacheEntry{}}
+}
+
+func (s *folderRuleLayers) LayersFor(ctx context.Context, target string) ([]rules.Layer, error) {
+	dir := path.Dir(vfs.CleanPath(target))
+	if rules.IsDirConfigPath(target) {
+		dir = path.Dir(path.Dir(vfs.CleanPath(target)))
+	} else if s.fs != nil {
+		if info, err := s.fs.Stat(target); err == nil && info.Dir {
+			dir = vfs.CleanPath(target)
+		}
+	}
+	return s.layersThrough(ctx, dir, true)
+}
+
+func (s *folderRuleLayers) LayersAbove(ctx context.Context, dir string) ([]rules.Layer, error) {
+	return s.layersThrough(ctx, vfs.CleanPath(dir), false)
+}
+
+func (s *folderRuleLayers) layersThrough(_ context.Context, dir string, includeDir bool) ([]rules.Layer, error) {
+	root, _, _, ok := owningDocset(s.docsets, dir)
+	if !ok || !pathWithinRoot(root, dir) {
+		return nil, nil
+	}
+	dirs := directoriesFrom(root, dir)
+	if !includeDir && len(dirs) != 0 {
+		dirs = dirs[:len(dirs)-1]
+	}
+	var layers []rules.Layer
+	for _, candidate := range dirs {
+		entry := s.load(candidate)
+		if entry.err != nil {
+			return nil, entry.err
+		}
+		if entry.found {
+			layers = append(layers, entry.layer)
+		}
+	}
+	return layers, nil
+}
+
+func directoriesFrom(root, dir string) []string {
+	root, dir = vfs.CleanPath(root), vfs.CleanPath(dir)
+	result := []string{root}
+	if root == dir {
+		return result
+	}
+	rel := strings.TrimPrefix(dir, root)
+	if root == "/" {
+		rel = strings.TrimPrefix(dir, "/")
+	} else {
+		rel = strings.TrimPrefix(rel, "/")
+	}
+	current := root
+	for _, segment := range strings.Split(rel, "/") {
+		if segment == "" {
+			continue
+		}
+		current = path.Join(current, segment)
+		result = append(result, current)
+	}
+	return result
+}
+
+func (s *folderRuleLayers) load(dir string) folderRuleCacheEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.cache[dir]
+	if ok {
+		return entry
+	}
+	configPath := path.Join(dir, ".lore/config.yaml")
+	content, err := s.fs.ReadFile(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			entry = folderRuleCacheEntry{}
+		} else {
+			entry.err = fmt.Errorf("%s: %w", configPath, err)
+		}
+	} else {
+		fileConfig, decodeErr := rules.DecodeFile(content)
+		if decodeErr != nil {
+			entry.err = fmt.Errorf("%s: %w", configPath, decodeErr)
+		} else {
+			entry = folderRuleCacheEntry{found: true, layer: rules.Layer{Origin: configPath, Scope: dir, Rules: fileConfig.Rules}}
+		}
+	}
+	s.cache[dir] = entry
+	return entry
+}
+
+func (s *folderRuleLayers) Invalidate(dir string) {
+	dir = vfs.CleanPath(dir)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for cached := range s.cache {
+		if cached == dir || strings.HasPrefix(cached, strings.TrimSuffix(dir, "/")+"/") {
+			delete(s.cache, cached)
+		}
+	}
 }
 
 func (s configRuleLayers) LayersFor(_ context.Context, target string) ([]rules.Layer, error) {
@@ -77,44 +197,103 @@ func ruleRoots(docset config.DocsetSpec) []string {
 	return roots
 }
 
-type rulesPlugin struct{ engine *rules.Engine }
+type dirConfigAuthorizer interface {
+	CanEditDirConfig(Attribution, string) bool
+}
 
-func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, logger *slog.Logger) (*rulesPlugin, error) {
+type rulesPlugin struct {
+	engine     *rules.Engine
+	authorizer dirConfigAuthorizer
+	reportInfo bool
+}
+
+func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.FileSystem, authorizer dirConfigAuthorizer, logger *slog.Logger) (*rulesPlugin, error) {
 	var aliases []string
 	for _, docset := range auth.Docsets {
 		aliases = append(aliases, docset.Aliases...)
 	}
 	sort.Slice(aliases, func(i, j int) bool { return len(aliases[i]) > len(aliases[j]) })
-	engine := rules.New(rules.Options{Registry: rules.DefaultRegistry(), Config: configRuleLayers{global: auth.Rules, docsets: auth.Docsets}, Env: func(string) rules.Env { return rules.Env{Defaults: defaults, Logger: logger, AliasRoots: aliases} }, Logger: logger})
+	configLayers := configRuleLayers{global: auth.Rules, docsets: auth.Docsets}
+	env := func(string) rules.Env { return rules.Env{Defaults: defaults, Logger: logger, AliasRoots: aliases} }
+	bootEngine := rules.New(rules.Options{Registry: rules.DefaultRegistry(), Config: configLayers, Env: env, Logger: logger})
 	// Compile every configured docset at boot so invalid members, parameters,
 	// and unification conflicts fail before the server begins accepting writes.
 	for _, docset := range auth.Docsets {
 		for _, mapping := range docset.Paths {
 			root := displayPath(mapping)
-			if _, err := engine.Effective(context.Background(), path.Join(root, "__rules_boot_check__.md")); err != nil {
+			if _, err := bootEngine.Effective(context.Background(), path.Join(root, "__rules_boot_check__.md")); err != nil {
 				return nil, fmt.Errorf("configuring rules: %w", err)
 			}
 		}
 	}
-	return &rulesPlugin{engine: engine}, nil
+	options := rules.Options{Registry: rules.DefaultRegistry(), Config: configLayers, Env: env, Logger: logger}
+	if fsys != nil {
+		options.Folders = newFolderRuleLayers(fsys, auth.Docsets)
+	}
+	engine := rules.New(options)
+	reportInfo := anyConfiguredRules(auth)
+	for _, docset := range auth.Docsets {
+		reportInfo = reportInfo || docset.Config != nil
+	}
+	return &rulesPlugin{engine: engine, authorizer: authorizer, reportInfo: reportInfo}, nil
 }
 
 func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
 	return []WriteMiddleware{func(next WriteHandler) WriteHandler {
 		return func(ctx context.Context, op WriteOp) (WriteResult, error) {
 			for _, leaf := range op.Leaves() {
+				if rules.IsDirConfigPath(leaf.Target) {
+					if p.authorizer == nil || !p.authorizer.CanEditDirConfig(op.Attribution, leaf.Target) {
+						return WriteResult{}, os.ErrPermission
+					}
+					if leaf.Action == vfs.ChangeActionWrite && leaf.Write != nil {
+						dir := path.Dir(path.Dir(leaf.Target))
+						if err := p.engine.CheckConfigFile(ctx, dir, leaf.Write.Bytes); err != nil {
+							return WriteResult{}, err
+						}
+					}
+					continue
+				}
 				if err := p.engine.AdmitLeaf(ctx, leaf, op.Attribution.String(), nil); err != nil {
 					return WriteResult{}, err
 				}
 			}
-			return next(ctx, op)
+			result, err := next(ctx, op)
+			if err == nil {
+				p.invalidateChanges(op.Leaves())
+			}
+			return result, err
+		}
+	}}
+}
+
+func (p *rulesPlugin) invalidateChanges(changes []vfs.Change) {
+	for _, leaf := range changes {
+		if rules.IsDirConfigPath(leaf.Target) {
+			p.engine.Invalidate(path.Dir(path.Dir(leaf.Target)))
+		} else if leaf.Action == vfs.ChangeActionRemoveAll {
+			p.engine.Invalidate(leaf.Target)
+		}
+	}
+}
+
+func (p *rulesPlugin) PostCommitMiddleware() []PostCommitMiddleware {
+	return []PostCommitMiddleware{func(next PostCommitHandler) PostCommitHandler {
+		return func(ctx context.Context, info CommitInfo) error {
+			p.invalidateChanges(info.ChangeSet.Leaves())
+			return next(ctx, info)
 		}
 	}}
 }
 func (p *rulesPlugin) Validators() []validation.Validator {
 	return []validation.Validator{p.engine.Validator()}
 }
-func (p *rulesPlugin) Info() PluginInfo { return PluginInfo{Name: "rules", Version: "0.1.0"} }
+func (p *rulesPlugin) Info() PluginInfo {
+	if !p.reportInfo {
+		return PluginInfo{}
+	}
+	return PluginInfo{Name: "rules", Version: "0.1.0"}
+}
 
 func anyConfiguredRules(auth *config.AuthConfig) bool {
 	if len(auth.Rules) != 0 {
@@ -130,6 +309,7 @@ func anyConfiguredRules(auth *config.AuthConfig) bool {
 
 var (
 	_ WriteMiddlewareProvider = (*rulesPlugin)(nil)
+	_ PostCommitProvider      = (*rulesPlugin)(nil)
 	_ ValidatorProvider       = (*rulesPlugin)(nil)
 	_ PluginInfoProvider      = (*rulesPlugin)(nil)
 )

--- a/pkg/openlore/rules_plugin_test.go
+++ b/pkg/openlore/rules_plugin_test.go
@@ -3,6 +3,7 @@ package openlore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -18,7 +19,7 @@ import (
 
 func newTestRulesPlugin(t *testing.T, auth *config.AuthConfig, logger *slog.Logger) *rulesPlugin {
 	t.Helper()
-	p, err := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, logger)
+	p, err := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, nil, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,6 +136,122 @@ func serverAuth(docsets map[string]config.DocsetSpec, global map[string]rules.Ru
 func admitServer(server *Server, target, content string) error {
 	_, err := server.writeChain()(context.Background(), NewWriteOp(Attribution{Principal: "alice"}, writeCSBytes(target, content)))
 	return err
+}
+
+func TestFolderRulesPermissionInheritanceInvalidationAndExemption(t *testing.T) {
+	docs := docset("/docs", nil)
+	docs.Access = config.DocsetAccess{Allow: map[string]string{"writer": "rw", "editor": "ro"}}
+	docs.Config = &config.DirConfigPermission{Edit: []string{"editor"}}
+	public := docset("/public", nil)
+	public.Access = config.DocsetAccess{Allow: map[string]string{"writer": "rw", "editor": "ro"}}
+	auth := &config.AuthConfig{
+		Roles:   map[string]config.RoleSpec{"writer": {}, "editor": {}},
+		Docsets: map[string]config.DocsetSpec{"docs": docs, "public": public},
+		Identities: []config.AuthIdentity{
+			{Name: "alice", Roles: []string{"writer", "editor"}},
+			{Name: "bob", Roles: []string{"writer"}},
+			{Name: "carol", Roles: []string{"editor"}},
+		},
+	}
+	server, root := bootRulesServer(t, auth, nil)
+	if err := os.MkdirAll(filepath.Join(root, "docs", "sub", "deep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	identity := func(name string) Identity {
+		return Identity{IdentityName: name, Principal: AuthenticatedPrincipal{IdentityName: name}, Attribution: Attribution{Principal: name}, Scopes: []string{ScopeFull}}
+	}
+	configPath := "/docs/.lore/config.yaml"
+	content := "version: 1\nrules:\n  short:\n    match: ['**/*.md']\n    use: size/lines\n    with: {max: 3}\n" + strings.Repeat("# config is exempt from its own rule\n", 500)
+	if _, err := server.buildSessionFS(identity("bob")).(vfs.WritableFS).WriteFileAtomic(configPath, []byte(content), vfs.WriteOpts{}); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("writer without config.edit = %v", err)
+	}
+	if _, err := server.buildSessionFS(identity("carol")).(vfs.WritableFS).WriteFileAtomic(configPath, []byte(content), vfs.WriteOpts{}); err == nil {
+		t.Fatal("read-only config editor wrote config")
+	}
+	if _, err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).WriteFileAtomic(configPath, []byte(content), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("config editor write: %v", err)
+	}
+	var readOut, readErr bytes.Buffer
+	readerShell := server.buildSessionShell(identity("carol"))
+	if code := readerShell.ExecPipeline("cat "+configPath+"; tree /docs", &readOut, &readErr, nil); code != 0 || !strings.Contains(readOut.String(), "use: size/lines") || !strings.Contains(readOut.String(), ".lore") || !strings.Contains(readOut.String(), "config.yaml") {
+		t.Fatalf("reader config view exit=%d stdout=%s stderr=%s", code, readOut.String(), readErr.String())
+	}
+	readOut.Reset()
+	readErr.Reset()
+	if code := readerShell.ExecPipeline("lore validate /docs", &readOut, &readErr, nil); code != 0 || !strings.Contains(readOut.String(), "0 errors, 0 warnings") {
+		t.Fatalf("config exemption validate exit=%d stdout=%s stderr=%s", code, readOut.String(), readErr.String())
+	}
+
+	deep := server.buildSessionFS(identity("alice")).(vfs.WritableFS)
+	if _, err := deep.WriteFileAtomic("/docs/sub/deep/x.md", []byte("1\n2\n3\n4\n"), vfs.WriteOpts{}); err == nil || !strings.Contains(err.Error(), "short @ /docs/.lore/config.yaml") {
+		t.Fatalf("inherited rule error = %v", err)
+	}
+	if _, err := deep.WriteFileAtomic("/public/x.md", []byte("1\n2\n3\n4\n"), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("folder rule escaped docset: %v", err)
+	}
+	if err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).Remove(configPath); err != nil {
+		t.Fatalf("remove config: %v", err)
+	}
+	if _, err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).WriteFileAtomic("/docs/sub/deep/y.md", []byte("1\n2\n3\n4\n"), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("rule remained after config removal: %v", err)
+	}
+}
+
+func TestFolderRulesUnificationAndDefaultOverride(t *testing.T) {
+	newAuth := func(isDefault bool) *config.AuthConfig {
+		docs := docset("/docs", nil)
+		docs.Config = &config.DirConfigPermission{Edit: []string{"writer"}}
+		return serverAuth(map[string]config.DocsetSpec{"docs": docs}, map[string]rules.RuleSpec{
+			"limit": {Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": 10}, Default: isDefault},
+		})
+	}
+	content := "version: 1\nrules:\n  limit:\n    match: ['**/*.md']\n    use: size/lines\n    with: {max: 3}\n"
+	identity := Identity{IdentityName: "alice", Principal: AuthenticatedPrincipal{IdentityName: "alice"}, Attribution: Attribution{Principal: "alice"}, Scopes: []string{ScopeFull}}
+
+	server, _ := bootRulesServer(t, newAuth(false), nil)
+	_, err := server.buildSessionFS(identity).(vfs.WritableFS).WriteFileAtomic("/docs/.lore/config.yaml", []byte(content), vfs.WriteOpts{})
+	if err == nil || !strings.Contains(err.Error(), "rules.limit: conflicts with limit @ lore.json (max: 10 vs 3); use a new rule name to tighten") {
+		t.Fatalf("conflict error = %v", err)
+	}
+
+	server, _ = bootRulesServer(t, newAuth(true), nil)
+	fsys := server.buildSessionFS(identity).(vfs.WritableFS)
+	if _, err := fsys.WriteFileAtomic("/docs/.lore/config.yaml", []byte(content), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("default override config: %v", err)
+	}
+	if _, err := server.buildSessionFS(identity).(vfs.WritableFS).WriteFileAtomic("/docs/too-long.md", []byte("1\n2\n3\n4\n"), vfs.WriteOpts{}); err == nil || !strings.Contains(err.Error(), "limit @ /docs/.lore/config.yaml") {
+		t.Fatalf("default override did not govern: %v", err)
+	}
+}
+
+func TestFolderRulesRejectInvalidConfigAndValidateHostConfig(t *testing.T) {
+	docs := docset("/docs", nil)
+	docs.Config = &config.DirConfigPermission{Edit: []string{"writer"}}
+	auth := serverAuth(map[string]config.DocsetSpec{"docs": docs}, nil)
+	server, root := bootRulesServer(t, auth, nil)
+	id := Identity{IdentityName: "alice", Principal: AuthenticatedPrincipal{IdentityName: "alice"}, Attribution: Attribution{Principal: "alice"}, Scopes: []string{ScopeFull}}
+	fsys := server.buildSessionFS(id).(vfs.WritableFS)
+	for _, tc := range []struct {
+		content string
+		want    string
+	}{
+		{"version: 1\nhooks: {x: {}}\n", "hooks: not supported yet"},
+		{"version: 1\nunknown: true\n", "field unknown not found"},
+	} {
+		if _, err := fsys.WriteFileAtomic("/docs/.lore/config.yaml", []byte(tc.content), vfs.WriteOpts{}); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("invalid config error = %v, want %q", err, tc.want)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, "docs", ".lore"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", ".lore", "config.yaml"), []byte("version: 1\nunknown: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if code := server.buildSessionShell(id).ExecPipeline("lore validate /docs", &out, &errOut, nil); code != 1 || !strings.Contains(out.String(), ".lore/config.yaml:1:1: error [rules/config]") || !strings.Contains(out.String(), "field unknown not found") {
+		t.Fatalf("validate exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
+	}
 }
 
 func TestRulesServerBootAdmissionAndValidateOutput(t *testing.T) {

--- a/pkg/openlore/rules_plugin_test.go
+++ b/pkg/openlore/rules_plugin_test.go
@@ -201,6 +201,13 @@ func TestFolderRulesPermissionInheritanceInvalidationAndExemption(t *testing.T) 
 	if _, err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).WriteFileAtomic("/docs/sub/deep/y.md", []byte("1\n2\n3\n4\n"), vfs.WriteOpts{}); err != nil {
 		t.Fatalf("rule remained after config removal: %v", err)
 	}
+	mixed := vfs.ChangeSet{Changes: []vfs.Change{
+		{Target: configPath, Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("version: 1\nrules: {}\n")}},
+		{Target: "/docs/mixed.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("content\n")}},
+	}}
+	if _, err := server.AdmitChangeSet(context.Background(), identity("alice"), mixed); err == nil || !strings.Contains(err.Error(), "folder config mutations must be submitted separately") {
+		t.Fatalf("mixed config batch error = %v", err)
+	}
 
 	for _, name := range []string{"configured", "plain"} {
 		if err := os.Mkdir(filepath.Join(root, "docs", name), 0o755); err != nil {
@@ -211,6 +218,9 @@ func TestFolderRulesPermissionInheritanceInvalidationAndExemption(t *testing.T) 
 	if _, err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).WriteFileAtomic(configuredPath, []byte("version: 1\nrules: {}\n"), vfs.WriteOpts{}); err != nil {
 		t.Fatalf("nested config write: %v", err)
 	}
+	if _, err := server.writeLog.SubmitIdentity(context.Background(), identity("bob"), vfs.ChangeSet{Target: "/docs/configured", Action: vfs.ChangeActionRemoveAll, RemoveAll: &vfs.RemoveAllChange{}}); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("serialized RemoveAll recheck without config.edit = %v", err)
+	}
 	if err := server.buildSessionFS(identity("bob")).(vfs.WritableFS).RemoveAll("/docs/configured", vfs.RemoveOpts{}); !errors.Is(err, os.ErrPermission) {
 		t.Fatalf("RemoveAll config tree without config.edit = %v", err)
 	}
@@ -219,6 +229,35 @@ func TestFolderRulesPermissionInheritanceInvalidationAndExemption(t *testing.T) 
 	}
 	if err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).RemoveAll("/docs/configured", vfs.RemoveOpts{}); err != nil {
 		t.Fatalf("RemoveAll config tree with config.edit = %v", err)
+	}
+}
+
+func TestFolderRulesValidateThroughAlias(t *testing.T) {
+	docs := docset("/docs", nil)
+	docs.Aliases = []string{"/alias"}
+	docs.Config = &config.DirConfigPermission{Edit: []string{"writer"}}
+	auth := serverAuth(map[string]config.DocsetSpec{"docs": docs}, nil)
+	server, root := bootRulesServer(t, auth, nil)
+	id := Identity{IdentityName: "alice", Principal: AuthenticatedPrincipal{IdentityName: "alice"}, Attribution: Attribution{Principal: "alice"}, Scopes: []string{ScopeFull}}
+
+	var out, errOut bytes.Buffer
+	if code := server.buildSessionShell(id).ExecPipeline("lore validate /alias", &out, &errOut, nil); code != 0 {
+		t.Fatalf("initial alias validate exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
+	}
+	configContent := "version: 1\nrules:\n  short:\n    match: ['**/*.md']\n    use: size/lines\n    with: {max: 3}\n"
+	if _, err := server.buildSessionFS(id).(vfs.WritableFS).WriteFileAtomic("/alias/.lore/config.yaml", []byte(configContent), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("alias config write: %v", err)
+	}
+	if _, err := server.writeLog.SubmitIdentity(context.Background(), id, writeCSBytes("/docs/preapply.md", "1\n2\n3\n4\n")); err == nil || !strings.Contains(err.Error(), "size/lines") {
+		t.Fatalf("serialized rule recheck error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "too-long.md"), []byte("1\n2\n3\n4\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	errOut.Reset()
+	if code := server.buildSessionShell(id).ExecPipeline("lore validate /alias", &out, &errOut, nil); code != 1 || !strings.Contains(out.String(), "too-long.md:1:1: error [size/lines]") {
+		t.Fatalf("alias validate exit=%d stdout=%s stderr=%s", code, out.String(), errOut.String())
 	}
 }
 

--- a/pkg/openlore/rules_plugin_test.go
+++ b/pkg/openlore/rules_plugin_test.go
@@ -19,7 +19,7 @@ import (
 
 func newTestRulesPlugin(t *testing.T, auth *config.AuthConfig, logger *slog.Logger) *rulesPlugin {
 	t.Helper()
-	p, err := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, nil, nil, logger)
+	p, err := newRulesPlugin(auth, rules.Defaults{Growth: 1.25}, nil, logger)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,6 +171,12 @@ func TestFolderRulesPermissionInheritanceInvalidationAndExemption(t *testing.T) 
 	if _, err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).WriteFileAtomic(configPath, []byte(content), vfs.WriteOpts{}); err != nil {
 		t.Fatalf("config editor write: %v", err)
 	}
+	if err := server.buildSessionFS(identity("bob")).(vfs.WritableFS).Remove(configPath); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("config remove without config.edit = %v", err)
+	}
+	if _, err := server.AdmitChangeSet(context.Background(), identity("bob"), vfs.ChangeSet{Target: configPath, Action: vfs.ChangeActionRemove}); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("AdmitChangeSet config remove without config.edit = %v", err)
+	}
 	var readOut, readErr bytes.Buffer
 	readerShell := server.buildSessionShell(identity("carol"))
 	if code := readerShell.ExecPipeline("cat "+configPath+"; tree /docs", &readOut, &readErr, nil); code != 0 || !strings.Contains(readOut.String(), "use: size/lines") || !strings.Contains(readOut.String(), ".lore") || !strings.Contains(readOut.String(), "config.yaml") {
@@ -194,6 +200,25 @@ func TestFolderRulesPermissionInheritanceInvalidationAndExemption(t *testing.T) 
 	}
 	if _, err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).WriteFileAtomic("/docs/sub/deep/y.md", []byte("1\n2\n3\n4\n"), vfs.WriteOpts{}); err != nil {
 		t.Fatalf("rule remained after config removal: %v", err)
+	}
+
+	for _, name := range []string{"configured", "plain"} {
+		if err := os.Mkdir(filepath.Join(root, "docs", name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configuredPath := "/docs/configured/.lore/config.yaml"
+	if _, err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).WriteFileAtomic(configuredPath, []byte("version: 1\nrules: {}\n"), vfs.WriteOpts{}); err != nil {
+		t.Fatalf("nested config write: %v", err)
+	}
+	if err := server.buildSessionFS(identity("bob")).(vfs.WritableFS).RemoveAll("/docs/configured", vfs.RemoveOpts{}); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("RemoveAll config tree without config.edit = %v", err)
+	}
+	if err := server.buildSessionFS(identity("bob")).(vfs.WritableFS).RemoveAll("/docs/plain", vfs.RemoveOpts{}); err != nil {
+		t.Fatalf("RemoveAll plain tree with rw = %v", err)
+	}
+	if err := server.buildSessionFS(identity("alice")).(vfs.WritableFS).RemoveAll("/docs/configured", vfs.RemoveOpts{}); err != nil {
+		t.Fatalf("RemoveAll config tree with config.edit = %v", err)
 	}
 }
 

--- a/pkg/openlore/scoped_write_fs.go
+++ b/pkg/openlore/scoped_write_fs.go
@@ -94,19 +94,21 @@ func mutationDeniedError(fsys vfs.FileSystem, action vfs.ChangeAction, target st
 	if isDirConfigPath(target) {
 		return os.ErrPermission
 	}
-	if action == vfs.ChangeActionRemoveAll {
-		containsConfig := false
-		_ = vfs.WalkDir(fsys, target, func(candidate string, _ *vfs.FileInfo, err error) error {
-			if err == nil && isDirConfigPath(candidate) {
-				containsConfig = true
-			}
-			return nil
-		})
-		if containsConfig {
-			return os.ErrPermission
-		}
+	if action == vfs.ChangeActionRemoveAll && treeContainsDirConfig(fsys, target) {
+		return os.ErrPermission
 	}
 	return vfs.ErrReadOnly
+}
+
+func treeContainsDirConfig(fsys vfs.FileSystem, target string) bool {
+	containsConfig := false
+	_ = vfs.WalkDir(fsys, target, func(candidate string, _ *vfs.FileInfo, err error) error {
+		if err == nil && isDirConfigPath(candidate) {
+			containsConfig = true
+		}
+		return nil
+	})
+	return containsConfig
 }
 func (s *scopedWriteFS) GetXattr(p, name string) ([]byte, error) {
 	x, ok := s.FileSystem.(vfs.XattrReader)

--- a/pkg/openlore/scoped_write_fs.go
+++ b/pkg/openlore/scoped_write_fs.go
@@ -38,10 +38,7 @@ func newScopedWriteFS(base vfs.FileSystem, authz writeAuthorizer) *scopedWriteFS
 
 func (s *scopedWriteFS) WriteFileAtomic(p string, data []byte, opts vfs.WriteOpts) (string, error) {
 	if s.inner == nil || !s.authorize(vfs.ChangeActionWrite, p) {
-		if isDirConfigPath(p) {
-			return "", os.ErrPermission
-		}
-		return "", vfs.ErrReadOnly
+		return "", mutationDeniedError(s.FileSystem, vfs.ChangeActionWrite, p)
 	}
 	return s.inner.WriteFileAtomic(p, data, opts)
 }
@@ -53,10 +50,7 @@ func (s *scopedWriteFS) AdmitChangeSet(cs vfs.ChangeSet) error {
 	}
 	for _, change := range cs.Leaves() {
 		if !s.authorize(change.Action, change.Target) {
-			if isDirConfigPath(change.Target) {
-				return os.ErrPermission
-			}
-			return vfs.ErrReadOnly
+			return mutationDeniedError(s.FileSystem, change.Action, change.Target)
 		}
 	}
 	return a.AdmitChangeSet(cs)
@@ -70,30 +64,49 @@ func (s *scopedWriteFS) CanWrite(p string) bool {
 
 func (s *scopedWriteFS) Mkdir(p string) error {
 	if s.inner == nil || !s.authorize(vfs.ChangeActionMkdir, p) {
-		return vfs.ErrReadOnly
+		return mutationDeniedError(s.FileSystem, vfs.ChangeActionMkdir, p)
 	}
 	return s.inner.Mkdir(p)
 }
 
 func (s *scopedWriteFS) MkdirAll(p string) error {
 	if s.inner == nil || !s.authorize(vfs.ChangeActionMkdirAll, p) {
-		return vfs.ErrReadOnly
+		return mutationDeniedError(s.FileSystem, vfs.ChangeActionMkdirAll, p)
 	}
 	return s.inner.MkdirAll(p)
 }
 
 func (s *scopedWriteFS) Remove(p string) error {
 	if s.inner == nil || !s.authorize(vfs.ChangeActionRemove, p) {
-		return vfs.ErrReadOnly
+		return mutationDeniedError(s.FileSystem, vfs.ChangeActionRemove, p)
 	}
 	return s.inner.Remove(p)
 }
 
 func (s *scopedWriteFS) RemoveAll(p string, opts vfs.RemoveOpts) error {
 	if s.inner == nil || !s.authorize(vfs.ChangeActionRemoveAll, p) {
-		return vfs.ErrReadOnly
+		return mutationDeniedError(s.FileSystem, vfs.ChangeActionRemoveAll, p)
 	}
 	return s.inner.RemoveAll(p, opts)
+}
+
+func mutationDeniedError(fsys vfs.FileSystem, action vfs.ChangeAction, target string) error {
+	if isDirConfigPath(target) {
+		return os.ErrPermission
+	}
+	if action == vfs.ChangeActionRemoveAll {
+		containsConfig := false
+		_ = vfs.WalkDir(fsys, target, func(candidate string, _ *vfs.FileInfo, err error) error {
+			if err == nil && isDirConfigPath(candidate) {
+				containsConfig = true
+			}
+			return nil
+		})
+		if containsConfig {
+			return os.ErrPermission
+		}
+	}
+	return vfs.ErrReadOnly
 }
 func (s *scopedWriteFS) GetXattr(p, name string) ([]byte, error) {
 	x, ok := s.FileSystem.(vfs.XattrReader)

--- a/pkg/openlore/scoped_write_fs.go
+++ b/pkg/openlore/scoped_write_fs.go
@@ -1,8 +1,10 @@
 package openlore
 
 import (
-	"github.com/aakarim/go-openlore/pkg/vfs"
+	"os"
 	"syscall"
+
+	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
 // writeAuthorizer decides whether a session may perform a mutation action on a
@@ -36,6 +38,9 @@ func newScopedWriteFS(base vfs.FileSystem, authz writeAuthorizer) *scopedWriteFS
 
 func (s *scopedWriteFS) WriteFileAtomic(p string, data []byte, opts vfs.WriteOpts) (string, error) {
 	if s.inner == nil || !s.authorize(vfs.ChangeActionWrite, p) {
+		if isDirConfigPath(p) {
+			return "", os.ErrPermission
+		}
 		return "", vfs.ErrReadOnly
 	}
 	return s.inner.WriteFileAtomic(p, data, opts)
@@ -48,6 +53,9 @@ func (s *scopedWriteFS) AdmitChangeSet(cs vfs.ChangeSet) error {
 	}
 	for _, change := range cs.Leaves() {
 		if !s.authorize(change.Action, change.Target) {
+			if isDirConfigPath(change.Target) {
+				return os.ErrPermission
+			}
 			return vfs.ErrReadOnly
 		}
 	}

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -257,19 +257,17 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 			return nil, err
 		}
 	}
-	if anyConfiguredRules(s.auth) {
-		rulesPlugin, err := newRulesPlugin(s.auth, rules.Defaults{Growth: cfg.Rules.Growth}, logger)
-		if err != nil {
-			return nil, err
-		}
-		if err := s.registerPlugin(rulesPlugin); err != nil {
-			return nil, err
-		}
-		// OKF metadata remains owned by the existing adapter; admission and
-		// validation are provided exclusively by the rules engine above.
-		if anyDocsetHasOKF(s.auth.Docsets) {
-			s.metaExtenders = append(s.metaExtenders, newOKF(s.auth.Docsets, logger).MetaExtenders()...)
-		}
+	rulesPlugin, err := newRulesPlugin(s.auth, rules.Defaults{Growth: cfg.Rules.Growth}, s.merge, s, logger)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.registerPlugin(rulesPlugin); err != nil {
+		return nil, err
+	}
+	// OKF metadata remains owned by the existing adapter; admission and
+	// validation are provided exclusively by the rules engine above.
+	if anyDocsetHasOKF(s.auth.Docsets) {
+		s.metaExtenders = append(s.metaExtenders, newOKF(s.auth.Docsets, logger).MetaExtenders()...)
 	}
 	if shellPlugin != nil {
 		if err := s.registerPlugin(shellPlugin); err != nil {
@@ -847,7 +845,9 @@ func (s *Server) registerPlugin(p any) error {
 	// inbox plugin, wired by the CLI via RegisterPlugin) too.
 	if ip, ok := p.(PluginInfoProvider); ok && s.logger != nil {
 		info := ip.Info()
-		s.logger.Info("plugin registered", "name", info.Name, "version", info.Version)
+		if info.Name != "" {
+			s.logger.Info("plugin registered", "name", info.Name, "version", info.Version)
+		}
 	}
 	if hp, ok := p.(HTTPRouteProvider); ok {
 		s.httpRoutes = append(s.httpRoutes, hp)

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -257,7 +257,7 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 			return nil, err
 		}
 	}
-	rulesPlugin, err := newRulesPlugin(s.auth, rules.Defaults{Growth: cfg.Rules.Growth}, s.merge, s, logger)
+	rulesPlugin, err := newRulesPlugin(s.auth, rules.Defaults{Growth: cfg.Rules.Growth}, s.merge, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -757,7 +757,7 @@ func (s *Server) AdmitChangeSet(ctx context.Context, id Identity, cs vfs.ChangeS
 	}
 	for _, change := range cs.Leaves() {
 		if !s.identityCanWrite(id, change.Action, change.Target) {
-			return WriteResult{}, vfs.ErrReadOnly
+			return WriteResult{}, mutationDeniedError(s.merge, change.Action, change.Target)
 		}
 	}
 	return s.writeChain()(ctx, NewWriteOp(id.attribution(), cs))
@@ -845,9 +845,7 @@ func (s *Server) registerPlugin(p any) error {
 	// inbox plugin, wired by the CLI via RegisterPlugin) too.
 	if ip, ok := p.(PluginInfoProvider); ok && s.logger != nil {
 		info := ip.Info()
-		if info.Name != "" {
-			s.logger.Info("plugin registered", "name", info.Name, "version", info.Version)
-		}
+		s.logger.Info("plugin registered", "name", info.Name, "version", info.Version)
 	}
 	if hp, ok := p.(HTTPRouteProvider); ok {
 		s.httpRoutes = append(s.httpRoutes, hp)

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -313,12 +313,32 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		s.writeLog = newWriteLog(s.merge, s.postCommitChain(), logger, 0)
 		s.historyPath = filepath.Join(dataDir, "history", "commits.jsonl")
 		s.writeLog.SetCommitRecorder(NewJSONLCommitRecorder(s.historyPath))
+		s.writeLog.SetPreApply(func(identity *Identity, attribution Attribution, changes vfs.ChangeSet) error {
+			for _, change := range changes.Leaves() {
+				if identity != nil {
+					if !s.identityCanWrite(*identity, change.Action, change.Target) {
+						return mutationDeniedError(s.merge, change.Action, change.Target)
+					}
+				} else if isDirConfigPath(change.Target) || (change.Action == vfs.ChangeActionRemoveAll && treeContainsDirConfig(s.merge, change.Target)) {
+					// Approved/deferred submissions preserve attribution but not the
+					// original authorization context. Fail closed if current state
+					// requires config.edit; the caller must resubmit normally.
+					return os.ErrPermission
+				}
+			}
+			if err := rulesPlugin.PreApply(attribution, changes); err != nil {
+				return err
+			}
+			if agentSkills != nil {
+				return agentSkills.validateMutation(attribution, changes)
+			}
+			return nil
+		})
 		if agentSkills != nil {
 			agentSkills.submit = func(ctx context.Context, cs vfs.ChangeSet) error {
 				_, err := s.CommitChangeSet(ctx, Attribution{Principal: "agent_skills_remote", internal: true}, cs)
 				return err
 			}
-			s.writeLog.SetPreApply(agentSkills.validateMutation)
 		}
 
 		// Async external work (Part D): the `spawn` command runs a command in a
@@ -760,7 +780,7 @@ func (s *Server) AdmitChangeSet(ctx context.Context, id Identity, cs vfs.ChangeS
 			return WriteResult{}, mutationDeniedError(s.merge, change.Action, change.Target)
 		}
 	}
-	return s.writeChain()(ctx, NewWriteOp(id.attribution(), cs))
+	return s.writeChain()(ctx, newIdentityWriteOp(id, cs))
 }
 
 type HTTPRouteProvider interface {
@@ -861,7 +881,13 @@ func (s *Server) registerPlugin(p any) error {
 // chain is just the terminal submit.
 func (s *Server) writeChain() WriteHandler {
 	terminal := func(ctx context.Context, op WriteOp) (WriteResult, error) {
-		h, err := s.writeLog.Submit(ctx, op.Attribution, op.persistenceChangeSet())
+		var h string
+		var err error
+		if op.identity != nil {
+			h, err = s.writeLog.SubmitIdentity(ctx, *op.identity, op.persistenceChangeSet())
+		} else {
+			h, err = s.writeLog.Submit(ctx, op.Attribution, op.persistenceChangeSet())
+		}
 		return WriteResult{Hash: h}, err
 	}
 	return chainWrite(terminal, s.writeMW...)
@@ -933,7 +959,7 @@ func (s *Server) buildCanonicalSessionFS(id Identity) vfs.FileSystem {
 	// Innermost writable wrapper, so the outer layers (scope) can deny or defer
 	// a mutation before it ever becomes a log entry.
 	if s.writeLog != nil {
-		sessionFS = newMiddlewareFS(sessionFS, id.attribution(), s.writeChain())
+		sessionFS = newIdentityMiddlewareFS(sessionFS, id, s.writeChain())
 	}
 	// A write-capable session must be a named non-guest identity with full token
 	// scope. The per-operation authorizer below resolves current roles and grants;

--- a/pkg/openlore/server_seams_test.go
+++ b/pkg/openlore/server_seams_test.go
@@ -108,8 +108,8 @@ func TestUnsupportedShellUsageIsLoggedOnlyInDebugMode(t *testing.T) {
 			sh.ExecPipeline("| echo hello", &bytes.Buffer{}, &bytes.Buffer{}, nil)
 
 			got := logs.String()
-			if (got != "") != tt.want {
-				t.Fatalf("logs = %q, want event: %t", got, tt.want)
+			if strings.Contains(got, `"msg":"unsupported shell usage"`) != tt.want {
+				t.Fatalf("logs = %q, want unsupported-usage event: %t", got, tt.want)
 			}
 			if !tt.want {
 				return

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/rules"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -283,8 +284,7 @@ func hasReservedPath(p string) bool {
 }
 
 func isDirConfigPath(p string) bool {
-	clean := vfs.CleanPath(p)
-	return path.Base(clean) == "config.yaml" && path.Base(path.Dir(clean)) == ".lore"
+	return rules.IsDirConfigPath(p)
 }
 
 func hasTraversal(p string) bool {

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -110,7 +110,8 @@ func (d *DirFS) PreflightChange(change vfs.Change) error {
 	}
 	p := change.Target
 	clean := vfs.CleanPath(p)
-	if isTrashPath(clean) || hasReservedPath(p) || hasTraversal(p) || isIgnored(p, d.files) {
+	dirConfig := isDirConfigPath(p)
+	if isTrashPath(clean) || (hasReservedPath(p) && !dirConfig) || hasTraversal(p) || (isIgnored(p, d.files) && !dirConfig) {
 		return fmt.Errorf("access denied: %s", p)
 	}
 	switch change.Action {
@@ -125,7 +126,7 @@ func (d *DirFS) PreflightChange(change vfs.Change) error {
 		if !change.Write.Opts.ContentPolicyValidated && int64(len(change.Write.Bytes)) > max {
 			return fmt.Errorf("write rejected: %d bytes exceeds limit of %d", len(change.Write.Bytes), max)
 		}
-		if !change.Write.Opts.ContentPolicyValidated && !isAllowed(path.Base(p), d.files) {
+		if !dirConfig && !change.Write.Opts.ContentPolicyValidated && !isAllowed(path.Base(p), d.files) {
 			return fmt.Errorf("access denied: %s", p)
 		}
 	case vfs.ChangeActionMkdir, vfs.ChangeActionMkdirAll:
@@ -145,6 +146,7 @@ func (d *DirFS) PreflightChange(change vfs.Change) error {
 // the read-current → check → swap sequence is atomic. Returns the hex SHA-256
 // of the committed bytes.
 func (d *DirFS) WriteFileAtomic(p string, content []byte, opts vfs.WriteOpts) (string, error) {
+	dirConfig := isDirConfigPath(p)
 	max := d.maxWriteBytes
 	if max == 0 {
 		max = defaultMaxWriteBytes
@@ -152,13 +154,13 @@ func (d *DirFS) WriteFileAtomic(p string, content []byte, opts vfs.WriteOpts) (s
 	if !opts.ContentPolicyValidated && int64(len(content)) > max {
 		return "", fmt.Errorf("write rejected: %d bytes exceeds limit of %d", len(content), max)
 	}
-	if isTrashPath(vfs.CleanPath(p)) || hasReservedPath(p) || hasTraversal(p) {
+	if isTrashPath(vfs.CleanPath(p)) || (hasReservedPath(p) && !dirConfig) || hasTraversal(p) {
 		return "", fmt.Errorf("access denied: %s", p)
 	}
-	if !opts.ContentPolicyValidated && !isAllowed(path.Base(p), d.files) {
+	if !dirConfig && !opts.ContentPolicyValidated && !isAllowed(path.Base(p), d.files) {
 		return "", fmt.Errorf("access denied: %s", p)
 	}
-	if isIgnored(p, d.files) {
+	if !dirConfig && isIgnored(p, d.files) {
 		return "", fmt.Errorf("access denied: %s", p)
 	}
 
@@ -280,6 +282,11 @@ func hasReservedPath(p string) bool {
 	return false
 }
 
+func isDirConfigPath(p string) bool {
+	clean := vfs.CleanPath(p)
+	return path.Base(clean) == "config.yaml" && path.Base(path.Dir(clean)) == ".lore"
+}
+
 func hasTraversal(p string) bool {
 	for _, part := range strings.Split(strings.ReplaceAll(p, "\\", "/"), "/") {
 		if part == ".." {
@@ -374,10 +381,11 @@ func (d *DirFS) MkdirAll(p string) error {
 // root (or anything at/above one) and a non-empty directory.
 func (d *DirFS) Remove(p string) error {
 	clean := vfs.CleanPath(p)
+	dirConfig := isDirConfigPath(p)
 	if clean == "/" {
 		return fmt.Errorf("cannot delete docset root: %s", p)
 	}
-	if isTrashPath(clean) || hasReservedPath(p) || hasTraversal(p) || isIgnored(p, d.files) {
+	if isTrashPath(clean) || (hasReservedPath(p) && !dirConfig) || hasTraversal(p) || (isIgnored(p, d.files) && !dirConfig) {
 		return fmt.Errorf("access denied: %s", p)
 	}
 	if !d.insideDocset(clean) {
@@ -397,7 +405,7 @@ func (d *DirFS) Remove(p string) error {
 	if err != nil {
 		return err
 	}
-	if !info.IsDir() && !isAllowed(info.Name(), d.files) {
+	if !dirConfig && !info.IsDir() && !isAllowed(info.Name(), d.files) {
 		return fmt.Errorf("access denied: %s", p)
 	}
 	if err := os.Remove(full); err != nil {
@@ -479,6 +487,20 @@ func (d *DirFS) rawSnapshot(clean, full string) (*vfs.TreeSnapshot, error) {
 		}
 		rel = filepath.ToSlash(rel)
 		if entry.IsDir() && entry.Name() == ".lore" {
+			configPath := filepath.Join(fp, "config.yaml")
+			info, err := os.Stat(configPath)
+			if err == nil && !info.IsDir() {
+				dirRel := filepath.ToSlash(filepath.Join(rel))
+				snap.Ops = append(snap.Ops, vfs.TreeOp{RelPath: dirRel, Kind: "dir"})
+				data, err := os.ReadFile(configPath)
+				if err != nil {
+					return err
+				}
+				sum := sha256.Sum256(data)
+				snap.Ops = append(snap.Ops, vfs.TreeOp{RelPath: path.Join(dirRel, "config.yaml"), Kind: "file", Hash: hex.EncodeToString(sum[:]), Size: int64(len(data))})
+			} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return err
+			}
 			return filepath.SkipDir
 		}
 		logical := clean
@@ -622,7 +644,19 @@ func atomicWrite(full string, content []byte) error {
 }
 
 func (d *DirFS) Stat(p string) (*vfs.FileInfo, error) {
-	if isTrashPath(vfs.CleanPath(p)) || hasReservedPath(p) || hasTraversal(p) {
+	clean := vfs.CleanPath(p)
+	if path.Base(clean) == ".lore" && !hasTraversal(p) {
+		if info, err := os.Stat(filepath.Join(d.resolve(clean), "config.yaml")); err != nil || info.IsDir() {
+			return nil, os.ErrNotExist
+		}
+		info, err := os.Stat(d.resolve(clean))
+		if err != nil {
+			return nil, err
+		}
+		return &vfs.FileInfo{FileName: ".lore", FilePath: clean, FileSize: info.Size(), FileModTime: info.ModTime(), Dir: true}, nil
+	}
+	dirConfig := isDirConfigPath(p)
+	if isTrashPath(clean) || (hasReservedPath(p) && !dirConfig) || hasTraversal(p) {
 		return nil, os.ErrNotExist
 	}
 	full := d.resolve(p)
@@ -631,11 +665,11 @@ func (d *DirFS) Stat(p string) (*vfs.FileInfo, error) {
 		return nil, err
 	}
 
-	if !info.IsDir() && !isAllowed(info.Name(), d.files) {
+	if !dirConfig && !info.IsDir() && !isAllowed(info.Name(), d.files) {
 		return nil, fmt.Errorf("access denied: %s", p)
 	}
 
-	if info.IsDir() && isIgnored(p, d.files) {
+	if !dirConfig && info.IsDir() && isIgnored(p, d.files) {
 		return nil, fmt.Errorf("access denied: %s", p)
 	}
 
@@ -649,7 +683,22 @@ func (d *DirFS) Stat(p string) (*vfs.FileInfo, error) {
 }
 
 func (d *DirFS) ReadDir(p string) ([]vfs.FileInfo, error) {
-	if isTrashPath(vfs.CleanPath(p)) || hasReservedPath(p) || hasTraversal(p) {
+	clean := vfs.CleanPath(p)
+	if path.Base(clean) == ".lore" {
+		if hasTraversal(p) {
+			return nil, os.ErrNotExist
+		}
+		configPath := path.Join(clean, "config.yaml")
+		info, err := os.Stat(d.resolve(configPath))
+		if err != nil {
+			return nil, err
+		}
+		if info.IsDir() {
+			return nil, os.ErrNotExist
+		}
+		return []vfs.FileInfo{{FileName: "config.yaml", FilePath: configPath, FileSize: info.Size(), FileModTime: info.ModTime()}}, nil
+	}
+	if isTrashPath(clean) || hasReservedPath(p) || hasTraversal(p) {
 		return nil, os.ErrNotExist
 	}
 	if isIgnored(p, d.files) {
@@ -665,6 +714,13 @@ func (d *DirFS) ReadDir(p string) ([]vfs.FileInfo, error) {
 	var result []vfs.FileInfo
 	for _, e := range entries {
 		if e.Name() == ".lore" {
+			configInfo, err := os.Stat(filepath.Join(full, ".lore", "config.yaml"))
+			if err == nil && !configInfo.IsDir() {
+				info, infoErr := e.Info()
+				if infoErr == nil {
+					result = append(result, vfs.FileInfo{FileName: ".lore", FilePath: path.Join(vfs.CleanPath(p), ".lore"), FileSize: info.Size(), FileModTime: info.ModTime(), Dir: true})
+				}
+			}
 			continue
 		}
 		childPath := path.Join(p, e.Name())
@@ -697,10 +753,11 @@ func (d *DirFS) ReadDir(p string) ([]vfs.FileInfo, error) {
 }
 
 func (d *DirFS) ReadFile(p string) ([]byte, error) {
-	if isTrashPath(vfs.CleanPath(p)) || hasReservedPath(p) || hasTraversal(p) {
+	dirConfig := isDirConfigPath(p)
+	if isTrashPath(vfs.CleanPath(p)) || (hasReservedPath(p) && !dirConfig) || hasTraversal(p) {
 		return nil, os.ErrNotExist
 	}
-	if !isAllowed(path.Base(p), d.files) {
+	if !dirConfig && !isAllowed(path.Base(p), d.files) {
 		return nil, fmt.Errorf("access denied: %s", p)
 	}
 

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -645,7 +645,7 @@ func atomicWrite(full string, content []byte) error {
 
 func (d *DirFS) Stat(p string) (*vfs.FileInfo, error) {
 	clean := vfs.CleanPath(p)
-	if path.Base(clean) == ".lore" && !hasTraversal(p) {
+	if path.Base(clean) == ".lore" && !hasTraversal(p) && isDirConfigPath(path.Join(clean, "config.yaml")) {
 		if info, err := os.Stat(filepath.Join(d.resolve(clean), "config.yaml")); err != nil || info.IsDir() {
 			return nil, os.ErrNotExist
 		}
@@ -684,7 +684,7 @@ func (d *DirFS) Stat(p string) (*vfs.FileInfo, error) {
 
 func (d *DirFS) ReadDir(p string) ([]vfs.FileInfo, error) {
 	clean := vfs.CleanPath(p)
-	if path.Base(clean) == ".lore" {
+	if path.Base(clean) == ".lore" && isDirConfigPath(path.Join(clean, "config.yaml")) {
 		if hasTraversal(p) {
 			return nil, os.ErrNotExist
 		}

--- a/pkg/openlore/writelog.go
+++ b/pkg/openlore/writelog.go
@@ -31,6 +31,7 @@ type applyResult struct {
 type logEntry struct {
 	cs          vfs.ChangeSet
 	attribution Attribution
+	identity    *Identity
 	reply       chan applyResult
 }
 
@@ -93,7 +94,7 @@ type writeLog struct {
 
 	mu         sync.RWMutex      // guards closed + postCommit + serializes sends against Close
 	postCommit PostCommitHandler // optional; runs at the applier after a durable commit
-	preApply   func(Attribution, vfs.ChangeSet) error
+	preApply   func(*Identity, Attribution, vfs.ChangeSet) error
 	recorder   CommitRecorder
 	closed     bool
 	ch         chan logEntry
@@ -148,7 +149,7 @@ func (l *writeLog) run() {
 		pre := l.preApply
 		l.mu.RUnlock()
 		if err == nil && pre != nil {
-			err = pre(e.attribution, e.cs)
+			err = pre(e.identity, e.attribution, e.cs)
 		}
 		if err == nil {
 			committed, err = vfs.CommitChangeSet(l.substrate, e.cs)
@@ -184,7 +185,7 @@ func (l *writeLog) run() {
 	}
 }
 
-func (l *writeLog) SetPreApply(h func(Attribution, vfs.ChangeSet) error) {
+func (l *writeLog) SetPreApply(h func(*Identity, Attribution, vfs.ChangeSet) error) {
 	l.mu.Lock()
 	l.preApply = h
 	l.mu.Unlock()
@@ -211,6 +212,14 @@ func (l *writeLog) SetPostCommit(h PostCommitHandler) {
 // post-commit chain. It returns ErrLogClosed if the log is shutting down, or
 // ctx.Err() if ctx is cancelled first.
 func (l *writeLog) Submit(ctx context.Context, attribution Attribution, cs vfs.ChangeSet) (string, error) {
+	return l.submit(ctx, nil, attribution, cs)
+}
+
+func (l *writeLog) SubmitIdentity(ctx context.Context, identity Identity, cs vfs.ChangeSet) (string, error) {
+	return l.submit(ctx, &identity, identity.attribution(), cs)
+}
+
+func (l *writeLog) submit(ctx context.Context, identity *Identity, attribution Attribution, cs vfs.ChangeSet) (string, error) {
 	reply := make(chan applyResult, 1)
 
 	// Hold the read lock across the send so Close (which takes the write lock)
@@ -221,7 +230,7 @@ func (l *writeLog) Submit(ctx context.Context, attribution Attribution, cs vfs.C
 		return "", ErrLogClosed
 	}
 	select {
-	case l.ch <- logEntry{cs: cs, attribution: attribution, reply: reply}:
+	case l.ch <- logEntry{cs: cs, attribution: attribution, identity: identity, reply: reply}:
 		l.mu.RUnlock()
 	case <-ctx.Done():
 		l.mu.RUnlock()

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -37,6 +37,101 @@ func (e *BundleRootError) Error() string {
 
 func New(options Options) *Engine { return &Engine{options: options} }
 
+// CheckConfigFile validates a proposed .lore/config.yaml against every layer
+// above its containing directory.
+func (e *Engine) CheckConfigFile(ctx context.Context, dir string, content []byte) error {
+	configPath := path.Join(vfs.CleanPath(dir), ".lore/config.yaml")
+	config, err := DecodeFile(content)
+	if err != nil {
+		return fmt.Errorf("%s: %w", configPath, err)
+	}
+	target := path.Join(vfs.CleanPath(dir), "__rules_config_check__.md")
+	var layers []Layer
+	if e.options.Config != nil {
+		got, err := e.options.Config.LayersFor(ctx, target)
+		if err != nil {
+			return fmt.Errorf("%s: %w", configPath, err)
+		}
+		layers = append(layers, got...)
+	}
+	if e.options.Folders != nil {
+		folders, ok := e.options.Folders.(FolderLayerSource)
+		if !ok {
+			return fmt.Errorf("%s: folder layer source cannot validate config", configPath)
+		}
+		got, err := folders.LayersAbove(ctx, dir)
+		if err != nil {
+			return fmt.Errorf("%s: %w", configPath, err)
+		}
+		layers = append(layers, got...)
+	}
+	layers = append(layers, Layer{Origin: configPath, Scope: vfs.CleanPath(dir), Rules: config.Rules})
+	unified, err := Unify(layers)
+	if err != nil {
+		var conflict *UnificationError
+		if errors.As(err, &conflict) {
+			return fmt.Errorf("%s: rules.%s: conflicts with %s @ %s (%s); use a new rule name to tighten", configPath, conflict.Rule, conflict.Rule, conflict.OuterOrigin, conflictDetails(conflict, layers))
+		}
+		return fmt.Errorf("%s: %w", configPath, err)
+	}
+	env := e.options.Env
+	if env == nil {
+		env = func(string) Env { return Env{} }
+	}
+	if _, err := Compile(e.options.Registry, env, unified); err != nil {
+		return fmt.Errorf("%s: %w", configPath, err)
+	}
+	return nil
+}
+
+func conflictDetails(conflict *UnificationError, layers []Layer) string {
+	var outer, inner RuleSpec
+	for _, layer := range layers {
+		spec, ok := layer.Rules[conflict.Rule]
+		if !ok {
+			continue
+		}
+		if layer.Origin == conflict.OuterOrigin {
+			outer = spec
+		}
+		if layer.Origin == conflict.InnerOrigin {
+			inner = spec
+		}
+	}
+	var details []string
+	for _, key := range conflict.DifferingKeys {
+		if key != "with" {
+			details = append(details, key+" differs")
+			continue
+		}
+		keys := make(map[string]bool, len(outer.With)+len(inner.With))
+		for name := range outer.With {
+			keys[name] = true
+		}
+		for name := range inner.With {
+			keys[name] = true
+		}
+		names := make([]string, 0, len(keys))
+		for name := range keys {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if fmt.Sprint(outer.With[name]) != fmt.Sprint(inner.With[name]) {
+				details = append(details, fmt.Sprintf("%s: %v vs %v", name, outer.With[name], inner.With[name]))
+			}
+		}
+	}
+	return strings.Join(details, ", ")
+}
+
+// Invalidate drops cached folder layers at and below dir.
+func (e *Engine) Invalidate(dir string) {
+	if folders, ok := e.options.Folders.(FolderLayerSource); ok {
+		folders.Invalidate(dir)
+	}
+}
+
 func (e *Engine) Effective(ctx context.Context, target string) ([]CompiledRule, error) {
 	var layers []Layer
 	for _, source := range []LayerSource{e.options.Config, e.options.Folders} {
@@ -104,6 +199,11 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 	return nil
 }
 
+func IsDirConfigPath(target string) bool {
+	clean := vfs.CleanPath(target)
+	return path.Base(clean) == "config.yaml" && path.Base(path.Dir(clean)) == ".lore"
+}
+
 func (e *Engine) ValidateFile(ctx context.Context, fsys vfs.FileSystem, bundleRoot, target string, content []byte) []validation.Diagnostic {
 	return e.validateFile(ctx, fsys, bundleRoot, target, content, nil)
 }
@@ -155,16 +255,34 @@ func (e *Engine) validateFile(ctx context.Context, fsys vfs.FileSystem, bundleRo
 func (e *Engine) Validator() validation.Validator {
 	return func(bundle validation.Bundle) []validation.Diagnostic {
 		var out []validation.Diagnostic
-		bundleRules, err := e.Effective(context.Background(), bundle.Root)
-		if err != nil {
-			rule := "rules/config"
-			var rootErr *BundleRootError
-			if errors.As(err, &rootErr) {
-				rule = "rules/bundle-root"
+		invalidDirs := map[string]bool{}
+		for _, file := range bundle.Files {
+			if !IsDirConfigPath(file.AbsolutePath) || beneathInvalidConfig(file.AbsolutePath, invalidDirs) {
+				continue
 			}
-			return []validation.Diagnostic{{Path: bundle.Root, Line: 1, Column: 1, Severity: validation.SeverityError, Rule: rule, Message: err.Error()}}
+			dir := path.Dir(path.Dir(file.AbsolutePath))
+			if err := e.CheckConfigFile(context.Background(), dir, file.Content); err != nil {
+				invalidDirs[dir] = true
+				out = append(out, validation.Diagnostic{Path: relative(bundle.Root, file.AbsolutePath), Line: 1, Column: 1, Severity: validation.SeverityError, Rule: "rules/config", Message: err.Error()})
+			}
+		}
+		var bundleRules []CompiledRule
+		if !invalidDirs[vfs.CleanPath(bundle.Root)] {
+			var err error
+			bundleRules, err = e.Effective(context.Background(), bundle.Root)
+			if err != nil {
+				rule := "rules/config"
+				var rootErr *BundleRootError
+				if errors.As(err, &rootErr) {
+					rule = "rules/bundle-root"
+				}
+				return []validation.Diagnostic{{Path: bundle.Root, Line: 1, Column: 1, Severity: validation.SeverityError, Rule: rule, Message: err.Error()}}
+			}
 		}
 		for _, file := range bundle.Files {
+			if IsDirConfigPath(file.AbsolutePath) || beneathInvalidConfig(file.AbsolutePath, invalidDirs) {
+				continue
+			}
 			out = append(out, e.validateFile(context.Background(), bundle.FS, bundle.Root, file.AbsolutePath, file.Content, &bundle)...)
 		}
 		for _, rule := range bundleRules {
@@ -205,6 +323,15 @@ func (e *Engine) Validator() validation.Validator {
 		SortDiagnostics(out)
 		return out
 	}
+}
+
+func beneathInvalidConfig(target string, invalid map[string]bool) bool {
+	for dir := range invalid {
+		if target == dir || strings.HasPrefix(target, strings.TrimSuffix(dir, "/")+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func (e *Engine) ValidateBundle(ctx context.Context, fsys vfs.FileSystem, root string) ([]validation.Diagnostic, error) {

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -16,7 +16,7 @@ import (
 type Options struct {
 	Registry *Registry
 	Config   LayerSource
-	Folders  LayerSource
+	Folders  FolderLayerSource
 	Env      func(string) Env
 	Logger   *slog.Logger
 }
@@ -55,11 +55,7 @@ func (e *Engine) CheckConfigFile(ctx context.Context, dir string, content []byte
 		layers = append(layers, got...)
 	}
 	if e.options.Folders != nil {
-		folders, ok := e.options.Folders.(FolderLayerSource)
-		if !ok {
-			return fmt.Errorf("%s: folder layer source cannot validate config", configPath)
-		}
-		got, err := folders.LayersAbove(ctx, dir)
+		got, err := e.options.Folders.LayersAbove(ctx, dir)
 		if err != nil {
 			return fmt.Errorf("%s: %w", configPath, err)
 		}
@@ -127,18 +123,31 @@ func conflictDetails(conflict *UnificationError, layers []Layer) string {
 
 // Invalidate drops cached folder layers at and below dir.
 func (e *Engine) Invalidate(dir string) {
-	if folders, ok := e.options.Folders.(FolderLayerSource); ok {
-		folders.Invalidate(dir)
+	if e.options.Folders != nil {
+		e.options.Folders.Invalidate(dir)
 	}
 }
 
 func (e *Engine) Effective(ctx context.Context, target string) ([]CompiledRule, error) {
+	return e.effective(ctx, target, path.Dir(vfs.CleanPath(target)))
+}
+
+func (e *Engine) effectiveDir(ctx context.Context, dir string) ([]CompiledRule, error) {
+	dir = vfs.CleanPath(dir)
+	return e.effective(ctx, dir, dir)
+}
+
+func (e *Engine) effective(ctx context.Context, target, dir string) ([]CompiledRule, error) {
 	var layers []Layer
-	for _, source := range []LayerSource{e.options.Config, e.options.Folders} {
-		if source == nil {
-			continue
+	if e.options.Config != nil {
+		got, err := e.options.Config.LayersFor(ctx, target)
+		if err != nil {
+			return nil, err
 		}
-		got, err := source.LayersFor(ctx, target)
+		layers = append(layers, got...)
+	}
+	if e.options.Folders != nil {
+		got, err := e.options.Folders.LayersForDir(ctx, dir)
 		if err != nil {
 			return nil, err
 		}
@@ -201,7 +210,15 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 
 func IsDirConfigPath(target string) bool {
 	clean := vfs.CleanPath(target)
-	return path.Base(clean) == "config.yaml" && path.Base(path.Dir(clean)) == ".lore"
+	if path.Base(clean) != "config.yaml" || path.Base(path.Dir(clean)) != ".lore" {
+		return false
+	}
+	for _, segment := range strings.Split(strings.Trim(path.Dir(path.Dir(clean)), "/"), "/") {
+		if segment == ".lore" {
+			return false
+		}
+	}
+	return true
 }
 
 func (e *Engine) ValidateFile(ctx context.Context, fsys vfs.FileSystem, bundleRoot, target string, content []byte) []validation.Diagnostic {
@@ -269,7 +286,7 @@ func (e *Engine) Validator() validation.Validator {
 		var bundleRules []CompiledRule
 		if !invalidDirs[vfs.CleanPath(bundle.Root)] {
 			var err error
-			bundleRules, err = e.Effective(context.Background(), bundle.Root)
+			bundleRules, err = e.effectiveDir(context.Background(), bundle.Root)
 			if err != nil {
 				rule := "rules/config"
 				var rootErr *BundleRootError

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -113,8 +114,10 @@ func conflictDetails(conflict *UnificationError, layers []Layer) string {
 		}
 		sort.Strings(names)
 		for _, name := range names {
-			if fmt.Sprint(outer.With[name]) != fmt.Sprint(inner.With[name]) {
-				details = append(details, fmt.Sprintf("%s: %v vs %v", name, outer.With[name], inner.With[name]))
+			outerValue, outerOK := outer.With[name]
+			innerValue, innerOK := inner.With[name]
+			if outerOK != innerOK || !reflect.DeepEqual(outerValue, innerValue) {
+				details = append(details, fmt.Sprintf("%s: %#v vs %#v", name, outerValue, innerValue))
 			}
 		}
 	}

--- a/pkg/rules/engine_test.go
+++ b/pkg/rules/engine_test.go
@@ -13,6 +13,12 @@ type testSource []Layer
 
 func (s testSource) LayersFor(context.Context, string) ([]Layer, error) { return s, nil }
 
+type testFolderSource []Layer
+
+func (s testFolderSource) LayersForDir(context.Context, string) ([]Layer, error) { return s, nil }
+func (s testFolderSource) LayersAbove(context.Context, string) ([]Layer, error)  { return s, nil }
+func (testFolderSource) Invalidate(string)                                       {}
+
 type testMember struct {
 	manifest Manifest
 	calls    *int
@@ -62,6 +68,18 @@ func TestValidatorCallsBundleRuleOnceAtBundleRoot(t *testing.T) {
 	engine.Validator()(bundle)
 	if calls != 1 || len(subjects) != 1 || subjects[0].Path != bundle.Root {
 		t.Fatalf("calls=%d subjects=%#v", calls, subjects)
+	}
+}
+
+func TestValidatorRunsBundleRuleWhenFolderIsNamedBundleRoot(t *testing.T) {
+	calls := 0
+	registry := NewRegistry()
+	registry.Register(testMember{manifest: Manifest{Path: "test/bundle", Kind: KindRule, Scope: ScopeBundle}, calls: &calls})
+	engine := New(Options{Registry: registry, Folders: testFolderSource{{Origin: "/docs/sub/.lore/config.yaml", Scope: "/docs/sub", Rules: map[string]RuleSpec{"bundle": {Match: []string{"**"}, Use: "test/bundle"}}}}})
+	bundle := validation.Bundle{Root: "/docs/sub", Files: []validation.File{{AbsolutePath: "/docs/sub/a.md"}}}
+	engine.Validator()(bundle)
+	if calls != 1 {
+		t.Fatalf("bundle rule calls=%d, want 1", calls)
 	}
 }
 

--- a/pkg/rules/file_config.go
+++ b/pkg/rules/file_config.go
@@ -21,6 +21,10 @@ type FileConfig struct {
 // DecodeFile decodes a folder rule configuration. Reserved sections are
 // accepted while empty so configurations remain forward-compatible.
 func DecodeFile(content []byte) (FileConfig, error) {
+	versionPresent, err := inspectFileConfig(content)
+	if err != nil {
+		return FileConfig{}, err
+	}
 	var config FileConfig
 	decoder := yaml.NewDecoder(bytes.NewReader(content))
 	decoder.KnownFields(true)
@@ -34,6 +38,9 @@ func DecodeFile(content []byte) (FileConfig, error) {
 		}
 		return FileConfig{}, err
 	}
+	if !versionPresent {
+		return FileConfig{}, fmt.Errorf("version: required (expected 1)")
+	}
 	if config.Version != 1 {
 		return FileConfig{}, fmt.Errorf("version: expected 1, got %d", config.Version)
 	}
@@ -46,4 +53,57 @@ func DecodeFile(content []byte) (FileConfig, error) {
 		}
 	}
 	return config, nil
+}
+
+func inspectFileConfig(content []byte) (bool, error) {
+	var document yaml.Node
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return false, err
+	}
+	if len(document.Content) == 0 || len(document.Content[0].Content) == 0 {
+		return false, nil
+	}
+	root := document.Content[0]
+	versionPresent := false
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		key, value := root.Content[i].Value, root.Content[i+1]
+		switch key {
+		case "version":
+			versionPresent = true
+		case "rules":
+			if err := inspectRuleSpecs(value); err != nil {
+				return versionPresent, err
+			}
+		}
+	}
+	return versionPresent, nil
+}
+
+func inspectRuleSpecs(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	valid := []string{"match", "exclude", "use", "with", "enforce", "default"}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		name, spec := node.Content[i].Value, node.Content[i+1]
+		if spec.Kind != yaml.MappingNode {
+			continue
+		}
+		for j := 0; j+1 < len(spec.Content); j += 2 {
+			key := spec.Content[j].Value
+			known := false
+			for _, candidate := range valid {
+				known = known || key == candidate
+			}
+			if known {
+				continue
+			}
+			suffix := ""
+			if suggestion := nearest(key, valid); suggestion != "" {
+				suffix = fmt.Sprintf(" (did you mean %q?)", suggestion)
+			}
+			return fmt.Errorf("rules.%s: unknown key %q%s", name, key, suffix)
+		}
+	}
+	return nil
 }

--- a/pkg/rules/file_config.go
+++ b/pkg/rules/file_config.go
@@ -1,0 +1,49 @@
+package rules
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FileConfig is the strictly decoded contents of a folder's
+// .lore/config.yaml file.
+type FileConfig struct {
+	Version    int                 `yaml:"version"`
+	Rules      map[string]RuleSpec `yaml:"rules,omitempty"`
+	Packages   map[string]any      `yaml:"packages,omitempty"`
+	Hooks      map[string]any      `yaml:"hooks,omitempty"`
+	Operations map[string]any      `yaml:"operations,omitempty"`
+}
+
+// DecodeFile decodes a folder rule configuration. Reserved sections are
+// accepted while empty so configurations remain forward-compatible.
+func DecodeFile(content []byte) (FileConfig, error) {
+	var config FileConfig
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&config); err != nil {
+		return FileConfig{}, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return FileConfig{}, fmt.Errorf("multiple YAML documents are not supported")
+		}
+		return FileConfig{}, err
+	}
+	if config.Version != 1 {
+		return FileConfig{}, fmt.Errorf("version: expected 1, got %d", config.Version)
+	}
+	for _, reserved := range []struct {
+		name    string
+		section map[string]any
+	}{{"packages", config.Packages}, {"hooks", config.Hooks}, {"operations", config.Operations}} {
+		if len(reserved.section) != 0 {
+			return FileConfig{}, fmt.Errorf("%s: not supported yet", reserved.name)
+		}
+	}
+	return config, nil
+}

--- a/pkg/rules/file_config_test.go
+++ b/pkg/rules/file_config_test.go
@@ -18,10 +18,20 @@ func TestDecodeFileStrictAndReservedSections(t *testing.T) {
 		{"version: 1\nhooks: {x: {}}\n", "hooks: not supported yet"},
 		{"version: 1\nunknown: true\n", "field unknown not found"},
 		{"version: 2\n", "version: expected 1"},
-		{"version: 1\nrules:\n  x:\n    use: size/lines\n    matc: ['*.md']\n", "field matc not found"},
+		{"version: 1\nrules:\n  x:\n    use: size/lines\n    matc: ['*.md']\n", `rules.x: unknown key "matc" (did you mean "match"?)`},
+		{"rules: {}\n", "version: required (expected 1)"},
 	} {
 		if _, err := DecodeFile([]byte(tc.content)); err == nil || !strings.Contains(err.Error(), tc.want) {
 			t.Errorf("DecodeFile(%q) error = %v, want %q", tc.content, err, tc.want)
 		}
+	}
+}
+
+func TestIsDirConfigPathRejectsNestedLore(t *testing.T) {
+	if !IsDirConfigPath("/docs/backend/.lore/config.yaml") {
+		t.Fatal("folder config was not recognized")
+	}
+	if IsDirConfigPath("/docs/.lore/xattrs/.lore/config.yaml") {
+		t.Fatal("nested .lore path was recognized as a folder config")
 	}
 }

--- a/pkg/rules/file_config_test.go
+++ b/pkg/rules/file_config_test.go
@@ -1,0 +1,27 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeFileStrictAndReservedSections(t *testing.T) {
+	valid := "version: 1\nrules:\n  short:\n    match: ['**/*.md']\n    use: size/lines\n    with: {max: 3}\nhooks: {}\n"
+	config, err := DecodeFile([]byte(valid))
+	if err != nil || config.Rules["short"].Use != "size/lines" {
+		t.Fatalf("DecodeFile = %#v, %v", config, err)
+	}
+	for _, tc := range []struct {
+		content string
+		want    string
+	}{
+		{"version: 1\nhooks: {x: {}}\n", "hooks: not supported yet"},
+		{"version: 1\nunknown: true\n", "field unknown not found"},
+		{"version: 2\n", "version: expected 1"},
+		{"version: 1\nrules:\n  x:\n    use: size/lines\n    matc: ['*.md']\n", "field matc not found"},
+	} {
+		if _, err := DecodeFile([]byte(tc.content)); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("DecodeFile(%q) error = %v, want %q", tc.content, err, tc.want)
+		}
+	}
+}

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -142,6 +142,14 @@ type LayerSource interface {
 	LayersFor(context.Context, string) ([]Layer, error)
 }
 
+// FolderLayerSource additionally supports validating a proposed folder config
+// without reading the current config in that same folder.
+type FolderLayerSource interface {
+	LayerSource
+	LayersAbove(context.Context, string) ([]Layer, error)
+	Invalidate(string)
+}
+
 type CompiledRule struct {
 	Name    string
 	Spec    RuleSpec

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -145,7 +145,7 @@ type LayerSource interface {
 // FolderLayerSource additionally supports validating a proposed folder config
 // without reading the current config in that same folder.
 type FolderLayerSource interface {
-	LayerSource
+	LayersForDir(context.Context, string) ([]Layer, error)
 	LayersAbove(context.Context, string) ([]Layer, error)
 	Invalidate(string)
 }


### PR DESCRIPTION
## Summary
- expose only `.lore/config.yaml` through DirFS while keeping package state hidden
- strictly decode and layer folder rules with cache invalidation on config changes
- enforce per-docset `config.edit` permissions and exempt config files from content rules
- report folder config errors through `lore validate`
- cover VFS visibility, permissions, inheritance, invalidation, unification, validation, and shell visibility

## Testing
- `go test ./...`
- `go test -race ./pkg/openlore ./pkg/rules -run "(FolderRules|DirFSExposesOnlyFolderConfig|DecodeFile)"`