### PR TITLE
Implement folder rules phase 4

### DIFF
--- a/docs/rules-stdlib.md
+++ b/docs/rules-stdlib.md
@@ -47,11 +47,12 @@ evaluated: on every write (rejects) and by lore validate
 Reject writes whose size exceeds max KiB.
 
 PARAMETERS
-  max  integer  required  Fixed cap.
+  max     integer|initial  required  Fixed cap, or baseline × growth.
+  growth  number           optional  Multiplier when max is "initial".
 
 EXAMPLE
   use: size/kilobytes
-  with: { max: 60 }
+  with: { max: initial, growth: 1.1 }
 ```
 
 ## `size/lines`
@@ -63,11 +64,12 @@ evaluated: on every write (rejects) and by lore validate
 Reject writes whose line count exceeds max.
 
 PARAMETERS
-  max  integer  required  Fixed cap.
+  max     integer|initial  required  Fixed cap, or baseline × growth.
+  growth  number           optional  Multiplier when max is "initial".
 
 EXAMPLE
   use: size/lines
-  with: { max: 60 }
+  with: { max: initial, growth: 1.1 }
 ```
 
 ## `size/tokens`
@@ -79,9 +81,10 @@ evaluated: on every write (rejects) and by lore validate
 Reject writes whose estimated token count exceeds max. Tokens use estimate/v1: ceil(bytes / 4).
 
 PARAMETERS
-  max  integer  required  Fixed cap.
+  max     integer|initial  required  Fixed cap, or baseline × growth.
+  growth  number           optional  Multiplier when max is "initial".
 
 EXAMPLE
   use: size/tokens
-  with: { max: 60 }
+  with: { max: initial, growth: 1.1 }
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aakarim/go-openlore/pkg/rules"
+	"github.com/aakarim/go-openlore/pkg/rules/tokenizer"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
@@ -104,7 +105,14 @@ type Config struct {
 }
 
 type RulesConfig struct {
-	Growth float64
+	Growth    float64
+	Tokenizer tokenizer.Tokenizer
+}
+
+// WithRulesTokenizer injects a token counter. The YAML tokenizer setting stays
+// reserved; this option exists for embedders and compatibility tests.
+func WithRulesTokenizer(counter tokenizer.Tokenizer) Option {
+	return func(cfg *Config) error { cfg.Rules.Tokenizer = counter; return nil }
 }
 
 // Warnings returns non-fatal problems encountered while loading configuration.

--- a/pkg/openlore/alias_fs.go
+++ b/pkg/openlore/alias_fs.go
@@ -244,8 +244,18 @@ func (a *writableAliasFS) AdmitChangeSet(cs vfs.ChangeSet) error {
 	}
 	for i := range cs.Changes {
 		cs.Changes[i].Target, _ = a.canonical(cs.Changes[i].Target)
+		if cs.Changes[i].RemoveAll != nil {
+			remove := *cs.Changes[i].RemoveAll
+			remove.Opts = a.canonicalRemoveOpts(remove.Opts)
+			cs.Changes[i].RemoveAll = &remove
+		}
 	}
 	cs.Target, _ = a.canonical(cs.Target)
+	if cs.RemoveAll != nil {
+		remove := *cs.RemoveAll
+		remove.Opts = a.canonicalRemoveOpts(remove.Opts)
+		cs.RemoveAll = &remove
+	}
 	return admitter.AdmitChangeSet(cs)
 }
 

--- a/pkg/openlore/middleware.go
+++ b/pkg/openlore/middleware.go
@@ -112,6 +112,7 @@ func cloneWriteChangeSet(cs vfs.ChangeSet) vfs.ChangeSet {
 		return out
 	}
 	out := cs
+	out.Moves = append([]vfs.Move(nil), cs.Moves...)
 	leaf := cloneLeaf(vfs.Change{Target: cs.Target, Action: cs.Action, Write: cs.Write, RemoveAll: cs.RemoveAll, Xattr: cs.Xattr, XattrRepair: cs.XattrRepair, XattrMigration: cs.XattrMigration})
 	out.Write, out.RemoveAll, out.Xattr, out.XattrRepair, out.XattrMigration = leaf.Write, leaf.RemoveAll, leaf.Xattr, leaf.XattrRepair, leaf.XattrMigration
 	if cs.Changes != nil {

--- a/pkg/openlore/options.go
+++ b/pkg/openlore/options.go
@@ -53,6 +53,7 @@ var (
 	WithTLS             = config.WithTLS
 	WithCAKeysFile      = config.WithCAKeysFile
 	WithHostCertFile    = config.WithHostCertFile
+	WithRulesTokenizer  = config.WithRulesTokenizer
 	WithPasskeys        = config.WithPasskeys
 	WithReadonly        = config.WithReadonly
 	LoadAuthConfig      = config.LoadAuthConfig

--- a/pkg/openlore/overlay_fs.go
+++ b/pkg/openlore/overlay_fs.go
@@ -24,6 +24,8 @@ type OverlayFS struct {
 	mu    sync.Mutex
 }
 
+func (o *OverlayFS) HostDir(p string) (string, bool) { return o.upper.HostDir(p) }
+
 // NewOverlayFS creates a filesystem with upper as its writable layer and lower
 // as its read-only fallback.
 func NewOverlayFS(upper *DirFS, lower vfs.FileSystem) *OverlayFS {

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -13,10 +13,12 @@ import (
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/packagestate"
 	"github.com/aakarim/go-openlore/pkg/rules"
 	_ "github.com/aakarim/go-openlore/pkg/rules/link"
 	_ "github.com/aakarim/go-openlore/pkg/rules/okfrule"
 	_ "github.com/aakarim/go-openlore/pkg/rules/size"
+	"github.com/aakarim/go-openlore/pkg/rules/tokenizer"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -213,6 +215,7 @@ func ruleRoots(docset config.DocsetSpec) []string {
 
 type rulesPlugin struct {
 	engine *rules.Engine
+	fs     vfs.FileSystem
 }
 
 func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.FileSystem, logger *slog.Logger) (*rulesPlugin, error) {
@@ -222,7 +225,11 @@ func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.F
 	}
 	sort.Slice(aliases, func(i, j int) bool { return len(aliases[i]) > len(aliases[j]) })
 	configLayers := configRuleLayers{global: auth.Rules, docsets: auth.Docsets}
-	env := func(string) rules.Env { return rules.Env{Defaults: defaults, Logger: logger, AliasRoots: aliases} }
+	mapper, _ := fsys.(packagestate.HostMapper)
+	env := func(member string) rules.Env {
+		pkg := strings.SplitN(member, "/", 2)[0]
+		return rules.Env{Defaults: defaults, State: packagestate.Open(mapper, pkg), Tokenizer: tokenizer.Estimator{}, Logger: logger, AliasRoots: aliases}
+	}
 	bootEngine := rules.New(rules.Options{Registry: rules.DefaultRegistry(), Config: configLayers, Env: env, Logger: logger})
 	// Compile every configured docset at boot so invalid members, parameters,
 	// and unification conflicts fail before the server begins accepting writes.
@@ -239,7 +246,7 @@ func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.F
 		options.Folders = newFolderRuleLayers(fsys, auth.Docsets)
 	}
 	engine := rules.New(options)
-	return &rulesPlugin{engine: engine}, nil
+	return &rulesPlugin{engine: engine, fs: fsys}, nil
 }
 
 func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
@@ -255,7 +262,7 @@ func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
 					}
 					continue
 				}
-				if err := p.engine.AdmitLeaf(ctx, leaf, op.Attribution.String(), nil); err != nil {
+				if err := p.engine.AdmitLeaf(ctx, leaf, op.Attribution.String(), p.existing(leaf.Target)); err != nil {
 					return WriteResult{}, err
 				}
 			}
@@ -287,11 +294,24 @@ func (p *rulesPlugin) PreApply(attribution Attribution, changes vfs.ChangeSet) e
 			}
 			continue
 		}
