### PR TITLE
docs: folder rules guide, lore size commands, config keys, skill update

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ The container workflow publishes `latest` from `main`; releases also publish
 | [Workload identity federation](docs/workload-identity-federation.md) | Authenticate CI and agents with short-lived external identity tokens |
 | [Writing and publishing](docs/writing.md) | Write modes, inboxes, conflict handling, approvals, and jobs |
 | [Plugins and knowledge formats](docs/plugins.md) | Plugin installation, interfaces, OKF validation, `lore validate`, and `lore meta` |
+| [Folder rules](docs/folder-rules.md) | `.lore/config.yaml` and `lore.json` rules, layering, permissions, rejection messages, and growth limits |
 | [Rules standard library](docs/rules-stdlib.md) | Generated reference for compiled-in rule members and their parameters |
 | [Write system internals](docs/write-system.md) | Filesystem layering, write seam, changesets, hooks, and async jobs |
 | [Security evaluation](SECURITY.md) | Threat model and security properties |

--- a/assets/skills/openlore/SKILL.md
+++ b/assets/skills/openlore/SKILL.md
@@ -45,20 +45,66 @@ explanation on stderr.
 
 ## Folder rules
 
-OpenLore can enforce declarative rules configured by the server for a docset.
-Before writing, discover the compiled-in rule members and their parameters:
+Folders can carry rules: size caps, OKF conformance, link checks. They are
+declared in `lore.json` by the server operator and in `.lore/config.yaml`
+files inside the content tree; a folder's config applies to it and everything
+beneath it. Before writing to an unfamiliar folder, look:
 
 ```bash
-ssh -p <port> <host> "lore package list"
-ssh -p <port> <host> "lore package doc size/lines"
-ssh -p <port> <host> "lore package doc link/resolves"
+ssh -p <port> <host> "cat /docs/backend/.lore/config.yaml"   # rules for this folder, if any
+ssh -p <port> <host> "lore package list"                      # compiled-in rule members
+ssh -p <port> <host> "lore package doc size/lines"            # a member's parameters and example
 ```
 
 File-scoped rules run on every write and under `lore validate`. Bundle-scoped
-rules run only under `lore validate`, because they need to inspect related
-files. A rejected write ends with `see: lore package doc <member>`; run that
-command for the rule's purpose, parameters, and example. Validate a bundle
-before publishing with `lore validate /path/to/bundle`.
+rules (OKF bundle structure, link resolution) run only under `lore validate`,
+because they need to inspect related files. Validate a folder before
+publishing with `lore validate /path/to/folder` (name the docset or folder,
+not `/`).
+
+### When a write is rejected
+
+The error names the rule, the limit, what to do, and how to override:
+
+```text
+rules: /docs/backend/decisions/adr-001.md: size/lines (adr-length @ /docs/backend/.lore/config.yaml)
+  812 lines exceeds the limit of 800 (baseline 640 lines × growth 1.25, set 2026-08-30 on create)
+  this file cannot grow past 800 lines under this rule
+  suggested: keep adr-001.md under 800 lines; move the new material into a sibling file such as adr-001-details.md and add a link to it from adr-001.md so readers can drill in
+  override: a role in config.edit can run `lore size baseline reset /docs/backend/decisions/adr-001.md`
+  see: lore package doc size/lines
+```
+
+Follow the `suggested:` line: split the material into a sibling file and link
+to it from the original. Do not retry with small trims. A limit described as
+`baseline … × growth` is a growth limit — the file is frozen near the size it
+had when first written — and only a human with `config.edit` can raise it, by
+running the exact command on the `override:` line. Ask for that instead of
+working around it. `size/tokens` limits are estimates, so leave a margin.
+
+### Authoring rules
+
+If your identity has a role in the docset's `config.edit`, you can add rules to
+a folder by writing its `.lore/config.yaml`:
+
+```bash
+cat <<'EOF' | ssh -p <port> <host> "cat > /docs/backend/decisions/.lore/config.yaml"
+version: 1
+rules:
+  adr-length:
+    match: ["*.md"]
+    exclude: ["index.md"]
+    use: size/lines
+    with: { max: initial, growth: 1.1 }
+EOF
+ssh -p <port> <host> "lore validate /docs/backend/decisions"
+```
+
+Rule keys are `match`, `exclude`, `use`, `with`, `enforce` and `default`; take
+`use` and `with` from `lore package doc <member>`. A child folder can add rules
+or tighten under a new name; it cannot loosen a parent's rule unless the parent
+marked it `default: true`. The write is rejected with an explanation if the
+file conflicts with a layer above it or names an unknown member or parameter.
 
 ## Notes
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -115,7 +115,30 @@ them.
 | `lore meta [path]` | Emit document frontmatter as NDJSON, scoped to the current directory or path |
 | `lore meta --filter skills [path]` | Discover Agent Skills collections without scanning unrelated docs |
 | `lore package list` / `lore package doc <path>` | List compiled-in rule members or show a member's parameters and example |
