### PR TITLE
Add /llms.txt

### DIFF
--- a/assets/web/llms.txt
+++ b/assets/web/llms.txt
@@ -1,0 +1,4 @@
+# OpenLore
+> A minimal, extensible, agent-native knowledge base that keeps shared context current and inspectable
+
+- Repo: https://github.com/aakarim/OpenLore


### PR DESCRIPTION
Following up on #65 — this adds the `/llms.txt` drafted in that issue to `assets/web/`, which is embedded with the rest of the site assets and served from the root by the file server, so it answers at https://openlore.sh/llms.txt on the next deploy. One new file, nothing else changed. Happy to tweak the wording.