-		if err := p.engine.AdmitLeaf(context.Background(), leaf, attribution.String(), nil); err != nil {
+		if err := p.engine.AdmitLeaf(context.Background(), leaf, attribution.String(), p.existing(leaf.Target)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (p *rulesPlugin) existing(target string) func() ([]byte, bool, error) {
+	return func() ([]byte, bool, error) {
+		if p.fs == nil {
+			return nil, false, nil
+		}
+		content, err := p.fs.ReadFile(target)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return content, err == nil, err
+	}
 }
 
 func (p *rulesPlugin) invalidateChanges(changes []vfs.Change) {
@@ -307,7 +327,37 @@ func (p *rulesPlugin) invalidateChanges(changes []vfs.Change) {
 func (p *rulesPlugin) PostCommitMiddleware() []PostCommitMiddleware {
 	return []PostCommitMiddleware{func(next PostCommitHandler) PostCommitHandler {
 		return func(ctx context.Context, info CommitInfo) error {
+			ctx = rules.WithActor(ctx, info.Attribution.String())
 			p.invalidateChanges(info.ChangeSet.Leaves())
+			leaves := info.ChangeSet.Leaves()
+			moved := map[int]bool{}
+			for i, remove := range leaves {
+				if remove.Action != vfs.ChangeActionRemoveAll || remove.RemoveAll == nil || remove.RemoveAll.Opts.Expected == nil {
+					continue
+				}
+				var sourceHash string
+				for _, op := range remove.RemoveAll.Opts.Expected.Ops {
+					if op.RelPath == "." && op.Kind == "file" {
+						sourceHash = op.Hash
+					}
+				}
+				for j, write := range leaves {
+					if write.Action == vfs.ChangeActionWrite && write.Write != nil && hashBytes(write.Write.Bytes) == sourceHash {
+						if err := p.engine.OnMove(ctx, remove.Target, write.Target); err != nil {
+							return err
+						}
+						moved[i], moved[j] = true, true
+						break
+					}
+				}
+			}
+			for i, leaf := range leaves {
+				if !moved[i] && (leaf.Action == vfs.ChangeActionRemove || leaf.Action == vfs.ChangeActionRemoveAll) {
+					if err := p.engine.OnRemove(ctx, leaf.Target); err != nil {
+						return err
+					}
+				}
+			}
 			return next(ctx, info)
 		}
 	}}

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -301,7 +301,7 @@ func (p *rulesPlugin) PreApply(attribution Attribution, changes vfs.ChangeSet) e
 			}
 			continue
 		}
-		if err := p.engine.AdmitLeaf(context.Background(), leaf, attribution.String(), p.existing(leaf.Target)); err != nil {
+		if err := p.engine.PreApplyLeaf(context.Background(), leaf, attribution.String(), p.existing(leaf.Target)); err != nil {
 			return err
 		}
 	}
@@ -335,40 +335,36 @@ func (p *rulesPlugin) PostCommitMiddleware() []PostCommitMiddleware {
 	return []PostCommitMiddleware{func(next PostCommitHandler) PostCommitHandler {
 		return func(ctx context.Context, info CommitInfo) error {
 			p.invalidateChanges(info.ChangeSet.Leaves())
-			leaves := info.ChangeSet.Leaves()
-			movedRemoves := map[int]bool{}
-			for i, remove := range leaves {
-				if remove.Action != vfs.ChangeActionRemoveAll || remove.RemoveAll == nil || remove.RemoveAll.Opts.Expected == nil {
-					continue
-				}
-				var sourceHash string
-				for _, op := range remove.RemoveAll.Opts.Expected.Ops {
-					if op.RelPath == "." && op.Kind == "file" {
-						sourceHash = op.Hash
-					}
-				}
-				for _, write := range leaves {
-					if write.Action == vfs.ChangeActionWrite && write.Write != nil && hashBytes(write.Write.Bytes) == sourceHash {
-						// Destination admission may have recorded a create baseline. Move
-						// deliberately replaces it wholesale with the source history.
-						if err := p.engine.OnMove(ctx, remove.Target, write.Target); err != nil {
-							return err
-						}
-						movedRemoves[i] = true
-						break
-					}
-				}
-			}
-			for i, leaf := range leaves {
-				if !movedRemoves[i] && (leaf.Action == vfs.ChangeActionRemove || leaf.Action == vfs.ChangeActionRemoveAll) {
-					if err := p.engine.OnRemove(ctx, leaf.Target, info.Attribution.String()); err != nil {
-						return err
-					}
-				}
-			}
 			return next(ctx, info)
 		}
 	}}
+}
+
+// CommitState updates package-local state synchronously after content commits
+// and before the submitter receives success.
+func (p *rulesPlugin) CommitState(ctx context.Context, info CommitInfo) error {
+	leaves := info.ChangeSet.Leaves()
+	movedRemoves := map[int]bool{}
+	for _, move := range info.ChangeSet.Moves {
+		remove, write := leaves[move.From], leaves[move.To]
+		if err := p.engine.OnMove(ctx, remove.Target, write.Target); err != nil {
+			return err
+		}
+		movedRemoves[move.From] = true
+	}
+	for i, leaf := range leaves {
+		switch {
+		case leaf.Action == vfs.ChangeActionWrite && leaf.Write != nil && !rules.IsDirConfigPath(leaf.Target):
+			if err := p.engine.OnWrite(ctx, leaf.Target, leaf.Write.Bytes, info.Attribution.String()); err != nil {
+				return err
+			}
+		case (leaf.Action == vfs.ChangeActionRemove || leaf.Action == vfs.ChangeActionRemoveAll) && !movedRemoves[i]:
+			if err := p.engine.OnRemove(ctx, leaf.Target, info.Attribution.String()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 func (p *rulesPlugin) Validators() []validation.Validator {
 	return []validation.Validator{p.engine.Validator()}

--- a/pkg/openlore/rules_plugin.go
+++ b/pkg/openlore/rules_plugin.go
@@ -214,11 +214,19 @@ func ruleRoots(docset config.DocsetSpec) []string {
 }
 
 type rulesPlugin struct {
-	engine *rules.Engine
-	fs     vfs.FileSystem
+	engine    *rules.Engine
+	fs        vfs.FileSystem
+	tokenizer tokenizer.Tokenizer
 }
 
 func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.FileSystem, logger *slog.Logger) (*rulesPlugin, error) {
+	return newRulesPluginWithTokenizer(auth, defaults, fsys, logger, tokenizer.Estimator{})
+}
+
+func newRulesPluginWithTokenizer(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.FileSystem, logger *slog.Logger, counter tokenizer.Tokenizer) (*rulesPlugin, error) {
+	if counter == nil {
+		counter = tokenizer.Estimator{}
+	}
 	var aliases []string
 	for _, docset := range auth.Docsets {
 		aliases = append(aliases, docset.Aliases...)
@@ -227,8 +235,7 @@ func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.F
 	configLayers := configRuleLayers{global: auth.Rules, docsets: auth.Docsets}
 	mapper, _ := fsys.(packagestate.HostMapper)
 	env := func(member string) rules.Env {
-		pkg := strings.SplitN(member, "/", 2)[0]
-		return rules.Env{Defaults: defaults, State: packagestate.Open(mapper, pkg), Tokenizer: tokenizer.Estimator{}, Logger: logger, AliasRoots: aliases}
+		return rules.Env{Defaults: defaults, State: packagestate.Open(mapper, rules.PackageOf(member)), Tokenizer: counter, Logger: logger, AliasRoots: aliases}
 	}
 	bootEngine := rules.New(rules.Options{Registry: rules.DefaultRegistry(), Config: configLayers, Env: env, Logger: logger})
 	// Compile every configured docset at boot so invalid members, parameters,
@@ -246,7 +253,7 @@ func newRulesPlugin(auth *config.AuthConfig, defaults rules.Defaults, fsys vfs.F
 		options.Folders = newFolderRuleLayers(fsys, auth.Docsets)
 	}
 	engine := rules.New(options)
-	return &rulesPlugin{engine: engine, fs: fsys}, nil
+	return &rulesPlugin{engine: engine, fs: fsys, tokenizer: counter}, nil
 }
 
 func (p *rulesPlugin) WriteMiddleware() []WriteMiddleware {
@@ -327,10 +334,9 @@ func (p *rulesPlugin) invalidateChanges(changes []vfs.Change) {
 func (p *rulesPlugin) PostCommitMiddleware() []PostCommitMiddleware {
 	return []PostCommitMiddleware{func(next PostCommitHandler) PostCommitHandler {
 		return func(ctx context.Context, info CommitInfo) error {
-			ctx = rules.WithActor(ctx, info.Attribution.String())
 			p.invalidateChanges(info.ChangeSet.Leaves())
 			leaves := info.ChangeSet.Leaves()
-			moved := map[int]bool{}
+			movedRemoves := map[int]bool{}
 			for i, remove := range leaves {
 				if remove.Action != vfs.ChangeActionRemoveAll || remove.RemoveAll == nil || remove.RemoveAll.Opts.Expected == nil {
 					continue
@@ -341,19 +347,21 @@ func (p *rulesPlugin) PostCommitMiddleware() []PostCommitMiddleware {
 						sourceHash = op.Hash
 					}
 				}
-				for j, write := range leaves {
+				for _, write := range leaves {
 					if write.Action == vfs.ChangeActionWrite && write.Write != nil && hashBytes(write.Write.Bytes) == sourceHash {
+						// Destination admission may have recorded a create baseline. Move
+						// deliberately replaces it wholesale with the source history.
 						if err := p.engine.OnMove(ctx, remove.Target, write.Target); err != nil {
 							return err
 						}
-						moved[i], moved[j] = true, true
+						movedRemoves[i] = true
 						break
 					}
 				}
 			}
 			for i, leaf := range leaves {
-				if !moved[i] && (leaf.Action == vfs.ChangeActionRemove || leaf.Action == vfs.ChangeActionRemoveAll) {
-					if err := p.engine.OnRemove(ctx, leaf.Target); err != nil {
+				if !movedRemoves[i] && (leaf.Action == vfs.ChangeActionRemove || leaf.Action == vfs.ChangeActionRemoveAll) {
+					if err := p.engine.OnRemove(ctx, leaf.Target, info.Attribution.String()); err != nil {
 						return err
 					}
 				}

--- a/pkg/openlore/rules_plugin_test.go
+++ b/pkg/openlore/rules_plugin_test.go
@@ -138,6 +138,34 @@ func admitServer(server *Server, target, content string) error {
 	return err
 }
 
+func TestInitialSizeBaselinePersistsAndRejectsGrowth(t *testing.T) {
+	auth := serverAuth(map[string]config.DocsetSpec{"docs": docset("/docs", nil)}, map[string]rules.RuleSpec{
+		"length": {Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": "initial", "growth": 1.5}},
+	})
+	server, root := bootRulesServer(t, auth, nil)
+	id := Identity{IdentityName: "alice", Principal: AuthenticatedPrincipal{IdentityName: "alice"}, Attribution: Attribution{Principal: "alice"}, Scopes: []string{ScopeFull}}
+	write := func(lines int) error {
+		_, err := server.writeLog.SubmitIdentity(context.Background(), id, writeCSBytes("/docs/a.md", strings.Repeat("x\n", lines)))
+		return err
+	}
+	if err := write(10); err != nil {
+		t.Fatal(err)
+	}
+	if err := write(15); err != nil {
+		t.Fatal(err)
+	}
+	if err := write(16); err == nil || !strings.Contains(err.Error(), "16 lines exceeds the limit of 15 (baseline 10 lines × growth 1.5") || !strings.Contains(err.Error(), "lore size baseline reset /docs/a.md") {
+		t.Fatalf("rejection=%v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "docs", ".lore", "size", "a.md.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(raw), `"op":"baseline"`) != 1 || !strings.Contains(string(raw), `"reason":"create"`) || !strings.Contains(string(raw), `"lines":10`) || !strings.Contains(string(raw), `"actor":"alice"`) {
+		t.Fatalf("state=%s", raw)
+	}
+}
+
 func TestFolderRulesPermissionInheritanceInvalidationAndExemption(t *testing.T) {
 	docs := docset("/docs", nil)
 	docs.Access = config.DocsetAccess{Allow: map[string]string{"writer": "rw", "editor": "ro"}}

--- a/pkg/openlore/rules_plugin_test.go
+++ b/pkg/openlore/rules_plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
@@ -163,6 +164,207 @@ func TestInitialSizeBaselinePersistsAndRejectsGrowth(t *testing.T) {
 	}
 	if strings.Count(string(raw), `"op":"baseline"`) != 1 || !strings.Contains(string(raw), `"reason":"create"`) || !strings.Contains(string(raw), `"lines":10`) || !strings.Contains(string(raw), `"actor":"alice"`) {
 		t.Fatalf("state=%s", raw)
+	}
+}
+
+func initialRulesAuth() *config.AuthConfig {
+	docs := docset("/docs", nil)
+	docs.Config = &config.DirConfigPermission{Edit: []string{"writer"}}
+	return serverAuth(map[string]config.DocsetSpec{"docs": docs}, map[string]rules.RuleSpec{
+		"length": {Match: []string{"**/*.md"}, Use: "size/lines", With: map[string]any{"max": "initial", "growth": 1.5}},
+	})
+}
+
+func testIdentity(name string) Identity {
+	return Identity{IdentityName: name, Principal: AuthenticatedPrincipal{IdentityName: name}, Attribution: Attribution{Principal: name}, Scopes: []string{ScopeFull}}
+}
+
+func TestInitialBaselineRuleAddedAndRejectedCreate(t *testing.T) {
+	t.Run("rule-added", func(t *testing.T) {
+		server, root := bootRulesServer(t, initialRulesAuth(), nil)
+		if err := os.WriteFile(filepath.Join(root, "docs", "a.md"), []byte(strings.Repeat("x\n", 20)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := server.writeLog.SubmitIdentity(context.Background(), testIdentity("alice"), writeCSBytes("/docs/a.md", strings.Repeat("x\n", 40)))
+		if err == nil || !strings.Contains(err.Error(), "40 lines exceeds the limit of 30") || strings.Contains(err.Error(), "0001-01-01") {
+			t.Fatalf("rejection=%v", err)
+		}
+		if _, err := server.writeLog.SubmitIdentity(context.Background(), testIdentity("alice"), writeCSBytes("/docs/a.md", strings.Repeat("x\n", 30))); err != nil {
+			t.Fatal(err)
+		}
+		raw, _ := os.ReadFile(filepath.Join(root, "docs", ".lore", "size", "a.md.jsonl"))
+		if !strings.Contains(string(raw), `"reason":"rule-added"`) || !strings.Contains(string(raw), `"lines":20`) {
+			t.Fatalf("state=%s", raw)
+		}
+	})
+
+	t.Run("rejected create cannot govern", func(t *testing.T) {
+		auth := initialRulesAuth()
+		auth.Rules["fixed"] = rules.RuleSpec{Match: []string{"**/*.md"}, Use: "size/kilobytes", With: map[string]any{"max": 1}}
+		server, _ := bootRulesServer(t, auth, nil)
+		id := testIdentity("alice")
+		if _, err := server.writeLog.SubmitIdentity(context.Background(), id, writeCSBytes("/docs/a.md", strings.Repeat("x\n", 1000))); err == nil {
+			t.Fatal("oversized create succeeded")
+		}
+		if _, err := server.writeLog.SubmitIdentity(context.Background(), id, writeCSBytes("/docs/a.md", strings.Repeat("x\n", 10))); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := server.writeLog.SubmitIdentity(context.Background(), id, writeCSBytes("/docs/a.md", strings.Repeat("x\n", 16))); err == nil || !strings.Contains(err.Error(), "baseline 10 lines") {
+			t.Fatalf("rejection=%v", err)
+		}
+	})
+}
+
+func TestInitialBaselineRemoveRecreateAndMove(t *testing.T) {
+	server, root := bootRulesServer(t, initialRulesAuth(), nil)
+	id := testIdentity("alice")
+	write := func(target string, lines int) error {
+		_, err := server.writeLog.SubmitIdentity(context.Background(), id, writeCSBytes(target, strings.Repeat("x\n", lines)))
+		return err
+	}
+	if err := write("/docs/a.md", 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := write("/docs/a.md", 15); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "docs", "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if code := server.buildSessionShell(id).ExecPipeline("mv /docs/a.md /docs/sub/b.md", &out, &errOut, nil); code != 0 {
+		t.Fatalf("mv: %s", errOut.String())
+	}
+	if err := write("/docs/flush.md", 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := write("/docs/sub/b.md", 16); err == nil || !strings.Contains(err.Error(), "baseline 10 lines") {
+		t.Fatalf("moved cap=%v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "docs", "sub", ".lore", "size", "b.md.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"path":"/docs/a.md"`) || !strings.Contains(string(raw), `"path":"/docs/sub/b.md"`) {
+		t.Fatalf("moved state=%s", raw)
+	}
+	if _, err := server.writeLog.SubmitIdentity(context.Background(), id, vfs.ChangeSet{Target: "/docs/sub/b.md", Action: vfs.ChangeActionRemove}); err != nil {
+		t.Fatal(err)
+	}
+	if err := write("/docs/flush2.md", 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := write("/docs/sub/b.md", 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := write("/docs/sub/b.md", 151); err == nil || !strings.Contains(err.Error(), "baseline 100 lines") {
+		t.Fatalf("recreated cap=%v", err)
+	}
+	raw, _ = os.ReadFile(filepath.Join(root, "docs", "sub", ".lore", "size", "b.md.jsonl"))
+	if !strings.Contains(string(raw), `"op":"remove"`) || !strings.Contains(string(raw), `"actor":"alice"`) {
+		t.Fatalf("state=%s", raw)
+	}
+}
+
+func TestValidateDoesNotCreateBaselineState(t *testing.T) {
+	server, root := bootRulesServer(t, initialRulesAuth(), nil)
+	if err := os.WriteFile(filepath.Join(root, "docs", "a.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if code := server.buildSessionShell(testIdentity("alice")).ExecPipeline("lore validate /docs", &out, &errOut, nil); code != 0 {
+		t.Fatalf("validate=%d %s", code, errOut.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", ".lore", "size")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("state created: %v", err)
+	}
+}
+
+func TestInitialBaselineEmbeddedContentIsReadOnly(t *testing.T) {
+	fsys := NewFSAdapter(fstest.MapFS{"docs/a.md": {Data: []byte("x\n")}})
+	p, err := newRulesPlugin(initialRulesAuth(), rules.Defaults{Growth: 1.5}, fsys, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diagnostics := p.engine.ValidateFile(context.Background(), fsys, "/docs", "/docs/a.md", []byte("x\n")); len(diagnostics) != 0 {
+		t.Fatalf("diagnostics=%#v", diagnostics)
+	}
+}
+
+func TestSizeBaselineResetCommandAndAudit(t *testing.T) {
+	server, root := bootRulesServer(t, initialRulesAuth(), nil)
+	id := testIdentity("alice")
+	write := func(lines int) error {
+		_, err := server.writeLog.SubmitIdentity(context.Background(), id, writeCSBytes("/docs/a.md", strings.Repeat("x\n", lines)))
+		return err
+	}
+	if err := write(10); err != nil {
+		t.Fatal(err)
+	}
+	if err := write(15); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(root, "docs", ".lore", "size", "a.md.jsonl")
+	before, _ := os.ReadFile(statePath)
+	audit := &captureAuditLog{}
+	server.audit = audit
+	var out, errOut bytes.Buffer
+	if code := server.buildSessionShell(id).ExecPipeline(`lore size baseline reset /docs/a.md --note "grew after review"`, &out, &errOut, nil); code != 0 {
+		t.Fatalf("reset=%d out=%s err=%s", code, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "previous 10, new 15, new cap 22 lines") {
+		t.Fatalf("output=%s", out.String())
+	}
+	after, _ := os.ReadFile(statePath)
+	if !bytes.HasPrefix(after, before) || strings.Count(string(after), `"op":"baseline"`) != 2 || !strings.Contains(string(after), `"note":"grew after review"`) {
+		t.Fatalf("before=%s after=%s", before, after)
+	}
+	if len(audit.events) != 1 || audit.events[0].Type != "rules.baseline.reset" {
+		t.Fatalf("audit=%#v", audit.events)
+	}
+	if err := write(22); err != nil {
+		t.Fatal(err)
+	}
+	if err := write(23); err == nil {
+		t.Fatal("23 lines accepted")
+	}
+	out.Reset()
+	errOut.Reset()
+	if code := server.buildSessionShell(id).ExecPipeline("lore size baseline /docs/a.md", &out, &errOut, nil); code != 0 || !strings.Contains(out.String(), "size/lines via length @ lore.json, growth 1.5") || !strings.Contains(out.String(), "current cap: 22 lines") {
+		t.Fatalf("history=%d out=%s err=%s", code, out.String(), errOut.String())
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "plain.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	errOut.Reset()
+	if code := server.buildSessionShell(id).ExecPipeline("lore size baseline reset /docs/plain.txt", &out, &errOut, nil); code != 1 || !strings.Contains(errOut.String(), "no max: initial size rule applies") {
+		t.Fatalf("ungoverned=%d out=%s err=%s", code, out.String(), errOut.String())
+	}
+}
+
+func TestSizeBaselineResetDeniedDoesNotMutate(t *testing.T) {
+	docs := docset("/docs", nil)
+	docs.Access = config.DocsetAccess{Allow: map[string]string{"writer": "rw", "editor": "ro"}}
+	docs.Config = &config.DirConfigPermission{Edit: []string{"editor"}}
+	auth := &config.AuthConfig{Rules: initialRulesAuth().Rules, Roles: map[string]config.RoleSpec{"writer": {}, "editor": {}}, Docsets: map[string]config.DocsetSpec{"docs": docs}, Identities: []config.AuthIdentity{{Name: "alice", Roles: []string{"writer"}}, {Name: "carol", Roles: []string{"editor"}}}}
+	server, root := bootRulesServer(t, auth, nil)
+	if _, err := server.writeLog.SubmitIdentity(context.Background(), testIdentity("alice"), writeCSBytes("/docs/a.md", strings.Repeat("x\n", 10))); err != nil {
+		t.Fatal(err)
+	}
+	statePath := filepath.Join(root, "docs", ".lore", "size", "a.md.jsonl")
+	before, _ := os.ReadFile(statePath)
+	audit := &captureAuditLog{}
+	server.audit = audit
+	for _, name := range []string{"alice", "carol"} {
+		var out, errOut bytes.Buffer
+		if code := server.buildSessionShell(testIdentity(name)).ExecPipeline("lore size baseline reset /docs/a.md", &out, &errOut, nil); code != 1 || !strings.Contains(errOut.String(), "permission denied") {
+			t.Fatalf("%s code=%d out=%s err=%s", name, code, out.String(), errOut.String())
+		}
+	}
+	after, _ := os.ReadFile(statePath)
+	if !bytes.Equal(before, after) || len(audit.events) != 0 {
+		t.Fatalf("state changed=%v audit=%#v", !bytes.Equal(before, after), audit.events)
 	}
 }
 

--- a/pkg/openlore/rules_size.go
+++ b/pkg/openlore/rules_size.go
@@ -75,17 +75,22 @@ func (p *rulesPlugin) baselineText(ctx context.Context, target string) (string, 
 		}
 		fmt.Fprintln(&b)
 	}
-	current, ok, err := store.Get(ctx, target)
-	if err != nil {
-		return "", err
-	}
-	if ok && len(states) != 0 {
-		fmt.Fprint(&b, "current cap:")
+	if len(states) != 0 {
+		var caps strings.Builder
 		for _, state := range states {
+			current, ok, err := size.Current(ctx, state.rule.Check, target)
+			if err != nil {
+				return "", err
+			}
+			if !ok {
+				continue
+			}
 			value, unit := baselineMetric(current, state.metric)
-			fmt.Fprintf(&b, " %d %s", int(math.Floor(float64(value)*state.growth)), unit)
+			fmt.Fprintf(&caps, " %d %s", int(math.Floor(float64(value)*state.growth)), unit)
 		}
-		fmt.Fprintln(&b)
+		if caps.Len() != 0 {
+			fmt.Fprintf(&b, "current cap:%s\n", caps.String())
+		}
 	}
 	return b.String(), nil
 }
@@ -132,27 +137,41 @@ func (b sessionSizeBackend) Reset(target, note string, a cmds.JobAttribution) (s
 	if !b.server.identityHasDirConfigRole(id, configPath) || !b.server.identityCanWrite(id, vfs.ChangeActionWrite, target) {
 		return "", errors.New("permission denied")
 	}
-	content, err := b.server.merge.ReadFile(target)
-	if err != nil {
-		return "", err
-	}
-	states, err := b.server.rules.sizeRules(context.Background(), target)
-	if err != nil {
-		return "", err
-	}
-	if len(states) == 0 {
-		return "", fmt.Errorf("no max: initial size rule applies to %s", target)
-	}
 	actor := Attribution{Principal: a.Principal, Actor: a.Actor}.String()
-	previous, next, err := size.Reset(context.Background(), states[0].store, target, content, states[0].tokenizer, actor, note)
+	var states []sizeRuleState
+	var previous, next size.Baseline
+	var previousByRule []size.Baseline
+	err := b.server.writeLog.Do(context.Background(), func() error {
+		content, err := b.server.merge.ReadFile(target)
+		if err != nil {
+			return err
+		}
+		states, err = b.server.rules.sizeRules(context.Background(), target)
+		if err != nil {
+			return err
+		}
+		if len(states) == 0 {
+			return fmt.Errorf("no max: initial size rule applies to %s", target)
+		}
+		previousByRule = make([]size.Baseline, len(states))
+		for i, state := range states {
+			current, _, currentErr := size.Current(context.Background(), state.rule.Check, target)
+			if currentErr != nil {
+				return currentErr
+			}
+			previousByRule[i] = current
+		}
+		previous, next, err = size.Reset(context.Background(), states[0].store, target, content, states[0].tokenizer, actor, note)
+		return err
+	})
 	if err != nil {
 		return "", err
 	}
 	if err = b.server.audit.Record(context.Background(), AuditEvent{Type: "rules.baseline.reset", Attribution: Attribution{Principal: a.Principal, Actor: a.Actor}, Details: map[string]any{"path": target, "previous": previous, "next": next, "note": note}}); err != nil {
-		return "", err
+		b.server.logger.Error("baseline reset audit failed", "path", target, "err", err)
 	}
 	var output strings.Builder
-	fmt.Fprintf(&output, "baseline reset: previous %d, new %d", baselineValue(previous, states[0].metric), baselineValue(next, states[0].metric))
+	fmt.Fprintf(&output, "baseline reset: previous %d, new %d", baselineValue(previousByRule[0], states[0].metric), baselineValue(next, states[0].metric))
 	for _, state := range states {
 		value, unit := baselineMetric(next, state.metric)
 		fmt.Fprintf(&output, ", new cap %d %s", int(math.Floor(float64(value)*state.growth)), unit)

--- a/pkg/openlore/rules_size.go
+++ b/pkg/openlore/rules_size.go
@@ -1,0 +1,141 @@
+package openlore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/aakarim/go-openlore/pkg/packagestate"
+	"github.com/aakarim/go-openlore/pkg/rules"
+	"github.com/aakarim/go-openlore/pkg/rules/size"
+	"github.com/aakarim/go-openlore/pkg/rules/tokenizer"
+	"github.com/aakarim/go-openlore/pkg/shell/cmds"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+)
+
+type sizeRuleState struct {
+	store  size.BaselineStore
+	metric size.Metric
+	growth float64
+	rule   rules.CompiledRule
+}
+
+func (p *rulesPlugin) sizeRules(ctx context.Context, target string) ([]sizeRuleState, error) {
+	compiled, err := p.engine.Effective(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	var out []sizeRuleState
+	for _, rule := range compiled {
+		store, metric, growth, ok := size.Inspect(rule.Check)
+		if ok && rules.Applies(rule, target) {
+			out = append(out, sizeRuleState{store, metric, growth, rule})
+		}
+	}
+	return out, nil
+}
+
+func (p *rulesPlugin) baselineText(ctx context.Context, target string) (string, error) {
+	states, err := p.sizeRules(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	var store size.BaselineStore
+	if len(states) == 0 {
+		mapper, _ := p.fs.(packagestate.HostMapper)
+		store = size.NewBaselineStore(packagestate.Open(mapper, "size"))
+	} else {
+		store = states[0].store
+	}
+	history, err := store.History(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if len(history) == 0 {
+		return "no baseline recorded\n", nil
+	}
+	var b strings.Builder
+	fmt.Fprintln(&b, target)
+	for _, record := range history {
+		fmt.Fprintf(&b, "  %s  %-10s  %-20s  %d lines  %d KiB  %d tokens", record.At.Format("2006-01-02T15:04:05Z"), first(record.Reason, record.Op), record.Actor, record.Lines, record.Kilobytes, record.Tokens)
+		if record.Tokenizer != "" {
+			fmt.Fprintf(&b, " (%s)", record.Tokenizer)
+		}
+		if record.Note != "" {
+			fmt.Fprintf(&b, "  %q", record.Note)
+		}
+		fmt.Fprintln(&b)
+	}
+	current, ok, err := store.Get(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if ok && len(states) != 0 {
+		fmt.Fprint(&b, "current cap:")
+		for _, state := range states {
+			value, unit := baselineMetric(current, state.metric)
+			fmt.Fprintf(&b, " %d %s", int(math.Floor(float64(value)*state.growth)), unit)
+		}
+		fmt.Fprintln(&b)
+	}
+	return b.String(), nil
+}
+
+func first(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+func baselineMetric(b size.Baseline, m size.Metric) (int, string) {
+	if m == size.Kilobytes {
+		return b.Kilobytes, "KiB"
+	}
+	if m == size.Lines {
+		return b.Lines, "lines"
+	}
+	return b.Tokens, "tokens"
+}
+
+type sessionSizeBackend struct {
+	server   *Server
+	identity Identity
+}
+
+func (b sessionSizeBackend) Baseline(target string) (string, error) {
+	if _, err := b.server.buildSessionFS(b.identity).ReadFile(target); err != nil {
+		return "", err
+	}
+	return b.server.rules.baselineText(context.Background(), target)
+}
+func (b sessionSizeBackend) Reset(target, note string, a cmds.JobAttribution) (string, error) {
+	id := b.server.resolveSessionIdentity(b.identity)
+	if !scopeGrantsWrite(id.Scopes) || !b.server.identityHasDirConfigRole(id, target) || !b.server.identityCanWrite(id, vfs.ChangeActionWrite, target) {
+		return "", errors.New("permission denied")
+	}
+	content, err := b.server.merge.ReadFile(target)
+	if err != nil {
+		return "", err
+	}
+	states, err := b.server.rules.sizeRules(context.Background(), target)
+	if err != nil {
+		return "", err
+	}
+	if len(states) == 0 {
+		return "", fmt.Errorf("no max: initial size rule applies to %s", target)
+	}
+	actor := Attribution{Principal: a.Principal, Actor: a.Actor}.String()
+	previous, next, err := size.Reset(context.Background(), states[0].store, target, content, tokenizer.Estimator{}, actor, note)
+	if err != nil {
+		return "", err
+	}
+	if err = b.server.audit.Record(context.Background(), AuditEvent{Type: "rules.baseline.reset", Attribution: Attribution{Principal: a.Principal, Actor: a.Actor}, Details: map[string]any{"path": target, "previous": previous, "next": next, "note": note}}); err != nil {
+		return "", err
+	}
+	value, unit := baselineMetric(next, states[0].metric)
+	cap := int(math.Floor(float64(value) * states[0].growth))
+	return fmt.Sprintf("baseline reset: previous %d %s, new %d %s, new cap %d %s\n", baselineValue(previous, states[0].metric), unit, value, unit, cap, unit), nil
+}
+func baselineValue(b size.Baseline, m size.Metric) int { v, _ := baselineMetric(b, m); return v }

--- a/pkg/openlore/rules_size.go
+++ b/pkg/openlore/rules_size.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"path"
 	"strings"
 
 	"github.com/aakarim/go-openlore/pkg/packagestate"
@@ -16,10 +17,11 @@ import (
 )
 
 type sizeRuleState struct {
-	store  size.BaselineStore
-	metric size.Metric
-	growth float64
-	rule   rules.CompiledRule
+	store     size.BaselineStore
+	metric    size.Metric
+	growth    float64
+	tokenizer tokenizer.Tokenizer
+	rule      rules.CompiledRule
 }
 
 func (p *rulesPlugin) sizeRules(ctx context.Context, target string) ([]sizeRuleState, error) {
@@ -29,9 +31,9 @@ func (p *rulesPlugin) sizeRules(ctx context.Context, target string) ([]sizeRuleS
 	}
 	var out []sizeRuleState
 	for _, rule := range compiled {
-		store, metric, growth, ok := size.Inspect(rule.Check)
+		store, metric, growth, counter, ok := size.Inspect(rule.Check)
 		if ok && rules.Applies(rule, target) {
-			out = append(out, sizeRuleState{store, metric, growth, rule})
+			out = append(out, sizeRuleState{store: store, metric: metric, growth: growth, tokenizer: counter, rule: rule})
 		}
 	}
 	return out, nil
@@ -57,7 +59,12 @@ func (p *rulesPlugin) baselineText(ctx context.Context, target string) (string, 
 		return "no baseline recorded\n", nil
 	}
 	var b strings.Builder
-	fmt.Fprintln(&b, target)
+	if len(states) == 0 {
+		fmt.Fprintln(&b, target)
+	} else {
+		firstState := states[0]
+		fmt.Fprintf(&b, "%s  (%s via %s @ %s, growth %g)\n", target, firstState.rule.Spec.Use, firstState.rule.Name, firstState.rule.Origins[len(firstState.rule.Origins)-1], firstState.growth)
+	}
 	for _, record := range history {
 		fmt.Fprintf(&b, "  %s  %-10s  %-20s  %d lines  %d KiB  %d tokens", record.At.Format("2006-01-02T15:04:05Z"), first(record.Reason, record.Op), record.Actor, record.Lines, record.Kilobytes, record.Tokens)
 		if record.Tokenizer != "" {
@@ -121,7 +128,8 @@ func (b sessionSizeBackend) Baseline(target string) (string, error) {
 }
 func (b sessionSizeBackend) Reset(target, note string, a cmds.JobAttribution) (string, error) {
 	id := b.server.resolveSessionIdentity(b.identity)
-	if !scopeGrantsWrite(id.Scopes) || !b.server.identityHasDirConfigRole(id, target) || !b.server.identityCanWrite(id, vfs.ChangeActionWrite, target) {
+	configPath := path.Join(path.Dir(target), ".lore", "config.yaml")
+	if !b.server.identityHasDirConfigRole(id, configPath) || !b.server.identityCanWrite(id, vfs.ChangeActionWrite, target) {
 		return "", errors.New("permission denied")
 	}
 	content, err := b.server.merge.ReadFile(target)
@@ -136,15 +144,20 @@ func (b sessionSizeBackend) Reset(target, note string, a cmds.JobAttribution) (s
 		return "", fmt.Errorf("no max: initial size rule applies to %s", target)
 	}
 	actor := Attribution{Principal: a.Principal, Actor: a.Actor}.String()
-	previous, next, err := size.Reset(context.Background(), states[0].store, target, content, tokenizer.Estimator{}, actor, note)
+	previous, next, err := size.Reset(context.Background(), states[0].store, target, content, states[0].tokenizer, actor, note)
 	if err != nil {
 		return "", err
 	}
 	if err = b.server.audit.Record(context.Background(), AuditEvent{Type: "rules.baseline.reset", Attribution: Attribution{Principal: a.Principal, Actor: a.Actor}, Details: map[string]any{"path": target, "previous": previous, "next": next, "note": note}}); err != nil {
 		return "", err
 	}
-	value, unit := baselineMetric(next, states[0].metric)
-	cap := int(math.Floor(float64(value) * states[0].growth))
-	return fmt.Sprintf("baseline reset: previous %d %s, new %d %s, new cap %d %s\n", baselineValue(previous, states[0].metric), unit, value, unit, cap, unit), nil
+	var output strings.Builder
+	fmt.Fprintf(&output, "baseline reset: previous %d, new %d", baselineValue(previous, states[0].metric), baselineValue(next, states[0].metric))
+	for _, state := range states {
+		value, unit := baselineMetric(next, state.metric)
+		fmt.Fprintf(&output, ", new cap %d %s", int(math.Floor(float64(value)*state.growth)), unit)
+	}
+	fmt.Fprintln(&output)
+	return output.String(), nil
 }
 func baselineValue(b size.Baseline, m size.Metric) int { v, _ := baselineMetric(b, m); return v }

--- a/pkg/openlore/rules_size.go
+++ b/pkg/openlore/rules_size.go
@@ -105,8 +105,17 @@ type sessionSizeBackend struct {
 }
 
 func (b sessionSizeBackend) Baseline(target string) (string, error) {
-	if _, err := b.server.buildSessionFS(b.identity).ReadFile(target); err != nil {
-		return "", err
+	if b.server.authEnforced {
+		allowed := false
+		for _, root := range b.server.readableRoots(b.server.resolveSessionIdentity(b.identity)) {
+			if pathWithinRoot(root, target) {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return "", errors.New("permission denied")
+		}
 	}
 	return b.server.rules.baselineText(context.Background(), target)
 }

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -258,7 +258,7 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 			return nil, err
 		}
 	}
-	rulesPlugin, err := newRulesPlugin(s.auth, rules.Defaults{Growth: cfg.Rules.Growth}, s.merge, logger)
+	rulesPlugin, err := newRulesPluginWithTokenizer(s.auth, rules.Defaults{Growth: cfg.Rules.Growth}, s.merge, logger, cfg.Rules.Tokenizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -315,6 +315,7 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		s.writeLog = newWriteLog(s.merge, s.postCommitChain(), logger, 0)
 		s.historyPath = filepath.Join(dataDir, "history", "commits.jsonl")
 		s.writeLog.SetCommitRecorder(NewJSONLCommitRecorder(s.historyPath))
+		s.writeLog.SetCommitState(rulesPlugin.CommitState)
 		s.writeLog.SetPreApply(func(identity *Identity, attribution Attribution, changes vfs.ChangeSet) error {
 			for _, change := range changes.Leaves() {
 				if identity != nil {

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -94,6 +94,7 @@ type Server struct {
 	readMW            []ReadMiddleware
 	contentTransforms []ContentTransform
 	agentSkills       *agentSkillsPlugin
+	rules             *rulesPlugin
 
 	// metaExtenders are the `lore meta` extenders contributed by plugins,
 	// installed per session in buildSessionShell.
@@ -264,6 +265,7 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 	if err := s.registerPlugin(rulesPlugin); err != nil {
 		return nil, err
 	}
+	s.rules = rulesPlugin
 	// OKF metadata remains owned by the existing adapter; admission and
 	// validation are provided exclusively by the rules engine above.
 	if anyDocsetHasOKF(s.auth.Docsets) {
@@ -1134,6 +1136,7 @@ func (s *Server) buildSessionShell(id Identity) *shell.Shell {
 		sh.SetHistoryBackend(fileHistory{path: s.historyPath, roots: historyRoots(s.sessionDocsets(id))})
 	}
 	sh.SetJobBackend(s.jobs)
+	sh.SetSizeBackend(sessionSizeBackend{server: s, identity: id})
 
 	// Set identity info as environment variables
 	if id.IdentityName != "" {

--- a/pkg/openlore/vfs.go
+++ b/pkg/openlore/vfs.go
@@ -589,6 +589,9 @@ func (d *DirFS) resolve(p string) string {
 	return filepath.Join(d.root, filepath.FromSlash(p))
 }
 
+// HostDir maps a VFS directory to its writable on-disk backing for package state.
+func (d *DirFS) HostDir(p string) (string, bool) { return d.resolve(p), true }
+
 // currentHash returns the hex SHA-256 of the bytes currently at full, and
 // whether the file exists. A directory is treated as nonexistent for hashing.
 func currentHash(full string) (hash string, exists bool, err error) {
@@ -1098,6 +1101,19 @@ func (m *MergeFS) resolve(p string) (string, vfs.FileSystem, error) {
 	}
 
 	return "", nil, fmt.Errorf("not found: %s", p)
+}
+
+// HostDir follows the same mount routing as content operations.
+func (m *MergeFS) HostDir(p string) (string, bool) {
+	sub, backend, err := m.resolve(p)
+	if err != nil || backend == nil {
+		return "", false
+	}
+	mapper, ok := backend.(interface{ HostDir(string) (string, bool) })
+	if !ok {
+		return "", false
+	}
+	return mapper.HostDir(sub)
 }
 
 func (m *MergeFS) Stat(p string) (*vfs.FileInfo, error) {

--- a/pkg/openlore/writelog.go
+++ b/pkg/openlore/writelog.go
@@ -32,6 +32,7 @@ type logEntry struct {
 	cs          vfs.ChangeSet
 	attribution Attribution
 	identity    *Identity
+	task        func() error
 	reply       chan applyResult
 }
 
@@ -92,12 +93,13 @@ type writeLog struct {
 	substrate vfs.WritableFS
 	logger    *slog.Logger
 
-	mu         sync.RWMutex      // guards closed + postCommit + serializes sends against Close
-	postCommit PostCommitHandler // optional; runs at the applier after a durable commit
-	preApply   func(*Identity, Attribution, vfs.ChangeSet) error
-	recorder   CommitRecorder
-	closed     bool
-	ch         chan logEntry
+	mu          sync.RWMutex      // guards closed + postCommit + serializes sends against Close
+	postCommit  PostCommitHandler // optional; runs at the applier after a durable commit
+	commitState func(context.Context, CommitInfo) error
+	preApply    func(*Identity, Attribution, vfs.ChangeSet) error
+	recorder    CommitRecorder
+	closed      bool
+	ch          chan logEntry
 
 	done chan struct{} // closed when the applier goroutine has exited
 }
@@ -136,6 +138,10 @@ func newWriteLog(substrate vfs.WritableFS, postCommit PostCommitHandler, logger 
 func (l *writeLog) run() {
 	defer close(l.done)
 	for e := range l.ch {
+		if e.task != nil {
+			e.reply <- applyResult{err: e.task()}
+			continue
+		}
 		var committed vfs.CommitResult
 		var err error
 		if preflight, ok := l.substrate.(vfs.ChangePreflighter); ok {
@@ -155,6 +161,14 @@ func (l *writeLog) run() {
 			committed, err = vfs.CommitChangeSet(l.substrate, e.cs)
 		}
 		if err == nil && committed.HasCommitted() {
+			l.mu.RLock()
+			state := l.commitState
+			l.mu.RUnlock()
+			if state != nil {
+				err = state(context.Background(), CommitInfo{ChangeSet: committed.Committed, Hash: committed.Hash, Attribution: e.attribution})
+			}
+		}
+		if committed.HasCommitted() {
 			l.mu.RLock()
 			recorder := l.recorder
 			l.mu.RUnlock()
@@ -191,6 +205,12 @@ func (l *writeLog) SetPreApply(h func(*Identity, Attribution, vfs.ChangeSet) err
 	l.mu.Unlock()
 }
 
+func (l *writeLog) SetCommitState(h func(context.Context, CommitInfo) error) {
+	l.mu.Lock()
+	l.commitState = h
+	l.mu.Unlock()
+}
+
 func (l *writeLog) SetCommitRecorder(recorder CommitRecorder) {
 	l.mu.Lock()
 	l.recorder = recorder
@@ -217,6 +237,29 @@ func (l *writeLog) Submit(ctx context.Context, attribution Attribution, cs vfs.C
 
 func (l *writeLog) SubmitIdentity(ctx context.Context, identity Identity, cs vfs.ChangeSet) (string, error) {
 	return l.submit(ctx, &identity, identity.attribution(), cs)
+}
+
+// Do runs fn at the write applier, serialized with content commits.
+func (l *writeLog) Do(ctx context.Context, fn func() error) error {
+	reply := make(chan applyResult, 1)
+	l.mu.RLock()
+	if l.closed {
+		l.mu.RUnlock()
+		return ErrLogClosed
+	}
+	select {
+	case l.ch <- logEntry{task: fn, reply: reply}:
+		l.mu.RUnlock()
+	case <-ctx.Done():
+		l.mu.RUnlock()
+		return ctx.Err()
+	}
+	select {
+	case result := <-reply:
+		return result.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (l *writeLog) submit(ctx context.Context, identity *Identity, attribution Attribution, cs vfs.ChangeSet) (string, error) {

--- a/pkg/openlore/writelog_test.go
+++ b/pkg/openlore/writelog_test.go
@@ -391,6 +391,29 @@ func TestWriteLog_PostCommitRunsWithActorAndDoesNotBlockSubmit(t *testing.T) {
 	}
 }
 
+func TestWriteLogCommitStateRunsBeforeSuccessAndSurfacesFailure(t *testing.T) {
+	fs := &wlRecordingFS{}
+	stateErr := errors.New("state disk full")
+	var stateSawContent bool
+	l := newWriteLog(fs, nil, nil, 1)
+	l.SetCommitState(func(_ context.Context, info CommitInfo) error {
+		content, err := fs.ReadFile(info.ChangeSet.Target)
+		stateSawContent = err == nil && string(content) == "x"
+		return stateErr
+	})
+	defer l.Close(context.Background())
+
+	if _, err := l.Submit(context.Background(), Attribution{}, writeCS("/committed")); !errors.Is(err, stateErr) {
+		t.Fatalf("state failure = %v", err)
+	}
+	if !stateSawContent {
+		t.Fatal("state hook ran before content commit")
+	}
+	if content, err := fs.ReadFile("/committed"); err != nil || string(content) != "x" {
+		t.Fatalf("content was not committed: content=%q err=%v", content, err)
+	}
+}
+
 func TestWriteLog_RecorderFailureDoesNotTurnCommittedWriteIntoFailure(t *testing.T) {
 	fs := &wlRecordingFS{}
 	l := newWriteLog(fs, nil, nil, 1)

--- a/pkg/packagestate/store.go
+++ b/pkg/packagestate/store.go
@@ -1,0 +1,231 @@
+// Package packagestate stores package-owned, per-file append-only state beside content.
+package packagestate
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type HostMapper interface {
+	HostDir(vfsDir string) (string, bool)
+}
+
+type Store interface {
+	Dir(context.Context, string) (DirStore, error)
+}
+
+type DirStore interface {
+	Append(key string, record []byte) error
+	Records(key string) iter.Seq2[[]byte, error]
+	Replace(key string, records [][]byte) error
+	Remove(key string) error
+	Move(key string, to DirStore, toKey string) error
+}
+
+type store struct {
+	mapper HostMapper
+	pkg    string
+}
+
+// Open scopes a store to one package. Uppercase letters use Go module-cache
+// escaping (Github.com/X becomes !github.com/!x).
+func Open(mapper HostMapper, pkg string) Store {
+	return &store{mapper: mapper, pkg: escapePath(pkg)}
+}
+
+func escapePath(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		if r >= 'A' && r <= 'Z' {
+			b.WriteByte('!')
+			b.WriteRune(r + ('a' - 'A'))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func (s *store) Dir(_ context.Context, vfsDir string) (DirStore, error) {
+	if s.mapper == nil {
+		return unavailable{}, nil
+	}
+	host, ok := s.mapper.HostDir(vfsDir)
+	if !ok {
+		return unavailable{}, nil
+	}
+	return &dirStore{host: host, pkg: s.pkg}, nil
+}
+
+type unavailable struct{}
+
+func (unavailable) Append(string, []byte) error             { return os.ErrPermission }
+func (unavailable) Records(string) iter.Seq2[[]byte, error] { return func(func([]byte, error) bool) {} }
+func (unavailable) Replace(string, [][]byte) error          { return os.ErrPermission }
+func (unavailable) Remove(string) error                     { return nil }
+func (unavailable) Move(string, DirStore, string) error     { return os.ErrPermission }
+
+type dirStore struct {
+	host string
+	pkg  string
+}
+
+func validKey(key string) error {
+	if key == "" || key == "." || key == ".." || filepath.Base(key) != key || strings.ContainsAny(key, `/\\`) || strings.ContainsRune(key, 0) {
+		return fmt.Errorf("invalid package-state key %q", key)
+	}
+	return nil
+}
+
+func (d *dirStore) withRoot(create bool, fn func(*os.Root) error) error {
+	r, err := os.OpenRoot(d.host)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	if create {
+		current := ".lore"
+		if err := r.Mkdir(current, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		for _, segment := range strings.Split(d.pkg, "/") {
+			current = filepath.ToSlash(filepath.Join(current, segment))
+			if err := r.Mkdir(current, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+				return err
+			}
+		}
+	}
+	return fn(r)
+}
+
+func (d *dirStore) rel(key string) string {
+	return filepath.ToSlash(filepath.Join(".lore", filepath.FromSlash(d.pkg), key))
+}
+
+func (d *dirStore) Append(key string, record []byte) error {
+	if err := validKey(key); err != nil {
+		return err
+	}
+	return d.withRoot(true, func(r *os.Root) error {
+		f, err := r.OpenFile(d.rel(key), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if _, err = f.Write(append(append([]byte(nil), record...), '\n')); err != nil {
+			return err
+		}
+		return f.Sync()
+	})
+}
+
+func (d *dirStore) Records(key string) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		if err := validKey(key); err != nil {
+			yield(nil, err)
+			return
+		}
+		err := d.withRoot(false, func(r *os.Root) error {
+			f, err := r.Open(d.rel(key))
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			s := bufio.NewScanner(f)
+			for s.Scan() {
+				if !yield(append([]byte(nil), s.Bytes()...), nil) {
+					return nil
+				}
+			}
+			return s.Err()
+		})
+		if err != nil {
+			yield(nil, err)
+		}
+	}
+}
+
+func (d *dirStore) Replace(key string, records [][]byte) error {
+	if err := validKey(key); err != nil {
+		return err
+	}
+	return d.withRoot(true, func(r *os.Root) error {
+		tmp := d.rel(key) + ".tmp"
+		f, err := r.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+		if err != nil {
+			return err
+		}
+		ok := false
+		defer func() {
+			f.Close()
+			if !ok {
+				_ = r.Remove(tmp)
+			}
+		}()
+		for _, record := range records {
+			if _, err = f.Write(append(append([]byte(nil), record...), '\n')); err != nil {
+				return err
+			}
+		}
+		if err = f.Sync(); err != nil {
+			return err
+		}
+		if err = f.Close(); err != nil {
+			return err
+		}
+		if err = r.Rename(tmp, d.rel(key)); err != nil {
+			return err
+		}
+		ok = true
+		return nil
+	})
+}
+
+func (d *dirStore) Remove(key string) error {
+	if err := validKey(key); err != nil {
+		return err
+	}
+	return d.withRoot(false, func(r *os.Root) error {
+		err := r.Remove(d.rel(key))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	})
+}
+
+func (d *dirStore) Move(key string, target DirStore, toKey string) error {
+	if err := validKey(key); err != nil {
+		return err
+	}
+	if err := validKey(toKey); err != nil {
+		return err
+	}
+	to, ok := target.(*dirStore)
+	if !ok {
+		return os.ErrPermission
+	}
+	var records [][]byte
+	for record, err := range d.Records(key) {
+		if err != nil {
+			return err
+		}
+		records = append(records, record)
+	}
+	if len(records) == 0 {
+		return nil
+	}
+	if err := to.Replace(toKey, records); err != nil {
+		return err
+	}
+	return d.Remove(key)
+}

--- a/pkg/packagestate/store.go
+++ b/pkg/packagestate/store.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"iter"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 type HostMapper interface {
@@ -26,17 +28,37 @@ type DirStore interface {
 	Replace(key string, records [][]byte) error
 	Remove(key string) error
 	Move(key string, to DirStore, toKey string) error
+	RewriteMove(key string, to DirStore, toKey string, rewrite func([]byte) ([]byte, error)) error
 }
 
 type store struct {
 	mapper HostMapper
 	pkg    string
+	err    error
+	mu     *sync.Mutex
 }
+
+var packageLocks sync.Map
 
 // Open scopes a store to one package. Uppercase letters use Go module-cache
 // escaping (Github.com/X becomes !github.com/!x).
 func Open(mapper HostMapper, pkg string) Store {
-	return &store{mapper: mapper, pkg: escapePath(pkg)}
+	err := validPackage(pkg)
+	escaped := escapePath(pkg)
+	lock, _ := packageLocks.LoadOrStore(escaped, &sync.Mutex{})
+	return &store{mapper: mapper, pkg: escaped, err: err, mu: lock.(*sync.Mutex)}
+}
+
+func validPackage(pkg string) error {
+	if pkg == "" || strings.ContainsRune(pkg, 0) || strings.ContainsAny(pkg, `\:`) || strings.HasPrefix(pkg, "/") || strings.HasSuffix(pkg, "/") || path.Clean(pkg) != pkg {
+		return fmt.Errorf("invalid package-state package %q", pkg)
+	}
+	for _, segment := range strings.Split(pkg, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return fmt.Errorf("invalid package-state package %q", pkg)
+		}
+	}
+	return nil
 }
 
 func escapePath(value string) string {
@@ -53,6 +75,9 @@ func escapePath(value string) string {
 }
 
 func (s *store) Dir(_ context.Context, vfsDir string) (DirStore, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
 	if s.mapper == nil {
 		return unavailable{}, nil
 	}
@@ -60,7 +85,7 @@ func (s *store) Dir(_ context.Context, vfsDir string) (DirStore, error) {
 	if !ok {
 		return unavailable{}, nil
 	}
-	return &dirStore{host: host, pkg: s.pkg}, nil
+	return &dirStore{host: host, pkg: s.pkg, mu: s.mu}, nil
 }
 
 type unavailable struct{}
@@ -70,10 +95,14 @@ func (unavailable) Records(string) iter.Seq2[[]byte, error] { return func(func([
 func (unavailable) Replace(string, [][]byte) error          { return os.ErrPermission }
 func (unavailable) Remove(string) error                     { return nil }
 func (unavailable) Move(string, DirStore, string) error     { return os.ErrPermission }
+func (unavailable) RewriteMove(string, DirStore, string, func([]byte) ([]byte, error)) error {
+	return os.ErrPermission
+}
 
 type dirStore struct {
 	host string
 	pkg  string
+	mu   *sync.Mutex
 }
 
 func validKey(key string) error {
@@ -109,6 +138,12 @@ func (d *dirStore) rel(key string) string {
 }
 
 func (d *dirStore) Append(key string, record []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.append(key, record)
+}
+
+func (d *dirStore) append(key string, record []byte) error {
 	if err := validKey(key); err != nil {
 		return err
 	}
@@ -127,34 +162,46 @@ func (d *dirStore) Append(key string, record []byte) error {
 
 func (d *dirStore) Records(key string) iter.Seq2[[]byte, error] {
 	return func(yield func([]byte, error) bool) {
-		if err := validKey(key); err != nil {
-			yield(nil, err)
-			return
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		d.records(key, yield)
+	}
+}
+
+func (d *dirStore) records(key string, yield func([]byte, error) bool) {
+	if err := validKey(key); err != nil {
+		yield(nil, err)
+		return
+	}
+	err := d.withRoot(false, func(r *os.Root) error {
+		f, err := r.Open(d.rel(key))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
 		}
-		err := d.withRoot(false, func(r *os.Root) error {
-			f, err := r.Open(d.rel(key))
-			if errors.Is(err, os.ErrNotExist) {
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		s := bufio.NewScanner(f)
+		for s.Scan() {
+			if !yield(append([]byte(nil), s.Bytes()...), nil) {
 				return nil
 			}
-			if err != nil {
-				return err
-			}
-			defer f.Close()
-			s := bufio.NewScanner(f)
-			for s.Scan() {
-				if !yield(append([]byte(nil), s.Bytes()...), nil) {
-					return nil
-				}
-			}
-			return s.Err()
-		})
-		if err != nil {
-			yield(nil, err)
 		}
+		return s.Err()
+	})
+	if err != nil {
+		yield(nil, err)
 	}
 }
 
 func (d *dirStore) Replace(key string, records [][]byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.replace(key, records)
+}
+
+func (d *dirStore) replace(key string, records [][]byte) error {
 	if err := validKey(key); err != nil {
 		return err
 	}
@@ -191,6 +238,12 @@ func (d *dirStore) Replace(key string, records [][]byte) error {
 }
 
 func (d *dirStore) Remove(key string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.remove(key)
+}
+
+func (d *dirStore) remove(key string) error {
 	if err := validKey(key); err != nil {
 		return err
 	}
@@ -204,6 +257,10 @@ func (d *dirStore) Remove(key string) error {
 }
 
 func (d *dirStore) Move(key string, target DirStore, toKey string) error {
+	return d.RewriteMove(key, target, toKey, func(record []byte) ([]byte, error) { return record, nil })
+}
+
+func (d *dirStore) RewriteMove(key string, target DirStore, toKey string, rewrite func([]byte) ([]byte, error)) error {
 	if err := validKey(key); err != nil {
 		return err
 	}
@@ -211,21 +268,34 @@ func (d *dirStore) Move(key string, target DirStore, toKey string) error {
 		return err
 	}
 	to, ok := target.(*dirStore)
-	if !ok {
+	if !ok || to.mu != d.mu {
 		return os.ErrPermission
 	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	var records [][]byte
-	for record, err := range d.Records(key) {
+	var readErr error
+	d.records(key, func(record []byte, err error) bool {
 		if err != nil {
-			return err
+			readErr = err
+			return false
 		}
-		records = append(records, record)
+		rewritten, err := rewrite(record)
+		if err != nil {
+			readErr = err
+			return false
+		}
+		records = append(records, rewritten)
+		return true
+	})
+	if readErr != nil {
+		return readErr
 	}
 	if len(records) == 0 {
 		return nil
 	}
-	if err := to.Replace(toKey, records); err != nil {
+	if err := to.replace(toKey, records); err != nil {
 		return err
 	}
-	return d.Remove(key)
+	return d.remove(key)
 }

--- a/pkg/packagestate/store_test.go
+++ b/pkg/packagestate/store_test.go
@@ -1,0 +1,70 @@
+package packagestate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+type testMapper map[string]string
+
+func (m testMapper) HostDir(dir string) (string, bool) { host, ok := m[dir]; return host, ok }
+
+func collect(t *testing.T, d DirStore, key string) [][]byte {
+	t.Helper()
+	var out [][]byte
+	for record, err := range d.Records(key) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, record)
+	}
+	return out
+}
+
+func TestStoreRoundTripMoveRemoveReplaceAndEscaping(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	store := Open(testMapper{"/a": a, "/b": b}, "Github.com/X")
+	da, _ := store.Dir(context.Background(), "/a")
+	db, _ := store.Dir(context.Background(), "/b")
+	if err := da.Append("x.jsonl", []byte(`{"n":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := da.Append("x.jsonl", []byte(`{"n":2}`)); err != nil {
+		t.Fatal(err)
+	}
+	if got := collect(t, da, "x.jsonl"); !reflect.DeepEqual(got, [][]byte{[]byte(`{"n":1}`), []byte(`{"n":2}`)}) {
+		t.Fatalf("records=%q", got)
+	}
+	if err := da.Replace("x.jsonl", [][]byte{[]byte(`{"n":3}`)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := da.Move("x.jsonl", db, "y.jsonl"); err != nil {
+		t.Fatal(err)
+	}
+	if got := collect(t, db, "y.jsonl"); len(got) != 1 || string(got[0]) != `{"n":3}` {
+		t.Fatalf("moved=%q", got)
+	}
+	if err := db.Remove("y.jsonl"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(a, ".lore", "!github.com", "!x")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStoreRefusesSymlinkEscape(t *testing.T) {
+	host, outside := t.TempDir(), t.TempDir()
+	if err := os.MkdirAll(filepath.Join(host, ".lore"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(host, ".lore", "size")); err != nil {
+		t.Fatal(err)
+	}
+	d, _ := Open(testMapper{"/": host}, "size").Dir(context.Background(), "/")
+	if err := d.Append("x.jsonl", []byte("x")); err == nil {
+		t.Fatal("symlink escape succeeded")
+	}
+}

--- a/pkg/packagestate/store_test.go
+++ b/pkg/packagestate/store_test.go
@@ -68,3 +68,11 @@ func TestStoreRefusesSymlinkEscape(t *testing.T) {
 		t.Fatal("symlink escape succeeded")
 	}
 }
+
+func TestStoreRejectsUnsafePackagePaths(t *testing.T) {
+	for _, pkg := range []string{"", ".", "..", "../other", "other/..", "/root", "a//b", `a\b`, "a:b"} {
+		if _, err := Open(testMapper{"/": t.TempDir()}, pkg).Dir(context.Background(), "/"); err == nil {
+			t.Errorf("package %q accepted", pkg)
+		}
+	}
+}

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -171,6 +171,14 @@ func (e *Engine) effective(ctx context.Context, target, dir string) ([]CompiledR
 }
 
 func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, existing func() ([]byte, bool, error)) error {
+	return e.evaluateLeaf(ctx, leaf, actor, existing, ModeAdmit)
+}
+
+func (e *Engine) PreApplyLeaf(ctx context.Context, leaf vfs.Change, actor string, existing func() ([]byte, bool, error)) error {
+	return e.evaluateLeaf(ctx, leaf, actor, existing, ModePreApply)
+}
+
+func (e *Engine) evaluateLeaf(ctx context.Context, leaf vfs.Change, actor string, existing func() ([]byte, bool, error), mode Mode) error {
 	if leaf.Action != vfs.ChangeActionWrite || leaf.Write == nil {
 		return nil
 	}
@@ -182,7 +190,7 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 		if rule.Member.Manifest().Scope != ScopeFile || !Applies(rule, leaf.Target) {
 			continue
 		}
-		findings, checkErr := rule.Check.Evaluate(ctx, Subject{Mode: ModeAdmit, Path: leaf.Target, Dir: path.Dir(leaf.Target), Content: leaf.Write.Bytes, Existing: existing, Actor: actor})
+		findings, checkErr := rule.Check.Evaluate(ctx, Subject{Mode: mode, Path: leaf.Target, Dir: path.Dir(leaf.Target), Content: leaf.Write.Bytes, Existing: existing, Actor: actor})
 		if checkErr != nil {
 			if rule.Spec.IsEnforcing() {
 				return &Rejection{Path: leaf.Target, Rule: rule.Name, Member: rule.Spec.Use, Origin: last(rule.Origins), Err: checkErr}
@@ -206,6 +214,21 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 		}
 		for _, finding := range violations {
 			e.warn(rule, leaf.Target, findingText(finding, rule, leaf.Target))
+		}
+	}
+	return nil
+}
+
+func (e *Engine) OnWrite(ctx context.Context, target string, content []byte, actor string) error {
+	compiled, err := e.Effective(ctx, target)
+	if err != nil {
+		return err
+	}
+	for _, rule := range compiled {
+		if rule.Member.Manifest().Scope == ScopeFile && Applies(rule, target) {
+			if err := rule.Check.OnWrite(ctx, target, content, actor); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -211,6 +211,36 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 	return nil
 }
 
+func (e *Engine) OnRemove(ctx context.Context, target string) error {
+	compiled, err := e.Effective(ctx, target)
+	if err != nil {
+		return err
+	}
+	for _, rule := range compiled {
+		if rule.Member.Manifest().Scope == ScopeFile && matchesAtScope(rule, target) {
+			if err := rule.Check.OnRemove(ctx, target); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *Engine) OnMove(ctx context.Context, from, to string) error {
+	compiled, err := e.Effective(ctx, from)
+	if err != nil {
+		return err
+	}
+	for _, rule := range compiled {
+		if rule.Member.Manifest().Scope == ScopeFile && matchesAtScope(rule, from) {
+			if err := rule.Check.OnMove(ctx, from, to); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func IsDirConfigPath(target string) bool {
 	clean := vfs.CleanPath(target)
 	if path.Base(clean) != "config.yaml" || path.Base(path.Dir(clean)) != ".lore" {
@@ -363,6 +393,8 @@ func matchesAtScope(rule CompiledRule, target string) bool {
 	rel, ok := relativeTo(rule.Scope, target)
 	return ok && Matches(rule.Spec, rel)
 }
+
+func Applies(rule CompiledRule, target string) bool { return matchesAtScope(rule, target) }
 
 func bundleMatches(rule CompiledRule, bundle *validation.Bundle) bool {
 	for _, file := range bundle.Files {

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -179,7 +179,7 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 		return err
 	}
 	for _, rule := range rules {
-		if rule.Member.Manifest().Scope != ScopeFile || !matchesAtScope(rule, leaf.Target) {
+		if rule.Member.Manifest().Scope != ScopeFile || !Applies(rule, leaf.Target) {
 			continue
 		}
 		findings, checkErr := rule.Check.Evaluate(ctx, Subject{Mode: ModeAdmit, Path: leaf.Target, Dir: path.Dir(leaf.Target), Content: leaf.Write.Bytes, Existing: existing, Actor: actor})
@@ -211,14 +211,14 @@ func (e *Engine) AdmitLeaf(ctx context.Context, leaf vfs.Change, actor string, e
 	return nil
 }
 
-func (e *Engine) OnRemove(ctx context.Context, target string) error {
+func (e *Engine) OnRemove(ctx context.Context, target, actor string) error {
 	compiled, err := e.Effective(ctx, target)
 	if err != nil {
 		return err
 	}
 	for _, rule := range compiled {
-		if rule.Member.Manifest().Scope == ScopeFile && matchesAtScope(rule, target) {
-			if err := rule.Check.OnRemove(ctx, target); err != nil {
+		if rule.Member.Manifest().Scope == ScopeFile && Applies(rule, target) {
+			if err := rule.Check.OnRemove(ctx, target, actor); err != nil {
 				return err
 			}
 		}
@@ -232,7 +232,7 @@ func (e *Engine) OnMove(ctx context.Context, from, to string) error {
 		return err
 	}
 	for _, rule := range compiled {
-		if rule.Member.Manifest().Scope == ScopeFile && matchesAtScope(rule, from) {
+		if rule.Member.Manifest().Scope == ScopeFile && Applies(rule, from) {
 			if err := rule.Check.OnMove(ctx, from, to); err != nil {
 				return err
 			}
@@ -265,7 +265,7 @@ func (e *Engine) validateFile(ctx context.Context, fsys vfs.FileSystem, bundleRo
 	}
 	var diagnostics []validation.Diagnostic
 	for _, rule := range rules {
-		if rule.Member.Manifest().Scope != ScopeFile || !matchesAtScope(rule, target) {
+		if rule.Member.Manifest().Scope != ScopeFile || !Applies(rule, target) {
 			continue
 		}
 		findings, checkErr := rule.Check.Evaluate(ctx, Subject{Mode: ModeValidate, Path: target, Dir: path.Dir(target), Content: content, FS: fsys, BundleRoot: bundleRoot, Bundle: bundle})
@@ -389,16 +389,14 @@ func (e *Engine) ValidateBundle(ctx context.Context, fsys vfs.FileSystem, root s
 	return validation.Scan(fsys, root, e.Validator())
 }
 
-func matchesAtScope(rule CompiledRule, target string) bool {
+func Applies(rule CompiledRule, target string) bool {
 	rel, ok := relativeTo(rule.Scope, target)
 	return ok && Matches(rule.Spec, rel)
 }
 
-func Applies(rule CompiledRule, target string) bool { return matchesAtScope(rule, target) }
-
 func bundleMatches(rule CompiledRule, bundle *validation.Bundle) bool {
 	for _, file := range bundle.Files {
-		if matchesAtScope(rule, file.AbsolutePath) {
+		if Applies(rule, file.AbsolutePath) {
 			return true
 		}
 	}

--- a/pkg/rules/engine_test.go
+++ b/pkg/rules/engine_test.go
@@ -44,8 +44,8 @@ func (c testCheck) Evaluate(_ context.Context, subject Subject) ([]Finding, erro
 	}
 	return nil, nil
 }
-func (testCheck) OnRemove(context.Context, string) error       { return nil }
-func (testCheck) OnMove(context.Context, string, string) error { return nil }
+func (testCheck) OnRemove(context.Context, string, string) error { return nil }
+func (testCheck) OnMove(context.Context, string, string) error   { return nil }
 
 func TestAdmitLeafNeverCallsBundleRule(t *testing.T) {
 	calls := 0

--- a/pkg/rules/engine_test.go
+++ b/pkg/rules/engine_test.go
@@ -44,8 +44,9 @@ func (c testCheck) Evaluate(_ context.Context, subject Subject) ([]Finding, erro
 	}
 	return nil, nil
 }
-func (testCheck) OnRemove(context.Context, string, string) error { return nil }
-func (testCheck) OnMove(context.Context, string, string) error   { return nil }
+func (testCheck) OnRemove(context.Context, string, string) error        { return nil }
+func (testCheck) OnMove(context.Context, string, string) error          { return nil }
+func (testCheck) OnWrite(context.Context, string, []byte, string) error { return nil }
 
 func TestAdmitLeafNeverCallsBundleRule(t *testing.T) {
 	calls := 0

--- a/pkg/rules/link/link.go
+++ b/pkg/rules/link/link.go
@@ -75,8 +75,9 @@ func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Findi
 	}
 	return findings, nil
 }
-func (check) OnRemove(context.Context, string, string) error { return nil }
-func (check) OnMove(context.Context, string, string) error   { return nil }
+func (check) OnRemove(context.Context, string, string) error        { return nil }
+func (check) OnMove(context.Context, string, string) error          { return nil }
+func (check) OnWrite(context.Context, string, []byte, string) error { return nil }
 
 func finding(file string, l okf.Link, code, message string) rules.Finding {
 	return rules.Finding{Code: code, Path: file, Line: l.Line, Column: l.Column, Measured: message}

--- a/pkg/rules/link/link.go
+++ b/pkg/rules/link/link.go
@@ -75,8 +75,8 @@ func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Findi
 	}
 	return findings, nil
 }
-func (check) OnRemove(context.Context, string) error       { return nil }
-func (check) OnMove(context.Context, string, string) error { return nil }
+func (check) OnRemove(context.Context, string, string) error { return nil }
+func (check) OnMove(context.Context, string, string) error   { return nil }
 
 func finding(file string, l okf.Link, code, message string) rules.Finding {
 	return rules.Finding{Code: code, Path: file, Line: l.Line, Column: l.Column, Measured: message}

--- a/pkg/rules/okfrule/okf.go
+++ b/pkg/rules/okfrule/okf.go
@@ -57,5 +57,6 @@ func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Findi
 	}
 	return findings, nil
 }
-func (check) OnRemove(context.Context, string, string) error { return nil }
-func (check) OnMove(context.Context, string, string) error   { return nil }
+func (check) OnRemove(context.Context, string, string) error        { return nil }
+func (check) OnMove(context.Context, string, string) error          { return nil }
+func (check) OnWrite(context.Context, string, []byte, string) error { return nil }

--- a/pkg/rules/okfrule/okf.go
+++ b/pkg/rules/okfrule/okf.go
@@ -57,5 +57,5 @@ func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Findi
 	}
 	return findings, nil
 }
-func (check) OnRemove(context.Context, string) error       { return nil }
-func (check) OnMove(context.Context, string, string) error { return nil }
+func (check) OnRemove(context.Context, string, string) error { return nil }
+func (check) OnMove(context.Context, string, string) error   { return nil }

--- a/pkg/rules/registry.go
+++ b/pkg/rules/registry.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -66,6 +67,15 @@ func (r *Registry) Suggest(name string) string {
 func IsStdlib(name string) bool {
 	first := strings.SplitN(name, "/", 2)[0]
 	return first != "" && !strings.Contains(first, ".")
+}
+
+// PackageOf returns the package path that owns a member path.
+func PackageOf(member string) string {
+	pkg := path.Dir(member)
+	if pkg == "." {
+		return member
+	}
+	return pkg
 }
 
 func distance(a, b string) int {

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -33,3 +33,12 @@ func TestUnify(t *testing.T) {
 		t.Fatalf("default replacement: %v %#v", err, unified)
 	}
 }
+
+func TestPackageOf(t *testing.T) {
+	if got := PackageOf("size/lines"); got != "size" {
+		t.Fatalf("stdlib package=%q", got)
+	}
+	if got := PackageOf("github.com/acme/rules/check"); got != "github.com/acme/rules" {
+		t.Fatalf("VCS package=%q", got)
+	}
+}

--- a/pkg/rules/size/size.go
+++ b/pkg/rules/size/size.go
@@ -22,9 +22,9 @@ type Baseline struct {
 	Actor     string    `json:"actor,omitempty"`
 	Note      string    `json:"note,omitempty"`
 	Commit    string    `json:"commit,omitempty"`
-	Kilobytes int       `json:"kilobytes,omitempty"`
-	Lines     int       `json:"lines,omitempty"`
-	Tokens    int       `json:"tokens,omitempty"`
+	Kilobytes int       `json:"kilobytes"`
+	Lines     int       `json:"lines"`
+	Tokens    int       `json:"tokens"`
 	Tokenizer string    `json:"tokenizer,omitempty"`
 }
 
@@ -104,7 +104,29 @@ func (s *baselineStore) Move(ctx context.Context, from, to string) error {
 	if err != nil {
 		return err
 	}
-	return src.Move(stateKey(from), dst, stateKey(to))
+	var records [][]byte
+	for raw, recordErr := range src.Records(stateKey(from)) {
+		if recordErr != nil {
+			return recordErr
+		}
+		var record Baseline
+		if err := json.Unmarshal(raw, &record); err != nil {
+			return err
+		}
+		record.Path = to
+		rewritten, err := json.Marshal(record)
+		if err != nil {
+			return err
+		}
+		records = append(records, rewritten)
+	}
+	if len(records) == 0 {
+		return nil
+	}
+	if err := dst.Replace(stateKey(to), records); err != nil {
+		return err
+	}
+	return src.Remove(stateKey(from))
 }
 
 func Measure(content []byte, tok tokenizer.Tokenizer) (Baseline, error) {
@@ -134,6 +156,7 @@ func Reset(ctx context.Context, store BaselineStore, p string, content []byte, t
 		return Baseline{}, Baseline{}, err
 	}
 	next.Path, next.Op, next.Reason, next.Actor, next.Note = p, "baseline", "reset", actor, note
+	next.At = time.Now().UTC()
 	if err := store.Record(ctx, next); err != nil {
 		return Baseline{}, Baseline{}, err
 	}
@@ -212,12 +235,12 @@ type check struct {
 }
 
 // Inspect exposes the stateful configuration to the size administration command.
-func Inspect(value rules.Check) (BaselineStore, Metric, float64, bool) {
+func Inspect(value rules.Check) (BaselineStore, Metric, float64, tokenizer.Tokenizer, bool) {
 	c, ok := value.(*check)
 	if !ok || !c.initial {
-		return nil, 0, 0, false
+		return nil, 0, 0, nil, false
 	}
-	return c.store, c.metric, c.growth, true
+	return c.store, c.metric, c.growth, c.tokenizer(), true
 }
 
 func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Finding, error) {
@@ -228,27 +251,32 @@ func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Fi
 	value, unit := c.value(measured)
 	limit, provenance := c.max, fmt.Sprintf("max: %d", c.max)
 	if c.initial {
-		baseline, ok, err := c.store.Get(ctx, subject.Path)
+		baseline, ok, err := c.baseline(ctx, subject.Path)
 		if err != nil {
 			return nil, err
 		}
-		if c.metric == Tokens && ok && baseline.Tokenizer != c.tokenizer().Name() {
+		tokenizerChanged := c.metric == Tokens && ok && baseline.Tokenizer != c.tokenizer().Name()
+		if tokenizerChanged {
 			ok = false
 		}
-		if !ok {
-			baseContent, existed := subject.Content, false
-			if subject.Existing != nil {
-				existingContent, exists, existingErr := subject.Existing()
-				existed, err = exists, existingErr
-				if err != nil {
-					return nil, err
-				}
-				if existed {
-					baseContent = existingContent
-				}
+		var existingContent []byte
+		existed := false
+		if subject.Mode == rules.ModeAdmit && subject.Existing != nil {
+			existingContent, existed, err = subject.Existing()
+			if err != nil {
+				return nil, err
 			}
+			if !existed {
+				ok = false
+			}
+		}
+		if !ok {
+			baseContent := subject.Content
 			if subject.Mode == rules.ModeValidate {
 				return nil, nil
+			}
+			if len(existingContent) != 0 || existed {
+				baseContent = existingContent
 			}
 			baseline, err = Measure(baseContent, c.tokenizer())
 			if err != nil {
@@ -258,6 +286,10 @@ func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Fi
 			if existed {
 				baseline.Reason = "rule-added"
 			}
+			if tokenizerChanged && existed {
+				baseline.Reason = "tokenizer-changed"
+			}
+			baseline.At = time.Now().UTC()
 			if err = c.store.Record(ctx, baseline); err != nil {
 				return nil, err
 			}
@@ -281,11 +313,34 @@ func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Fi
 	}
 	return []rules.Finding{{Code: c.member, Measured: fmt.Sprintf("%d %s exceeds the limit of %d (%s)", value, unit, limit, provenance), Limit: fmt.Sprintf("this file cannot grow past %d %s under this rule", limit, unit), Remedy: fmt.Sprintf("keep %s under %d %s; move the new material into a sibling file such as %s and add a link to it from %s so readers can drill in", base, limit, unit, sibling, base), Override: override}}, nil
 }
-func (c *check) OnRemove(ctx context.Context, p string) error {
+
+func (c *check) baseline(ctx context.Context, p string) (Baseline, bool, error) {
+	history, err := c.store.History(ctx, p)
+	if err != nil {
+		return Baseline{}, false, err
+	}
+	var current Baseline
+	found := false
+	for _, record := range history {
+		if record.Op == "remove" {
+			found = false
+			continue
+		}
+		if record.Op != "baseline" {
+			continue
+		}
+		if c.metric != Tokens && record.Reason == "tokenizer-changed" {
+			continue
+		}
+		current, found = record, true
+	}
+	return current, found, nil
+}
+func (c *check) OnRemove(ctx context.Context, p, actor string) error {
 	if !c.initial {
 		return nil
 	}
-	return c.store.Clear(ctx, p, rules.Actor(ctx))
+	return c.store.Clear(ctx, p, actor)
 }
 func (c *check) OnMove(ctx context.Context, from, to string) error {
 	if !c.initial {

--- a/pkg/rules/size/size.go
+++ b/pkg/rules/size/size.go
@@ -104,29 +104,18 @@ func (s *baselineStore) Move(ctx context.Context, from, to string) error {
 	if err != nil {
 		return err
 	}
-	var records [][]byte
-	for raw, recordErr := range src.Records(stateKey(from)) {
-		if recordErr != nil {
-			return recordErr
-		}
+	return src.RewriteMove(stateKey(from), dst, stateKey(to), func(raw []byte) ([]byte, error) {
 		var record Baseline
 		if err := json.Unmarshal(raw, &record); err != nil {
-			return err
+			return nil, err
 		}
 		record.Path = to
 		rewritten, err := json.Marshal(record)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		records = append(records, rewritten)
-	}
-	if len(records) == 0 {
-		return nil
-	}
-	if err := dst.Replace(stateKey(to), records); err != nil {
-		return err
-	}
-	return src.Remove(stateKey(from))
+		return rewritten, nil
+	})
 }
 
 func Measure(content []byte, tok tokenizer.Tokenizer) (Baseline, error) {
@@ -206,7 +195,7 @@ func (r Rule) Compile(with map[string]any, env rules.Env) (rules.Check, error) {
 				return nil, fmt.Errorf("growth must be a number >= 1")
 			}
 		}
-		if growth < 1 {
+		if math.IsNaN(growth) || math.IsInf(growth, 0) || growth < 1 {
 			return nil, fmt.Errorf("growth must be a number >= 1")
 		}
 		if env.State == nil {
@@ -243,6 +232,19 @@ func Inspect(value rules.Check) (BaselineStore, Metric, float64, tokenizer.Token
 	return c.store, c.metric, c.growth, c.tokenizer(), true
 }
 
+// Current returns the metric-aware effective baseline used by enforcement.
+func Current(ctx context.Context, value rules.Check, p string) (Baseline, bool, error) {
+	c, ok := value.(*check)
+	if !ok || !c.initial {
+		return Baseline{}, false, nil
+	}
+	baseline, found, err := c.baseline(ctx, p)
+	if err == nil && found && c.metric == Tokens && baseline.Tokenizer != c.tokenizer().Name() {
+		found = false
+	}
+	return baseline, found, err
+}
+
 func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Finding, error) {
 	measured, err := Measure(subject.Content, c.tokenizer())
 	if err != nil {
@@ -261,7 +263,7 @@ func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Fi
 		}
 		var existingContent []byte
 		existed := false
-		if subject.Mode == rules.ModeAdmit && subject.Existing != nil {
+		if subject.Mode != rules.ModeValidate && subject.Existing != nil {
 			existingContent, existed, err = subject.Existing()
 			if err != nil {
 				return nil, err
@@ -290,8 +292,10 @@ func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Fi
 				baseline.Reason = "tokenizer-changed"
 			}
 			baseline.At = time.Now().UTC()
-			if err = c.store.Record(ctx, baseline); err != nil {
-				return nil, err
+			if subject.Mode == rules.ModePreApply && existed {
+				if err = c.store.Record(ctx, baseline); err != nil {
+					return nil, err
+				}
 			}
 			if !existed {
 				return nil, nil
@@ -335,6 +339,21 @@ func (c *check) baseline(ctx context.Context, p string) (Baseline, bool, error) 
 		current, found = record, true
 	}
 	return current, found, nil
+}
+func (c *check) OnWrite(ctx context.Context, p string, content []byte, actor string) error {
+	if !c.initial {
+		return nil
+	}
+	if _, ok, err := c.baseline(ctx, p); err != nil || ok {
+		return err
+	}
+	baseline, err := Measure(content, c.tokenizer())
+	if err != nil {
+		return err
+	}
+	baseline.Path, baseline.Reason, baseline.Actor = p, "create", actor
+	baseline.At = time.Now().UTC()
+	return c.store.Record(ctx, baseline)
 }
 func (c *check) OnRemove(ctx context.Context, p, actor string) error {
 	if !c.initial {

--- a/pkg/rules/size/size.go
+++ b/pkg/rules/size/size.go
@@ -2,13 +2,143 @@ package size
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"path"
 	"strings"
+	"time"
 
+	"github.com/aakarim/go-openlore/pkg/packagestate"
 	"github.com/aakarim/go-openlore/pkg/rules"
 	"github.com/aakarim/go-openlore/pkg/rules/tokenizer"
 )
+
+type Baseline struct {
+	Path      string    `json:"path,omitempty"`
+	At        time.Time `json:"ts"`
+	Op        string    `json:"op"`
+	Reason    string    `json:"reason,omitempty"`
+	Actor     string    `json:"actor,omitempty"`
+	Note      string    `json:"note,omitempty"`
+	Commit    string    `json:"commit,omitempty"`
+	Kilobytes int       `json:"kilobytes,omitempty"`
+	Lines     int       `json:"lines,omitempty"`
+	Tokens    int       `json:"tokens,omitempty"`
+	Tokenizer string    `json:"tokenizer,omitempty"`
+}
+
+type BaselineStore interface {
+	Get(context.Context, string) (Baseline, bool, error)
+	History(context.Context, string) ([]Baseline, error)
+	Record(context.Context, Baseline) error
+	Clear(context.Context, string, string) error
+	Move(context.Context, string, string) error
+}
+
+type baselineStore struct{ state packagestate.Store }
+
+func NewBaselineStore(state packagestate.Store) BaselineStore { return &baselineStore{state: state} }
+func stateKey(p string) string                                { return path.Base(p) + ".jsonl" }
+
+func (s *baselineStore) History(ctx context.Context, p string) ([]Baseline, error) {
+	d, err := s.state.Dir(ctx, path.Dir(p))
+	if err != nil {
+		return nil, err
+	}
+	var out []Baseline
+	for raw, recordErr := range d.Records(stateKey(p)) {
+		if recordErr != nil {
+			return nil, recordErr
+		}
+		var record Baseline
+		if err := json.Unmarshal(raw, &record); err != nil {
+			return nil, err
+		}
+		out = append(out, record)
+	}
+	return out, nil
+}
+func (s *baselineStore) Get(ctx context.Context, p string) (Baseline, bool, error) {
+	history, err := s.History(ctx, p)
+	if err != nil {
+		return Baseline{}, false, err
+	}
+	var current Baseline
+	found := false
+	for _, record := range history {
+		if record.Op == "remove" {
+			found = false
+		} else if record.Op == "baseline" {
+			current, found = record, true
+		}
+	}
+	return current, found, nil
+}
+func (s *baselineStore) Record(ctx context.Context, b Baseline) error {
+	if b.At.IsZero() {
+		b.At = time.Now().UTC()
+	}
+	if b.Op == "" {
+		b.Op = "baseline"
+	}
+	d, err := s.state.Dir(ctx, path.Dir(b.Path))
+	if err != nil {
+		return err
+	}
+	raw, err := json.Marshal(b)
+	if err != nil {
+		return err
+	}
+	return d.Append(stateKey(b.Path), raw)
+}
+func (s *baselineStore) Clear(ctx context.Context, p, actor string) error {
+	return s.Record(ctx, Baseline{Path: p, Op: "remove", Actor: actor})
+}
+func (s *baselineStore) Move(ctx context.Context, from, to string) error {
+	src, err := s.state.Dir(ctx, path.Dir(from))
+	if err != nil {
+		return err
+	}
+	dst, err := s.state.Dir(ctx, path.Dir(to))
+	if err != nil {
+		return err
+	}
+	return src.Move(stateKey(from), dst, stateKey(to))
+}
+
+func Measure(content []byte, tok tokenizer.Tokenizer) (Baseline, error) {
+	b := Baseline{Kilobytes: (len(content) + 1023) / 1024}
+	if len(content) != 0 {
+		b.Lines = strings.Count(string(content), "\n")
+		if content[len(content)-1] != '\n' {
+			b.Lines++
+		}
+	}
+	if tok != nil {
+		count, err := tok.Count(content)
+		if err != nil {
+			return Baseline{}, err
+		}
+		b.Tokens, b.Tokenizer = count, tok.Name()
+	}
+	return b, nil
+}
+func Reset(ctx context.Context, store BaselineStore, p string, content []byte, tok tokenizer.Tokenizer, actor, note string) (Baseline, Baseline, error) {
+	previous, _, err := store.Get(ctx, p)
+	if err != nil {
+		return Baseline{}, Baseline{}, err
+	}
+	next, err := Measure(content, tok)
+	if err != nil {
+		return Baseline{}, Baseline{}, err
+	}
+	next.Path, next.Op, next.Reason, next.Actor, next.Note = p, "baseline", "reset", actor, note
+	if err := store.Record(ctx, next); err != nil {
+		return Baseline{}, Baseline{}, err
+	}
+	return previous, next, nil
+}
 
 type Metric int
 
@@ -26,87 +156,177 @@ func Register(reg *rules.Registry) {
 		reg.Register(member)
 	}
 }
-
 func init() { Register(rules.DefaultRegistry()) }
 
 func (r Rule) Manifest() rules.Manifest {
-	memberPath, summary := "size/kilobytes", "Reject writes larger than max kibibytes"
-	doc := "Reject writes whose size exceeds max KiB."
+	member, summary, doc := "size/kilobytes", "Reject writes larger than max kibibytes", "Reject writes whose size exceeds max KiB."
 	if r.Metric == Lines {
-		memberPath, summary = "size/lines", "Reject writes with more than max lines"
-		doc = "Reject writes whose line count exceeds max."
+		member, summary, doc = "size/lines", "Reject writes with more than max lines", "Reject writes whose line count exceeds max."
 	}
 	if r.Metric == Tokens {
-		memberPath, summary = "size/tokens", "Reject writes with more than max tokens"
-		doc = "Reject writes whose estimated token count exceeds max. Tokens use estimate/v1: ceil(bytes / 4)."
+		member, summary, doc = "size/tokens", "Reject writes with more than max tokens", "Reject writes whose estimated token count exceeds max. Tokens use estimate/v1: ceil(bytes / 4)."
 	}
-	return rules.Manifest{Path: memberPath, Kind: rules.KindRule, Scope: rules.ScopeFile, Summary: summary, Doc: doc,
-		Params:  []rules.Param{{Name: "max", Type: rules.ParamInteger, Required: true, Doc: "Fixed cap."}},
-		Example: "use: " + memberPath + "\nwith: { max: 60 }"}
+	return rules.Manifest{Path: member, Kind: rules.KindRule, Scope: rules.ScopeFile, Summary: summary, Doc: doc,
+		Params:  []rules.Param{{Name: "max", Type: rules.ParamIntegerOrInitial, Required: true, Doc: `Fixed cap, or baseline × growth.`}, {Name: "growth", Type: rules.ParamNumber, Doc: `Multiplier when max is "initial".`}},
+		Example: "use: " + member + "\nwith: { max: initial, growth: 1.1 }"}
 }
-
-func (r Rule) Compile(with map[string]any, _ rules.Env) (rules.Check, error) {
-	max, ok := asInteger(with["max"])
+func (r Rule) Compile(with map[string]any, env rules.Env) (rules.Check, error) {
+	if value, ok := with["max"].(string); ok && value == "initial" {
+		growth := env.Defaults.Growth
+		if growth == 0 {
+			growth = 1.25
+		}
+		if raw, exists := with["growth"]; exists {
+			var ok bool
+			growth, ok = number(raw)
+			if !ok {
+				return nil, fmt.Errorf("growth must be a number >= 1")
+			}
+		}
+		if growth < 1 {
+			return nil, fmt.Errorf("growth must be a number >= 1")
+		}
+		if env.State == nil {
+			return nil, fmt.Errorf("max initial requires package state")
+		}
+		return &check{metric: r.Metric, member: r.Manifest().Path, initial: true, growth: growth, store: NewBaselineStore(env.State), tok: env.Tokenizer}, nil
+	}
+	max, ok := integer(with["max"])
 	if !ok || max < 1 {
 		return nil, fmt.Errorf("max must be an integer >= 1")
 	}
-	return check{metric: r.Metric, max: max, member: r.Manifest().Path}, nil
+	if _, exists := with["growth"]; exists {
+		return nil, fmt.Errorf("growth is only meaningful with max: initial")
+	}
+	return &check{metric: r.Metric, member: r.Manifest().Path, max: max, tok: env.Tokenizer}, nil
 }
 
 type check struct {
-	metric Metric
-	max    int64
-	member string
+	metric  Metric
+	member  string
+	max     int
+	initial bool
+	growth  float64
+	store   BaselineStore
+	tok     tokenizer.Tokenizer
 }
 
-func (c check) Evaluate(_ context.Context, subject rules.Subject) ([]rules.Finding, error) {
-	measured, unit := c.measure(subject.Content)
-	if measured <= c.max {
+// Inspect exposes the stateful configuration to the size administration command.
+func Inspect(value rules.Check) (BaselineStore, Metric, float64, bool) {
+	c, ok := value.(*check)
+	if !ok || !c.initial {
+		return nil, 0, 0, false
+	}
+	return c.store, c.metric, c.growth, true
+}
+
+func (c *check) Evaluate(ctx context.Context, subject rules.Subject) ([]rules.Finding, error) {
+	measured, err := Measure(subject.Content, c.tokenizer())
+	if err != nil {
+		return nil, err
+	}
+	value, unit := c.value(measured)
+	limit, provenance := c.max, fmt.Sprintf("max: %d", c.max)
+	if c.initial {
+		baseline, ok, err := c.store.Get(ctx, subject.Path)
+		if err != nil {
+			return nil, err
+		}
+		if c.metric == Tokens && ok && baseline.Tokenizer != c.tokenizer().Name() {
+			ok = false
+		}
+		if !ok {
+			baseContent, existed := subject.Content, false
+			if subject.Existing != nil {
+				existingContent, exists, existingErr := subject.Existing()
+				existed, err = exists, existingErr
+				if err != nil {
+					return nil, err
+				}
+				if existed {
+					baseContent = existingContent
+				}
+			}
+			if subject.Mode == rules.ModeValidate {
+				return nil, nil
+			}
+			baseline, err = Measure(baseContent, c.tokenizer())
+			if err != nil {
+				return nil, err
+			}
+			baseline.Path, baseline.Reason, baseline.Actor = subject.Path, "create", subject.Actor
+			if existed {
+				baseline.Reason = "rule-added"
+			}
+			if err = c.store.Record(ctx, baseline); err != nil {
+				return nil, err
+			}
+			if !existed {
+				return nil, nil
+			}
+		}
+		base, _ := c.value(baseline)
+		limit = int(math.Floor(float64(base) * c.growth))
+		provenance = fmt.Sprintf("baseline %d %s × growth %g, set %s on %s", base, unit, c.growth, baseline.At.Format("2006-01-02"), baseline.Reason)
+	}
+	if value <= limit {
 		return nil, nil
 	}
 	base := path.Base(subject.Path)
 	ext := path.Ext(base)
 	sibling := strings.TrimSuffix(base, ext) + "-details" + ext
-	extra := ""
-	if c.metric == Tokens {
-		extra = "; estimate/v1, ≈ bytes/4"
+	override := ""
+	if c.initial {
+		override = fmt.Sprintf("a role in config.edit can run `lore size baseline reset %s`", subject.Path)
 	}
-	return []rules.Finding{{Code: c.member,
-		Measured: fmt.Sprintf("%d %s exceeds the limit of %d (max: %d%s)", measured, unit, c.max, c.max, extra),
-		Limit:    fmt.Sprintf("this file cannot grow past %d %s under this rule", c.max, unit),
-		Remedy:   fmt.Sprintf("keep %s under %d %s; move the new material into a sibling file such as %s and add a link to it from %s so readers can drill in", base, c.max, unit, sibling, base),
-	}}, nil
+	return []rules.Finding{{Code: c.member, Measured: fmt.Sprintf("%d %s exceeds the limit of %d (%s)", value, unit, limit, provenance), Limit: fmt.Sprintf("this file cannot grow past %d %s under this rule", limit, unit), Remedy: fmt.Sprintf("keep %s under %d %s; move the new material into a sibling file such as %s and add a link to it from %s so readers can drill in", base, limit, unit, sibling, base), Override: override}}, nil
 }
-func (check) OnRemove(context.Context, string) error       { return nil }
-func (check) OnMove(context.Context, string, string) error { return nil }
-
-func (c check) measure(content []byte) (int64, string) {
-	switch c.metric {
-	case Kilobytes:
-		return int64((len(content) + 1023) / 1024), "KiB"
-	case Lines:
-		if len(content) == 0 {
-			return 0, "lines"
-		}
-		n := int64(strings.Count(string(content), "\n"))
-		if content[len(content)-1] != '\n' {
-			n++
-		}
-		return n, "lines"
-	default:
-		return int64(tokenizer.Estimate(content)), "tokens"
+func (c *check) OnRemove(ctx context.Context, p string) error {
+	if !c.initial {
+		return nil
 	}
+	return c.store.Clear(ctx, p, rules.Actor(ctx))
 }
-
-func asInteger(value any) (int64, bool) {
-	switch n := value.(type) {
+func (c *check) OnMove(ctx context.Context, from, to string) error {
+	if !c.initial {
+		return nil
+	}
+	return c.store.Move(ctx, from, to)
+}
+func (c *check) tokenizer() tokenizer.Tokenizer {
+	if c.tok != nil {
+		return c.tok
+	}
+	return tokenizer.Estimator{}
+}
+func (c *check) value(b Baseline) (int, string) {
+	if c.metric == Kilobytes {
+		return b.Kilobytes, "KiB"
+	}
+	if c.metric == Lines {
+		return b.Lines, "lines"
+	}
+	return b.Tokens, "tokens"
+}
+func integer(v any) (int, bool) {
+	switch n := v.(type) {
 	case int:
-		return int64(n), true
-	case int64:
 		return n, true
+	case int64:
+		return int(n), true
 	case float64:
-		return int64(n), n == float64(int64(n))
-	default:
-		return 0, false
+		return int(n), n == float64(int(n))
 	}
+	return 0, false
+}
+func number(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case float64:
+		return n, true
+	}
+	return 0, false
 }

--- a/pkg/rules/size/size_test.go
+++ b/pkg/rules/size/size_test.go
@@ -2,10 +2,16 @@ package size
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/aakarim/go-openlore/pkg/packagestate"
 	"github.com/aakarim/go-openlore/pkg/rules"
 )
+
+type mapper map[string]string
+
+func (m mapper) HostDir(dir string) (string, bool) { host, ok := m[dir]; return host, ok }
 
 func TestLinesFixedMax(t *testing.T) {
 	check, err := (Rule{Metric: Lines}).Compile(map[string]any{"max": 3}, rules.Env{})
@@ -18,9 +24,34 @@ func TestLinesFixedMax(t *testing.T) {
 	}
 }
 
-func TestManifestOnlyAdvertisesFixedMax(t *testing.T) {
+func TestInitialBaselineUsesExistingContentAndResetAppends(t *testing.T) {
+	state := packagestate.Open(mapper{"/docs": t.TempDir()}, "size")
+	compiled, err := (Rule{Metric: Lines}).Compile(map[string]any{"max": "initial", "growth": 1.5}, rules.Env{State: state})
+	if err != nil {
+		t.Fatal(err)
+	}
+	existing := func() ([]byte, bool, error) { return []byte("x\n"), true, nil }
+	findings, err := compiled.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("1\n2\n"), Existing: existing, Actor: "alice"})
+	if err != nil || len(findings) != 1 || !strings.Contains(findings[0].Measured, "baseline 1 lines × growth 1.5") || !strings.Contains(findings[0].Measured, "on rule-added") {
+		t.Fatalf("findings=%v err=%v", findings, err)
+	}
+	store, _, _, _ := Inspect(compiled)
+	prev, next, err := Reset(context.Background(), store, "/docs/a.md", []byte("1\n2\n"), nil, "bob", "reviewed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev.Lines != 1 || next.Lines != 2 || next.Reason != "reset" || next.Actor != "bob" || next.Note != "reviewed" {
+		t.Fatalf("prev=%#v next=%#v", prev, next)
+	}
+	history, err := store.History(context.Background(), "/docs/a.md")
+	if err != nil || len(history) != 2 {
+		t.Fatalf("history=%#v err=%v", history, err)
+	}
+}
+
+func TestManifestAdvertisesInitialMax(t *testing.T) {
 	params := (Rule{Metric: Lines}).Manifest().Params
-	if len(params) != 1 || params[0].Name != "max" || params[0].Type != rules.ParamInteger || !params[0].Required {
-		t.Fatalf("params=%#v, want one required integer max", params)
+	if len(params) != 2 || params[0].Name != "max" || params[0].Type != rules.ParamIntegerOrInitial || !params[0].Required {
+		t.Fatalf("params=%#v", params)
 	}
 }

--- a/pkg/rules/size/size_test.go
+++ b/pkg/rules/size/size_test.go
@@ -2,6 +2,7 @@ package size
 
 import (
 	"context"
+	"math"
 	"strings"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestInitialBaselineUsesExistingContentAndResetAppends(t *testing.T) {
 		t.Fatal(err)
 	}
 	existing := func() ([]byte, bool, error) { return []byte("x\n"), true, nil }
-	findings, err := compiled.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("1\n2\n"), Existing: existing, Actor: "alice"})
+	findings, err := compiled.Evaluate(context.Background(), rules.Subject{Mode: rules.ModePreApply, Path: "/docs/a.md", Content: []byte("1\n2\n"), Existing: existing, Actor: "alice"})
 	if err != nil || len(findings) != 1 || !strings.Contains(findings[0].Measured, "baseline 1 lines × growth 1.5") || !strings.Contains(findings[0].Measured, "on rule-added") {
 		t.Fatalf("findings=%v err=%v", findings, err)
 	}
@@ -68,18 +69,15 @@ func TestTokenizerChangeRebaselinesTokensOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = old.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("one\ntwo\n"), Existing: func() ([]byte, bool, error) { return nil, false, nil }}); err != nil {
+	if err = old.OnWrite(context.Background(), "/docs/a.md", []byte("one\ntwo\n"), "alice"); err != nil {
 		t.Fatal(err)
 	}
 	line, _ := (Rule{Metric: Lines}).Compile(map[string]any{"max": "initial"}, rules.Env{State: state})
-	if _, err = line.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("one\ntwo\n"), Existing: func() ([]byte, bool, error) { return nil, false, nil }}); err != nil {
-		t.Fatal(err)
-	}
 	next, err := (Rule{Metric: Tokens}).Compile(map[string]any{"max": "initial"}, rules.Env{State: state, Tokenizer: fakeTokenizer{}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = next.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("one\ntwo\n"), Existing: existing}); err != nil {
+	if _, err = next.Evaluate(context.Background(), rules.Subject{Mode: rules.ModePreApply, Path: "/docs/a.md", Content: []byte("one\ntwo\n"), Existing: existing}); err != nil {
 		t.Fatal(err)
 	}
 	store, _, _, _, _ := Inspect(next)
@@ -94,5 +92,14 @@ func TestTokenizerChangeRebaselinesTokensOnly(t *testing.T) {
 	baseline, ok, err := lineCheck.baseline(context.Background(), "/docs/a.md")
 	if err != nil || !ok || baseline.Reason != "create" {
 		t.Fatalf("line baseline=%#v ok=%v err=%v", baseline, ok, err)
+	}
+}
+
+func TestInitialRejectsNonFiniteGrowth(t *testing.T) {
+	state := packagestate.Open(mapper{"/docs": t.TempDir()}, "size")
+	for _, growth := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		if _, err := (Rule{Metric: Lines}).Compile(map[string]any{"max": "initial", "growth": growth}, rules.Env{State: state}); err == nil {
+			t.Fatalf("growth %v accepted", growth)
+		}
 	}
 }

--- a/pkg/rules/size/size_test.go
+++ b/pkg/rules/size/size_test.go
@@ -35,7 +35,7 @@ func TestInitialBaselineUsesExistingContentAndResetAppends(t *testing.T) {
 	if err != nil || len(findings) != 1 || !strings.Contains(findings[0].Measured, "baseline 1 lines × growth 1.5") || !strings.Contains(findings[0].Measured, "on rule-added") {
 		t.Fatalf("findings=%v err=%v", findings, err)
 	}
-	store, _, _, _ := Inspect(compiled)
+	store, _, _, _, _ := Inspect(compiled)
 	prev, next, err := Reset(context.Background(), store, "/docs/a.md", []byte("1\n2\n"), nil, "bob", "reviewed")
 	if err != nil {
 		t.Fatal(err)
@@ -53,5 +53,46 @@ func TestManifestAdvertisesInitialMax(t *testing.T) {
 	params := (Rule{Metric: Lines}).Manifest().Params
 	if len(params) != 2 || params[0].Name != "max" || params[0].Type != rules.ParamIntegerOrInitial || !params[0].Required {
 		t.Fatalf("params=%#v", params)
+	}
+}
+
+type fakeTokenizer struct{}
+
+func (fakeTokenizer) Name() string                      { return "fake/v1" }
+func (fakeTokenizer) Count(content []byte) (int, error) { return len(content), nil }
+
+func TestTokenizerChangeRebaselinesTokensOnly(t *testing.T) {
+	state := packagestate.Open(mapper{"/docs": t.TempDir()}, "size")
+	existing := func() ([]byte, bool, error) { return []byte("one\ntwo\n"), true, nil }
+	old, err := (Rule{Metric: Tokens}).Compile(map[string]any{"max": "initial"}, rules.Env{State: state})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = old.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("one\ntwo\n"), Existing: func() ([]byte, bool, error) { return nil, false, nil }}); err != nil {
+		t.Fatal(err)
+	}
+	line, _ := (Rule{Metric: Lines}).Compile(map[string]any{"max": "initial"}, rules.Env{State: state})
+	if _, err = line.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("one\ntwo\n"), Existing: func() ([]byte, bool, error) { return nil, false, nil }}); err != nil {
+		t.Fatal(err)
+	}
+	next, err := (Rule{Metric: Tokens}).Compile(map[string]any{"max": "initial"}, rules.Env{State: state, Tokenizer: fakeTokenizer{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = next.Evaluate(context.Background(), rules.Subject{Mode: rules.ModeAdmit, Path: "/docs/a.md", Content: []byte("one\ntwo\n"), Existing: existing}); err != nil {
+		t.Fatal(err)
+	}
+	store, _, _, _, _ := Inspect(next)
+	history, err := store.History(context.Background(), "/docs/a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history[len(history)-1].Reason != "tokenizer-changed" || history[len(history)-1].Tokenizer != "fake/v1" {
+		t.Fatalf("history=%#v", history)
+	}
+	lineCheck := line.(*check)
+	baseline, ok, err := lineCheck.baseline(context.Background(), "/docs/a.md")
+	if err != nil || !ok || baseline.Reason != "create" {
+		t.Fatalf("line baseline=%#v ok=%v err=%v", baseline, ok, err)
 	}
 }

--- a/pkg/rules/tokenizer/estimator.go
+++ b/pkg/rules/tokenizer/estimator.go
@@ -3,8 +3,14 @@ package tokenizer
 
 const Version = "estimate/v1"
 
+type Tokenizer interface {
+	Name() string
+	Count([]byte) (int, error)
+}
+
 type Estimator struct{}
 
-func (Estimator) Name() string                  { return Version }
-func (Estimator) Estimate(content []byte) int64 { return int64((len(content) + 3) / 4) }
-func Estimate(content []byte) int64             { return Estimator{}.Estimate(content) }
+func (Estimator) Name() string                        { return Version }
+func (Estimator) Estimate(content []byte) int64       { return int64((len(content) + 3) / 4) }
+func (e Estimator) Count(content []byte) (int, error) { return int(e.Estimate(content)), nil }
+func Estimate(content []byte) int64                   { return Estimator{}.Estimate(content) }

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -102,16 +102,6 @@ const (
 	ModeValidate
 )
 
-type actorContextKey struct{}
-
-func WithActor(ctx context.Context, actor string) context.Context {
-	return context.WithValue(ctx, actorContextKey{}, actor)
-}
-func Actor(ctx context.Context) string {
-	actor, _ := ctx.Value(actorContextKey{}).(string)
-	return actor
-}
-
 type Finding struct {
 	Code   string
 	Path   string
@@ -128,7 +118,7 @@ type Finding struct {
 
 type Check interface {
 	Evaluate(context.Context, Subject) ([]Finding, error)
-	OnRemove(context.Context, string) error
+	OnRemove(context.Context, string, string) error
 	OnMove(context.Context, string, string) error
 }
 

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -99,6 +99,7 @@ type Mode int
 
 const (
 	ModeAdmit Mode = iota
+	ModePreApply
 	ModeValidate
 )
 
@@ -118,6 +119,7 @@ type Finding struct {
 
 type Check interface {
 	Evaluate(context.Context, Subject) ([]Finding, error)
+	OnWrite(context.Context, string, []byte, string) error
 	OnRemove(context.Context, string, string) error
 	OnMove(context.Context, string, string) error
 }

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 
 	"github.com/aakarim/go-openlore/pkg/openlore/validation"
+	"github.com/aakarim/go-openlore/pkg/packagestate"
+	"github.com/aakarim/go-openlore/pkg/rules/tokenizer"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -72,8 +74,10 @@ type Defaults struct {
 }
 
 type Env struct {
-	Defaults Defaults
-	Logger   *slog.Logger
+	Defaults  Defaults
+	State     packagestate.Store
+	Tokenizer tokenizer.Tokenizer
+	Logger    *slog.Logger
 	// AliasRoots contains configured docset aliases, longest first.
 	AliasRoots []string
 }
@@ -97,6 +101,16 @@ const (
 	ModeAdmit Mode = iota
 	ModeValidate
 )
+
+type actorContextKey struct{}
+
+func WithActor(ctx context.Context, actor string) context.Context {
+	return context.WithValue(ctx, actorContextKey{}, actor)
+}
+func Actor(ctx context.Context) string {
+	actor, _ := ctx.Value(actorContextKey{}).(string)
+	return actor
+}
 
 type Finding struct {
 	Code   string

--- a/pkg/shell/cmds/context.go
+++ b/pkg/shell/cmds/context.go
@@ -51,6 +51,13 @@ type CmdContext interface {
 	SkillsRemoteMaxBytes() int64
 }
 
+type SizeBackend interface {
+	Baseline(path string) (string, error)
+	Reset(path, note string, attribution JobAttribution) (string, error)
+}
+
+type sizeContext interface{ SizeBackend() SizeBackend }
+
 // DocsetInfo describes one docset a session can access. It is the per-session
 // view surfaced by `lore docsets` — the host resolves it from the session's
 // role-policy snapshot.

--- a/pkg/shell/cmds/lore_size.go
+++ b/pkg/shell/cmds/lore_size.go
@@ -1,0 +1,49 @@
+package cmds
+
+import (
+	"fmt"
+	"io"
+)
+
+func cmdLoreSize(ctx CmdContext, args []string, w, errW io.Writer, _ io.Reader) int {
+	provider, ok := ctx.(sizeContext)
+	if !ok || provider.SizeBackend() == nil {
+		fmt.Fprintln(errW, "lore size: baseline state is unavailable")
+		return 1
+	}
+	if len(args) >= 2 && args[0] == "baseline" && args[1] != "reset" {
+		if len(args) != 2 {
+			fmt.Fprintln(errW, "usage: lore size baseline <path>")
+			return 1
+		}
+		out, err := provider.SizeBackend().Baseline(ctx.Resolve(args[1]))
+		if err != nil {
+			fmt.Fprintf(errW, "lore size baseline: %v\n", err)
+			return 1
+		}
+		fmt.Fprint(w, out)
+		return 0
+	}
+	if len(args) >= 3 && args[0] == "baseline" && args[1] == "reset" {
+		path, note := ctx.Resolve(args[2]), ""
+		if len(args) == 5 && args[3] == "--note" {
+			note = args[4]
+		} else if len(args) != 3 {
+			fmt.Fprintln(errW, "usage: lore size baseline reset <path> [--note <text>]")
+			return 1
+		}
+		out, err := provider.SizeBackend().Reset(path, note, commandAttribution(ctx))
+		if err != nil {
+			fmt.Fprintf(errW, "lore size baseline reset: %v\n", err)
+			return 1
+		}
+		fmt.Fprint(w, out)
+		return 0
+	}
+	fmt.Fprintln(errW, "usage: lore size baseline <path> | lore size baseline reset <path> [--note <text>]")
+	return 1
+}
+
+func init() {
+	RegisterLoreSub(LoreSub{Name: "size", Summary: "Inspect and reset size baselines", Run: cmdLoreSize})
+}

--- a/pkg/shell/cmds/mv.go
+++ b/pkg/shell/cmds/mv.go
@@ -69,15 +69,6 @@ func CmdMv(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.
 		fmt.Fprintf(errW, "mv: cannot read %s: %s\n", source, err)
 		return 1
 	}
-	if _, err = WriteFile(ctx, destination, data, false); err != nil {
-		return writeResultMsg(errW, "mv", destination, err)
-	}
-
-	wfs, ok := ctx.FS().(vfs.WritableFS)
-	if !ok {
-		fmt.Fprintf(errW, "mv: %s: read-only filesystem\n", source)
-		return 1
-	}
 	hash := sha256.Sum256(data)
 	snapshot := &vfs.TreeSnapshot{
 		Root: resolvedSource,
@@ -87,6 +78,36 @@ func CmdMv(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.
 			Hash:    hex.EncodeToString(hash[:]),
 			Size:    int64(len(data)),
 		}},
+	}
+	if admitter, ok := ctx.FS().(vfs.ChangeSetAdmitter); ok {
+		err = admitter.AdmitChangeSet(vfs.ChangeSet{Changes: []vfs.Change{
+			{Target: resolvedDestination, Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: data, Opts: overwritePreconditions(ctx, resolvedDestination)}},
+			{Target: resolvedSource, Action: vfs.ChangeActionRemoveAll, RemoveAll: &vfs.RemoveAllChange{Opts: vfs.RemoveOpts{Expected: snapshot}}},
+		}})
+		if err == nil {
+			return 0
+		}
+		var pending *vfs.PendingChangeError
+		if errors.As(err, &pending) {
+			fmt.Fprintln(w, pendingChangeLine("mv", source, pending))
+			return 0
+		}
+		var stale *vfs.TreeStaleError
+		if errors.As(err, &stale) {
+			fmt.Fprintf(errW, "mv: %s: source changed concurrently; destination was not written\n", source)
+			return 1
+		}
+		return writeResultMsg(errW, "mv", destination, err)
+	}
+
+	if _, err = WriteFile(ctx, destination, data, false); err != nil {
+		return writeResultMsg(errW, "mv", destination, err)
+	}
+
+	wfs, ok := ctx.FS().(vfs.WritableFS)
+	if !ok {
+		fmt.Fprintf(errW, "mv: %s: read-only filesystem\n", source)
+		return 1
 	}
 	err = wfs.RemoveAll(resolvedSource, vfs.RemoveOpts{Expected: snapshot})
 	if err == nil {

--- a/pkg/shell/cmds/mv.go
+++ b/pkg/shell/cmds/mv.go
@@ -83,7 +83,7 @@ func CmdMv(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.
 		err = admitter.AdmitChangeSet(vfs.ChangeSet{Changes: []vfs.Change{
 			{Target: resolvedDestination, Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: data, Opts: overwritePreconditions(ctx, resolvedDestination)}},
 			{Target: resolvedSource, Action: vfs.ChangeActionRemoveAll, RemoveAll: &vfs.RemoveAllChange{Opts: vfs.RemoveOpts{Expected: snapshot}}},
-		}})
+		}, Moves: []vfs.Move{{From: 1, To: 0}}})
 		if err == nil {
 			return 0
 		}

--- a/pkg/shell/cmds/mv_test.go
+++ b/pkg/shell/cmds/mv_test.go
@@ -55,6 +55,9 @@ func TestMvSubmitsOneAtomicBatch(t *testing.T) {
 	if len(fs.admitted) != 1 || len(fs.admitted[0].Changes) != 2 {
 		t.Fatalf("admitted changesets = %#v, want one two-leaf batch", fs.admitted)
 	}
+	if moves := fs.admitted[0].Moves; len(moves) != 1 || moves[0] != (vfs.Move{From: 1, To: 0}) {
+		t.Fatalf("move metadata = %#v", moves)
+	}
 	changes := fs.admitted[0].Changes
 	if changes[0].Action != vfs.ChangeActionWrite || changes[0].Target != "/docs/moved.txt" || changes[0].Write == nil {
 		t.Fatalf("first change = %#v, want destination write", changes[0])

--- a/pkg/shell/cmds/mv_test.go
+++ b/pkg/shell/cmds/mv_test.go
@@ -1,9 +1,91 @@
 package cmds_test
 
 import (
+	"bytes"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/aakarim/go-openlore/pkg/shell"
+	"github.com/aakarim/go-openlore/pkg/vfs"
 )
+
+type mvBatchFS struct {
+	*mapFS
+	admitted []vfs.ChangeSet
+	reject   error
+}
+
+func (f *mvBatchFS) AdmitChangeSet(cs vfs.ChangeSet) error {
+	f.admitted = append(f.admitted, cs)
+	if f.reject != nil {
+		return f.reject
+	}
+	if err := vfs.ValidateChangeSet(cs); err != nil {
+		return err
+	}
+	for _, change := range cs.Changes {
+		switch change.Action {
+		case vfs.ChangeActionWrite:
+			if _, err := f.mapFS.WriteFileAtomic(change.Target, change.Write.Bytes, change.Write.Opts); err != nil {
+				return err
+			}
+		case vfs.ChangeActionRemoveAll:
+			if err := f.mapFS.RemoveAll(change.Target, change.RemoveAll.Opts); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func execMvBatch(fs *mvBatchFS, cmd string) (string, int) {
+	sh := shell.NewShell(fs)
+	var out, errOut bytes.Buffer
+	code := sh.ExecPipeline(cmd, &out, &errOut, nil)
+	return errOut.String(), code
+}
+
+func TestMvSubmitsOneAtomicBatch(t *testing.T) {
+	fs := &mvBatchFS{mapFS: testFS()}
+	errOut, code := execMvBatch(fs, "mv /docs/notes.txt /docs/moved.txt")
+	if code != 0 {
+		t.Fatalf("mv: code=%d err=%s", code, errOut)
+	}
+	if len(fs.admitted) != 1 || len(fs.admitted[0].Changes) != 2 {
+		t.Fatalf("admitted changesets = %#v, want one two-leaf batch", fs.admitted)
+	}
+	changes := fs.admitted[0].Changes
+	if changes[0].Action != vfs.ChangeActionWrite || changes[0].Target != "/docs/moved.txt" || changes[0].Write == nil {
+		t.Fatalf("first change = %#v, want destination write", changes[0])
+	}
+	if changes[1].Action != vfs.ChangeActionRemoveAll || changes[1].Target != "/docs/notes.txt" || changes[1].RemoveAll == nil || changes[1].RemoveAll.Opts.Expected == nil {
+		t.Fatalf("second change = %#v, want snapshot-guarded source removal", changes[1])
+	}
+	if _, ok := fs.Files["/docs/notes.txt"]; ok {
+		t.Fatal("source should be removed")
+	}
+	if _, ok := fs.Files["/docs/moved.txt"]; !ok {
+		t.Fatal("destination should be written")
+	}
+}
+
+func TestMvRejectedBatchHasNoPartialOperation(t *testing.T) {
+	fs := &mvBatchFS{mapFS: testFS(), reject: errors.New("batch rejected")}
+	errOut, code := execMvBatch(fs, "mv /docs/notes.txt /docs/moved.txt")
+	if code != 1 || !strings.Contains(errOut, "batch rejected") {
+		t.Fatalf("mv: code=%d err=%q", code, errOut)
+	}
+	if len(fs.admitted) != 1 {
+		t.Fatalf("admitted %d changesets, want one", len(fs.admitted))
+	}
+	if _, ok := fs.Files["/docs/notes.txt"]; !ok {
+		t.Fatal("rejected batch removed source")
+	}
+	if _, ok := fs.Files["/docs/moved.txt"]; ok {
+		t.Fatal("rejected batch wrote destination")
+	}
+}
 
 func TestMvFile(t *testing.T) {
 	fs := testFS()

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -51,6 +51,7 @@ type Shell struct {
 	configReload         cmds.ConfigReloadBackend
 	history              cmds.HistoryBackend
 	jobs                 cmds.JobBackend
+	size                 cmds.SizeBackend
 	exitRequested        bool
 }
 
@@ -162,6 +163,8 @@ func (s *Shell) SetHistoryBackend(b cmds.HistoryBackend)           { s.history =
 func (s *Shell) HistoryBackend() cmds.HistoryBackend               { return s.history }
 func (s *Shell) SetJobBackend(b cmds.JobBackend)                   { s.jobs = b }
 func (s *Shell) JobBackend() cmds.JobBackend                       { return s.jobs }
+func (s *Shell) SetSizeBackend(b cmds.SizeBackend)                 { s.size = b }
+func (s *Shell) SizeBackend() cmds.SizeBackend                     { return s.size }
 
 // --- CmdContext interface implementation ---
 

--- a/pkg/vfs/changeset.go
+++ b/pkg/vfs/changeset.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -59,6 +60,15 @@ type ChangeSet struct {
 	XattrRepair    *XattrRepairChange `json:"xattr_repair,omitempty"`
 	XattrMigration *XattrMigration    `json:"xattr_migration,omitempty"`
 	Changes        []Change           `json:"changes,omitempty"`
+	Moves          []Move             `json:"moves,omitempty"`
+}
+
+// Move explicitly pairs a write leaf with the remove leaf that supplies its
+// prior path. Indices refer to Changes and remove ambiguity when equal-content
+// files are moved in the same batch.
+type Move struct {
+	From int `json:"from"`
+	To   int `json:"to"`
 }
 
 // ChangeSetAdmitter is an optional session-filesystem capability for submitting
@@ -111,9 +121,43 @@ func ValidateChangeSet(cs ChangeSet) error {
 				return fmt.Errorf("changeset leaf %d: %w", i, err)
 			}
 		}
+		seenFrom, seenTo := map[int]bool{}, map[int]bool{}
+		for i, move := range cs.Moves {
+			if move.From < 0 || move.From >= len(cs.Changes) || move.To < 0 || move.To >= len(cs.Changes) || move.From == move.To {
+				return fmt.Errorf("changeset move %d: invalid leaf indices", i)
+			}
+			from, to := cs.Changes[move.From], cs.Changes[move.To]
+			if from.Action != ChangeActionRemoveAll || from.RemoveAll == nil || to.Action != ChangeActionWrite || to.Write == nil {
+				return fmt.Errorf("changeset move %d: from must be remove_all and to must be write", i)
+			}
+			if from.RemoveAll.Opts.Expected == nil || snapshotFileHash(from.RemoveAll.Opts.Expected) != hashBytes(to.Write.Bytes) {
+				return fmt.Errorf("changeset move %d: source snapshot must match destination content", i)
+			}
+			if seenFrom[move.From] || seenTo[move.To] {
+				return fmt.Errorf("changeset move %d: leaf is paired more than once", i)
+			}
+			seenFrom[move.From], seenTo[move.To] = true, true
+		}
 		return nil
 	}
+	if len(cs.Moves) != 0 {
+		return fmt.Errorf("changeset: singleton cannot contain moves")
+	}
 	return validateChange(Change{Target: cs.Target, Action: cs.Action, Write: cs.Write, RemoveAll: cs.RemoveAll, Xattr: cs.Xattr, XattrRepair: cs.XattrRepair, XattrMigration: cs.XattrMigration})
+}
+
+func snapshotFileHash(snapshot *TreeSnapshot) string {
+	for _, op := range snapshot.Ops {
+		if op.RelPath == "." && op.Kind == "file" {
+			return op.Hash
+		}
+	}
+	return ""
+}
+
+func hashBytes(content []byte) string {
+	hash := sha256.Sum256(content)
+	return fmt.Sprintf("%x", hash)
 }
 
 func validateChange(c Change) error {

--- a/pkg/vfs/changeset_test.go
+++ b/pkg/vfs/changeset_test.go
@@ -531,3 +531,16 @@ func TestValidateChangeSetBatchRejectsEmptyMixedMalformed(t *testing.T) {
 		t.Fatalf("valid batch: %v", err)
 	}
 }
+
+func TestValidateChangeSetMoveMetadata(t *testing.T) {
+	write := Change{Target: "/to", Action: ChangeActionWrite, Write: &WriteChange{Bytes: []byte("x")}}
+	remove := Change{Target: "/from", Action: ChangeActionRemoveAll, RemoveAll: &RemoveAllChange{Opts: RemoveOpts{Expected: &TreeSnapshot{Ops: []TreeOp{{RelPath: ".", Kind: "file", Hash: hashBytes([]byte("x"))}}}}}}
+	if err := ValidateChangeSet(ChangeSet{Changes: []Change{write, remove}, Moves: []Move{{From: 1, To: 0}}}); err != nil {
+		t.Fatal(err)
+	}
+	for _, moves := range [][]Move{{{From: 0, To: 1}}, {{From: 2, To: 0}}, {{From: 1, To: 0}, {From: 1, To: 0}}} {
+		if err := ValidateChangeSet(ChangeSet{Changes: []Change{write, remove}, Moves: moves}); err == nil {
+			t.Fatalf("moves %#v accepted", moves)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add symlink-safe per-package state storage under content-local `.lore/` directories
- implement append-only `max: initial` size baselines, growth enforcement, lifecycle handling, and tokenizer re-baselining
- make `mv` atomic through a batch change set and carry baseline state across moves
- add `lore size baseline` history/reset commands with authorization and audit logging
- publish the new size-rule parameters in generated stdlib docs

## Verification
- `nix develop --command go test ./...`
- `nix develop --command env GOOS=windows GOARCH=amd64 go build ./...`
- focused end-to-end server test for create baseline, allowed growth, and rejection