-| `lore validate [bundle]` | Validate an OKF bundle, local links, and aliased-path portability |
+| `lore validate [dir]` | Run folder rules over a docset or folder: file rules per file, bundle rules (OKF bundle structure, local links, alias portability) once at the root |
+| `lore size baseline <path>` | Show a file's size-baseline history and current cap under `max: initial` rules |
+| `lore size baseline reset <path> [--note <text>]` | Append a new baseline from the file's current content; needs a write grant on the path and a `config.edit` role |
+
+See [Folder rules](folder-rules.md) for the rules model. `lore validate` refuses
+to run from a directory above docsets that declare bundle rules
+(`run lore validate per docset`); name the docset or folder instead.
+
+Example `lore size baseline` output:
+
+```text
+/docs/backend/decisions/adr-001.md  (size/lines via adr-length @ /docs/backend/.lore/config.yaml, growth 1.1)
+  2026-08-30T09:12:04Z  create      agent:claude@acme.com   412 lines  12 KiB  3900 tokens (estimate/v1)
+  2026-09-02T14:01:37Z  reset       adil                    812 lines  21 KiB  6400 tokens (estimate/v1)  "ADR grew after review"
+current cap: 893 lines
+```
+
+A file with no history prints `no baseline recorded`. A reset prints the
+previous and new baseline and the resulting cap, and is also recorded in the
+server audit log as `rules.baseline.reset`:
+
+```text
+baseline reset: previous 412, new 812, new cap 893 lines
+```
 
 ## Skills management
 

--- a/docs/configuration-and-identity.md
+++ b/docs/configuration-and-identity.md
@@ -40,6 +40,13 @@ files:
     - "node_modules"
     - ".env"
 
+# Folder rules (see docs/folder-rules.md). `growth` is the default multiplier
+# for `max: initial` size rules and must be at least 1. `rules.tokenizer` is
+# reserved and rejected at boot until a real tokenizer ships; size/tokens uses
+# the built-in estimator.
+rules:
+  growth: 1.25
+
 # skills_dir: ./skills
 # auth_file: ./lore.json
 # tls_cert: ./cert.pem
@@ -84,6 +91,9 @@ mcp:
       "allow": { "capabilities": ["spawn"] }
     }
   },
+  "rules": {
+    "doc-size": { "match": ["**/*.md"], "use": "size/kilobytes", "with": { "max": 60 }, "default": true }
+  },
   "docsets": {
     "public": {
       "paths": ["/docs/public"],
@@ -92,7 +102,11 @@ mcp:
     "backend": {
       "paths": ["/docs/api", { "internal/specs": "/docs/specs" }],
       "aliases": ["/api"],
-      "access": { "allow": { "backend": "rw" } }
+      "access": { "allow": { "backend": "rw" } },
+      "rules": {
+        "format": { "match": ["**/*.md"], "use": "okf" }
+      },
+      "config": { "edit": ["backend"] }
     },
     "backend-home": {
       "paths": ["/home/backend"]
@@ -118,6 +132,22 @@ Docsets grant exact role names:
 
 Multiple roles contribute grants independently. Any matching docset deny wins.
 Capability allows form a union across roles, while any capability deny wins.
+
+Folder rules use three keys, all documented in [Folder rules](folder-rules.md):
+
+- Top-level `rules` declares rules that apply to every docset. Each rule has
+  `match`, optional `exclude`, `use` (a member such as `size/kilobytes` or
+  `okf`), `with` (the member's parameters), `enforce` (default `true`) and
+  `default` (`true` lets a folder's `.lore/config.yaml` replace the rule under
+  the same name).
+- `docsets.<name>.rules` declares rules for that docset's paths, with the same
+  shape. The older `docsets.<name>.okf` block is still accepted and is
+  equivalent to declaring the `okf`, `okf/bundle`, `link/resolves` and
+  `link/alias` rules.
+- `docsets.<name>.config.edit` lists the roles allowed to create, edit or
+  delete `.lore/config.yaml` files under the docset and to run
+  `lore size baseline reset`. The role also needs a write grant on the path. A
+  docset without `config.edit` has no one who can change its folder rules.
 
 ## HTTP inbox credentials
 

--- a/docs/folder-rules.md
+++ b/docs/folder-rules.md
@@ -1,0 +1,350 @@
+# Folder Rules
+
+Folder rules are declarative checks that OpenLore runs against files before
+they reach disk and again under `lore validate`. A rule names a set of files
+with globs and a *member* of the rules standard library to check them with:
+`size/lines` caps a file's length, `okf` enforces Open Knowledge Format
+conformance, `link/resolves` reports broken links. Rules live in three places
+that layer together: `lore.json` (server-wide and per docset) and
+`.lore/config.yaml` files inside the content tree.
+
+This guide explains how the layers combine, the configuration schema, what runs
+when, who may edit rules, how to read a rejection, and how growth limits
+(`max: initial`) work. For each member's parameters see the generated
+[Rules standard library](rules-stdlib.md), or run `lore package doc <member>`
+inside a session.
+
+## Three layers, one effective rule set
+
+For any target path the engine unifies every layer whose scope contains it:
+
+```diagram
+lore.json  rules:            ─┐  applies to every docset
+lore.json  docsets.X.rules:   │  applies under docset X's display roots
+/docs/backend/.lore/config.yaml   applies to /docs/backend and below
+/docs/backend/decisions/.lore/config.yaml   applies to decisions/ and below
+                             ─┘
+              ▼
+   effective rule set for /docs/backend/decisions/adr-001.md
+```
+
+- Rules with **different names** are all evaluated. A violation of any one of
+  them rejects the write. Layers only ever add checks.
+- The **same name** at two layers is the same rule. If the outer layer marked
+  it `default: true`, the inner spec replaces it. Otherwise the two specs must
+  be identical, or the configuration is invalid and is rejected when the
+  `.lore/config.yaml` is written (or at boot for `lore.json`, or by
+  `lore validate`):
+
+  ```text
+  .lore/config.yaml: rules.doc-size: conflicts with doc-size @ lore.json (max: 400 vs 60); use a new rule name to tighten
+  ```
+
+- To tighten a rule from a child folder, add a rule with a **new name**. A
+  child can never loosen a rule it did not author, except where the parent said
+  `default: true`.
+- To exempt files, add `exclude:` to the rule at the layer that owns it, or use
+  docset shadowing: a nested docset that does not declare a rule exempts its
+  subtree from the parent docset's rules, exactly as OKF scoping already works.
+
+There is no `inherit` key. A `.lore/config.yaml` applies to its directory and
+everything beneath it.
+
+## `.lore/config.yaml`
+
+```yaml
+version: 1
+
+rules:
+  adr-length:                         # rule name — unique within this file
+    match: ["decisions/*.md"]         # globs, relative to this folder; `**` supported
+    exclude: ["decisions/draft-*.md"] # optional
+    use: size/lines                   # standard library member
+    with: { max: initial, growth: 1.1 }
+    enforce: true                     # default true; false = warn and allow
+    default: false                    # true = a same-named rule in a child folder replaces this one
+
+# Reserved for future releases. Present but non-empty is an error: "not supported yet".
+packages: {}
+hooks: {}
+operations: {}
+```
+
+Rule-level keys are exactly `match`, `exclude`, `use`, `with`, `enforce` and
+`default`. Everything a member needs goes inside `with` and is validated
+against the member's declared parameters. Unknown keys, unknown members and
+unknown parameters are rejected with a suggestion:
+
+```text
+.lore/config.yaml: rules.adr-length.with.maxx: unknown parameter for size/lines (did you mean "max"?)
+```
+
+The file is written like any other file (`cat config.yaml | ssh … "cat >
+/docs/backend/.lore/config.yaml"`, `patch`, `sed -i`), subject to the
+permission below. Rules are never evaluated against the config file itself.
+`tree` and `ls` show `.lore/config.yaml` when it exists and nothing else under
+`.lore/`.
+
+### Globs
+
+`match` and `exclude` are matched against the target path **relative to the
+layer's scope directory**: the containing folder for `.lore/config.yaml`, the
+docset display root for `lore.json` layers. `*` matches within one path
+segment; `**` matches zero or more segments. A rule applies when any `match`
+pattern matches and no `exclude` pattern does.
+
+## `lore.json`
+
+```json
+{
+  "rules": {
+    "doc-size": { "match": ["**/*.md"], "use": "size/kilobytes", "with": { "max": 60 }, "default": true }
+  },
+  "docsets": {
+    "backend": {
+      "paths": ["/docs/backend"],
+      "access": { "allow": { "engineer": "rw" } },
+      "rules": {
+        "format": { "match": ["**/*.md"], "use": "okf" }
+      },
+      "config": { "edit": ["engineer"] }
+    }
+  }
+}
+```
+
+- Top-level `rules` apply to every docset. `docsets.<name>.rules` apply under
+  that docset's display roots. Both use the same rule shape as
+  `.lore/config.yaml`.
+- `config.edit` lists the roles that may create, edit or delete
+  `.lore/config.yaml` files under the docset (see [Permissions](#permissions)).
+- The existing per-docset `okf` block keeps working. It desugars to four rules
+  so that one switch governs the whole OKF family: `okf` (file scope, the
+  block's `patterns` as `**/<pattern>`, its `enforce`), `okf/bundle`,
+  `link/resolves` and `link/alias` (bundle scope, `**/*.md`; `link/alias` is
+  always a warning). Writes are still checked by `okf` alone and
+  `lore validate` still reports the rest, so existing deployments see no
+  change.
+
+## `openlore.yml`
+
+```yaml
+rules:
+  growth: 1.25          # default multiplier for `max: initial`; must be ≥ 1
+```
+
+`rules.tokenizer` is reserved. Setting it fails at boot with
+`rules.tokenizer is not supported yet`; `size/tokens` always uses the built-in
+estimator (see [Growth limits](#growth-limits)).
+
+## What runs when
+
+Every member declares a scope, shown by `lore package list` and in
+[rules-stdlib.md](rules-stdlib.md).
+
+| Scope | Members | On write | Under `lore validate` |
+|---|---|---|---|
+| `file` | `okf`, `size/kilobytes`, `size/lines`, `size/tokens` | evaluated; an enforcing finding rejects the write | evaluated per file |
+| `bundle` | `okf/bundle`, `link/resolves`, `link/alias` | never | evaluated once at the bundle root |
+
+Bundle rules need to see related files. A write that adds a new concept
+legitimately breaks `okf/bundle` until `index.md` is updated in a following
+write, and a link target may be written next. Rejecting or even warning on the
+first write would be noise, so bundle rules leave no trace on the write path
+and are the job of `lore validate`.
+
+On write, the engine resolves the effective rule set for each file in the
+operation and evaluates its file-scope rules. A finding from an `enforce: true`
+rule rejects the whole operation (a batch is one decision; the first violation
+rejects it). A finding from an `enforce: false` rule is logged as a warning and
+the write proceeds. A member that errors, rather than finding a violation,
+rejects the write unless the rule is non-enforcing: the system fails closed.
+
+`lore validate <dir>` runs both passes over `<dir>` (default: the current
+directory) without writing anything. Run it per docset or folder, not from `/`:
+if the named directory is *above* docsets that declare bundle rules, those
+rules would not be in effect at the root and would silently not run, so the
+command refuses instead:
+
+```text
+lore validate: / is above docsets docs, wiki with bundle rules; run lore validate per docset
+```
+
+Validate output is one line per finding (`path:line:col: severity [rule]
+message`), followed by one `see: lore package doc <member>` line per member
+that produced findings. Severity is `error` for enforcing rules and `warning`
+otherwise. Every `.lore/config.yaml` in the bundle is also decoded and unified;
+configuration errors are reported as diagnostics.
+
+## Permissions
+
+Writing `<dir>/.lore/config.yaml` requires both a write grant for `<dir>` under
+the owning docset **and** a role listed in that docset's `config.edit`.
+Otherwise the write fails with a permission error. A docset without
+`config.edit` has no one who can write its folder configs. Anyone who can read
+the folder can read its config.
+
+The same gate applies to deletion. `rm` of a config file needs the same two
+conditions. `rm -r` of a directory tree that contains one or more
+`.lore/config.yaml` files needs them for every config in the tree, otherwise
+the whole removal fails and nothing is deleted — without this, plain `rw` could
+drop a folder's governance by deleting and recreating the folder.
+
+`lore size baseline reset` (below) is authorised the same way, because it
+loosens a rule for one file.
+
+## Reading a rejection
+
+A rejected write exits non-zero and prints a block written for the agent that
+just had its write refused. It answers, in order: what was measured and what
+the limit is, what cannot be done, what to do instead, and how a privileged
+human can override.
+
+```text
+rules: /docs/backend/decisions/adr-001.md: size/lines (adr-length @ /docs/backend/.lore/config.yaml)
+  812 lines exceeds the limit of 800 (baseline 640 lines × growth 1.25, set 2026-08-30 on create)
+  this file cannot grow past 800 lines under this rule
+  suggested: keep adr-001.md under 800 lines; move the new material into a sibling file such as adr-001-details.md and add a link to it from adr-001.md so readers can drill in
+  override: a role in config.edit can run `lore size baseline reset /docs/backend/decisions/adr-001.md`
+  see: lore package doc size/lines
+```
+
+The header names the member, the rule and the layer that declared it
+(`/docs/backend/.lore/config.yaml`, `lore.json#docsets.backend`, or `lore.json`
+for a top-level rule), so you know which file to edit. For a fixed `max` the first line reads
+`812 lines exceeds the limit of 800 (max: 800)` and the `override:` line
+becomes `to raise the limit, edit adr-length in /docs/backend/.lore/config.yaml`.
+
+The `suggested:` remedy for `size/*` is progressive disclosure: keep the file
+within its limit, move the new material into a sibling file, and link to it
+from the original so readers can drill in. Retrying with small trims is
+pointless when the overrun is large.
+
+`okf` rejections keep their existing one-line diagnostic (it already names the
+fix) and add only the `see:` line:
+
+```text
+okf: /docs/bad.md: missing YAML frontmatter block (a concept must open with a '---' delimited block)
+  see: lore package doc okf
+```
+
+## Growth limits
+
+`max: initial` caps a file relative to its own size instead of a fixed number.
+The first admitted write of a file records a **baseline** (kilobytes, lines and
+tokens); afterwards the file may not exceed `baseline × growth`. `growth`
+defaults to `openlore.yml rules.growth` (1.25 unless configured) and can be set
+per rule.
+
+```yaml
+rules:
+  adr-length:
+    match: ["decisions/*.md"]
+    use: size/lines
+    with: { max: initial, growth: 1.1 }
+```
+
+How the baseline is taken:
+
+- **Create.** The baseline is the content of the first admitted write. If that
+  write is rejected by another rule, its baseline never governs anything: the
+  next write of the file is treated as a create again.
+- **Rule added to existing files.** The first write to a file that already
+  exists records the baseline from the *existing* content, before the proposed
+  write is evaluated. Adding `max: initial` to a folder never rejects the next
+  edit merely because the file was already large; it freezes the file at the
+  size it had.
+- **`rm`** clears the baseline; recreating the file starts a new one.
+- **`mv`** carries the baseline to the new path.
+- **`lore validate`** reads baselines but never records one.
+
+State lives in the content tree beside the file, in
+`<dir>/.lore/size/<basename>.jsonl`, so it travels with the content when the
+tree is copied or checked in. It is never listed by `tree` or `ls` and cannot be
+read or written through the VFS; `lore size baseline <path>` is the view onto
+it. Records are append-only: a new baseline is added, older ones are kept, and
+every record names the actor who caused it, so the history answers "who set
+this cap".
+
+`size/tokens` counts with the built-in estimator `estimate/v1`
+(`ceil(bytes / 4)`). It is an approximation, so leave a margin when a token cap
+matters. Each token baseline records the estimator that produced it; if the
+estimator changes in a later release, token baselines from the old one are
+re-taken on the next write while kilobyte and line baselines are untouched.
+
+### Inspecting and resetting a baseline
+
+```text
+$ lore size baseline /docs/backend/decisions/adr-001.md
+/docs/backend/decisions/adr-001.md  (size/lines via adr-length @ /docs/backend/.lore/config.yaml, growth 1.1)
+  2026-08-30T09:12:04Z  create      agent:claude@acme.com   412 lines  12 KiB  3900 tokens (estimate/v1)
+  2026-09-02T14:01:37Z  reset       adil                    812 lines  21 KiB  6400 tokens (estimate/v1)  "ADR grew after review"
+current cap: 893 lines
+```
+
+`lore size baseline reset <path> [--note <text>]` re-measures the current
+content and appends a new baseline with reason `reset`, so the file may grow
+again by `growth` from where it is now. It requires a write grant on the path
+and a role in the owning docset's `config.edit`, the same as editing
+`.lore/config.yaml`. Earlier records are kept, and the reset is also written to
+the server audit log as `rules.baseline.reset` with the previous and new
+baseline and the note.
+
+```text
+$ lore size baseline reset /docs/backend/decisions/adr-001.md --note "ADR grew after review"
+baseline reset: previous 412, new 812, new cap 893 lines
+```
+
+An agent that hits a growth limit should follow the `suggested:` line, or ask
+a human for the exact `override:` command, rather than retry.
+
+## Worked example: tightening a docset rule in one folder
+
+The docset allows Markdown files up to 60 KiB and marks that rule as a default:
+
+```json
+{
+  "docsets": {
+    "backend": {
+      "paths": ["/docs/backend"],
+      "access": { "allow": { "engineer": "rw" } },
+      "config": { "edit": ["engineer"] },
+      "rules": {
+        "doc-size": { "match": ["**/*.md"], "use": "size/kilobytes", "with": { "max": 60 }, "default": true }
+      }
+    }
+  }
+}
+```
+
+The team wants decision records kept short and frozen once written, and a
+tighter size for everything in `decisions/`. An `engineer` writes
+`/docs/backend/decisions/.lore/config.yaml`:
+
+```yaml
+version: 1
+rules:
+  doc-size:                              # same name + parent said default → replaces 60 KiB
+    match: ["**/*.md"]
+    use: size/kilobytes
+    with: { max: 20 }
+  adr-length:                            # new name → adds a check
+    match: ["*.md"]
+    exclude: ["index.md"]
+    use: size/lines
+    with: { max: initial, growth: 1.1 }
+```
+
+Under `decisions/`, a Markdown write must now pass `doc-size` at 20 KiB and
+`adr-length`, and any `okf` rule the docset declares. Elsewhere in the docset
+the 60 KiB default still applies. Had the docset's `doc-size` not been marked
+`default: true`, writing this config would have been rejected with the
+`conflicts with doc-size @ lore.json#docsets.backend (max: 60 vs 20)` error,
+and the folder would have had to
+add its tighter cap under a new name instead.
+
+Check the result without writing anything:
+
+```bash
+lore validate /docs/backend/decisions
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -62,6 +62,12 @@ allows findings.
 The owning docset's configuration governs each target. Use nested docsets to
 scope validation more narrowly or to exempt a subtree from its parent's policy.
 
+The `okf` block is shorthand for four [folder rules](folder-rules.md): `okf`
+(checked on write), plus `okf/bundle`, `link/resolves` and `link/alias`
+(checked by `lore validate` only). Declare them under `docsets.<name>.rules`
+instead when you want to combine them with other members such as `size/lines`,
+or scope them with `match`/`exclude` globs.
+
 Downstream Go code can apply the same rules directly:
 
 ```go

--- a/docs/write-system.md
+++ b/docs/write-system.md
@@ -352,6 +352,9 @@ In `openlore.yml` (global) and per docset in `lore.json`:
 | `readonly` | global / per-docset | Global is a hard physical lock (default `true`). A per-docset `readonly: false` cannot loosen a global lock; a per-docset `readonly: true` excludes that docset from writes. |
 | `write_conflict_policy` | global / per-docset | `hash` (CAS, default) or `last_write_wins`. Per-docset overrides global. |
 | `requires_approval` | per-docset | List of `{ path, capability }` rules that gate matching writes and deletes behind `approve` (as changesets). |
+| `rules` | global (`lore.json` top level) / per-docset | Folder rules evaluated as a write middleware and by `lore validate`; unified with `.lore/config.yaml` files in the content tree. See [Folder rules](folder-rules.md). |
+| `config` | per-docset | `config.edit`: roles that may write or delete `.lore/config.yaml` under the docset and run `lore size baseline reset`. |
+| `rules.growth` | global (`openlore.yml`) | Default multiplier for `max: initial` size rules (default `1.25`). |
 | `max_jobs` | global | Max concurrent async `spawn` jobs (default `8`). |
 | `hooks` | global | External commands subscribed to `on_startup`/`pre_read`/`post_write`/`post_delete`/`approval_pending`. |
 

--- a/lore.json.example
+++ b/lore.json.example
@@ -23,7 +23,12 @@
       "access": {
         "allow": { "engineer": "rw", "reviewer": "publish" },
         "deny": []
-      }
+      },
+      "rules": {
+        "format": { "match": ["**/*.md"], "use": "okf" },
+        "doc-size": { "match": ["**/*.md"], "use": "size/kilobytes", "with": { "max": 60 }, "default": true }
+      },
+      "config": { "edit": ["engineer"] }
     },
     "engineer-home": {
       "paths": [{ "published/engineer": "/home/engineer" }]

--- a/openlore.yml.example
+++ b/openlore.yml.example
@@ -267,6 +267,16 @@ files:
 # it for that docset's subtree; scope narrower subtrees with nested docsets.
 # See lore.json.example for the schema.
 
+# ── Folder Rules ──────────────────────────────────────
+#
+# Rules (size caps, OKF, link checks) are declared per docset in lore.json and
+# per folder in .lore/config.yaml files inside the content tree. See
+# docs/folder-rules.md. The only server-wide setting is the default growth
+# multiplier for `max: initial` size rules (must be >= 1). `rules.tokenizer`
+# is reserved and rejected until a real tokenizer ships.
+# rules:
+#   growth: 1.25
+
 # ── Display ───────────────────────────────────────────
 
 # Message of the day shown when a client connects.


### PR DESCRIPTION
Documentation deliverables for the folder rules system (plan acceptance tests Phase 3 #9 and Phase 4 #15), following the merge of #66, #67, #69 and #70.

## Changes

- **`docs/folder-rules.md`** (new) — user guide: the three layers and how they unify (`default: true`, conflict rule, new-name-to-tighten), full `.lore/config.yaml` schema and reserved sections, glob scoping relative to the layer, `lore.json` `rules` / `docsets.<x>.rules` / `config.edit` and the `okf` desugaring, `openlore.yml` `rules.growth` and reserved `rules.tokenizer`, file vs bundle scope and why bundle rules never run on write, `lore validate` anchoring and the above-docsets refusal, write/delete permissions incl. `rm -r`, how to read a rejection, growth limits (baseline sources, `rm`/recreate/`mv`, `.lore/size/<basename>.jsonl`, `estimate/v1`), `lore size baseline [reset]`, and a worked example tightening a docset rule from a folder.
- **`docs/commands.md`** — `lore size baseline <path>` and `lore size baseline reset <path> [--note]` with permission requirements and sample output; `lore validate` row reworded.
- **`docs/configuration-and-identity.md`** — `rules.growth` in the `openlore.yml` sample; `rules` and `config.edit` in the `lore.json` sample with a key description.
- **`docs/write-system.md`** — `rules`, `config`, `rules.growth` rows in the configuration table.
- **`docs/plugins.md`** — the `okf` block is shorthand for four rules; links the guide.
- **`README.md`** — Documentation table row.
- **`assets/skills/openlore/SKILL.md`** — "Folder rules" no longer says rules are "configured by the server"; tells an agent to check the folder's `.lore/config.yaml`, how to read a rejection, that a growth limit means ask a human for the exact `override:` command rather than retry, that token limits are estimates, and how a `config.edit` holder authors a folder config.
- **`openlore.yml.example` / `lore.json.example`** — commented `rules.growth` block; a docset with `rules` and `config.edit`.

## Verification

Every quoted output and error message was exercised against a booted test server (throwaway test, not committed): config written via `cat > …/.lore/config.yaml`, `tree -a` listing only `.lore/config.yaml`, the growth and fixed-`max` rejection blocks, `lore size baseline` history and `reset` output, `lore validate /` refusing above an OKF docset, the `did you mean "max"?` config error, and the `okf` one-liner. `go test ./internal/config/ ./pkg/openlore/ ./pkg/shell/...` passes; `lore.json.example` parses.

Examples use `cat > <path>` for writes since there is no `write` command in the registry.