### PR TITLE
fix(mcp): set is_error and exit_code on non-zero shell exit

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -138,6 +138,13 @@ The MCP server exposes:
 | `shell` | Execute a command against the virtual filesystem |
 | `list_commands` | List commands supported by that server |
 
+The `shell` tool returns the command's exit code as structured content. A
+non-zero exit is an MCP tool error (`isError: true`), while its text content
+continues to include stderr and a trailing `exit code: N` line. The plain JSON
+`POST /api/shell` endpoint follows the same convention: commands that run
+return HTTP 200 with `{"output":"...","is_error":false,"exit_code":0}`;
+non-zero exits set `is_error` to `true` and populate `exit_code`.
+
 ## MCP over stdio
 
 Use stdio for clients that launch a local process, including Claude Desktop:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -141,7 +141,8 @@ The MCP server exposes:
 The `shell` tool returns the command's exit code as structured content. A
 non-zero exit is an MCP tool error (`isError: true`), while its text content
 continues to include stderr and a trailing `exit code: N` line. The plain JSON
-`POST /api/shell` endpoint follows the same convention: commands that run
+`POST /api/shell` endpoint and the persistent-session endpoint
+`POST /api/sessions/{id}/shell` follow the same convention: commands that run
 return HTTP 200 with `{"output":"...","is_error":false,"exit_code":0}`;
 non-zero exits set `is_error` to `true` and populate `exit_code`.
 

--- a/pkg/openlore/mcp.go
+++ b/pkg/openlore/mcp.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -155,25 +156,62 @@ func newMCPShellHandler(fs vfs.FileSystem, envVars map[string]string, factory fu
 			}
 		}
 
-		var stdout, stderr bytes.Buffer
-		exitCode := sh.ExecPipeline(input.Command, &stdout, &stderr, nil)
-
-		result := stdout.String()
-		if stderr.Len() > 0 {
-			if len(result) > 0 {
-				result += "\n"
-			}
-			result += stderr.String()
-		}
-		if exitCode != 0 {
-			result += fmt.Sprintf("\nexit code: %d", exitCode)
-		}
+		output, exitCode := execShellTranscript(sh, input.Command)
 
 		return &mcp.CallToolResult{
-			Content:           []mcp.Content{&mcp.TextContent{Text: result}},
+			Content:           []mcp.Content{&mcp.TextContent{Text: output}},
 			StructuredContent: map[string]any{"exit_code": exitCode},
 			IsError:           exitCode != 0,
 		}, nil, nil
+	}
+}
+
+// execShellTranscript executes command in sh and returns the merged transcript plus the
+// exit code. stdout comes first, then stderr, then a trailing "exit code: N"
+// line on failure. Sections are separated by a single newline and the
+// transcript never starts with one, even when only stderr or only the exit
+// code is present.
+func execShellTranscript(sh *shell.Shell, command string) (string, int) {
+	var stdout, stderr bytes.Buffer
+	exitCode := sh.ExecPipeline(command, &stdout, &stderr, nil)
+
+	sections := make([]string, 0, 3)
+	if stdout.Len() > 0 {
+		sections = append(sections, stdout.String())
+	}
+	if stderr.Len() > 0 {
+		sections = append(sections, stderr.String())
+	}
+	if exitCode != 0 {
+		sections = append(sections, fmt.Sprintf("exit code: %d", exitCode))
+	}
+	return strings.Join(sections, "\n"), exitCode
+}
+
+// exitCodeFromStructured extracts the exit_code field the shell tool places in
+// StructuredContent. The value has been through JSON on the way back to the
+// client, so its concrete Go type depends on the decoder: float64 today,
+// json.Number or an integer type if the SDK changes how it decodes.
+func exitCodeFromStructured(structured any) (int, bool) {
+	m, ok := structured.(map[string]any)
+	if !ok {
+		return 0, false
+	}
+	switch v := m["exit_code"].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(n), true
+	default:
+		return 0, false
 	}
 }
 

--- a/pkg/openlore/mcp.go
+++ b/pkg/openlore/mcp.go
@@ -160,14 +160,19 @@ func newMCPShellHandler(fs vfs.FileSystem, envVars map[string]string, factory fu
 
 		result := stdout.String()
 		if stderr.Len() > 0 {
-			result += "\n" + stderr.String()
+			if len(result) > 0 {
+				result += "\n"
+			}
+			result += stderr.String()
 		}
 		if exitCode != 0 {
 			result += fmt.Sprintf("\nexit code: %d", exitCode)
 		}
 
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: result}},
+			Content:           []mcp.Content{&mcp.TextContent{Text: result}},
+			StructuredContent: map[string]any{"exit_code": exitCode},
+			IsError:           exitCode != 0,
 		}, nil, nil
 	}
 }

--- a/pkg/openlore/mcp_http_api.go
+++ b/pkg/openlore/mcp_http_api.go
@@ -59,8 +59,9 @@ type shellRequest struct {
 }
 
 type toolResponse struct {
-	Output  string `json:"output"`
-	IsError bool   `json:"is_error"`
+	Output   string `json:"output"`
+	IsError  bool   `json:"is_error"`
+	ExitCode int    `json:"exit_code"`
 }
 
 func (a *MCPHTTPAPI) handleShell(w http.ResponseWriter, r *http.Request) {
@@ -102,9 +103,22 @@ func (a *MCPHTTPAPI) callTool(w http.ResponseWriter, ctx context.Context, name s
 	}
 
 	writeJSON(w, http.StatusOK, toolResponse{
-		Output:  contentText(result),
-		IsError: result.IsError,
+		Output:   contentText(result),
+		IsError:  result.IsError,
+		ExitCode: resultExitCode(result),
 	})
+}
+
+func resultExitCode(result *mcp.CallToolResult) int {
+	structured, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		return 0
+	}
+	exitCode, ok := structured["exit_code"].(float64)
+	if !ok {
+		return 0
+	}
+	return int(exitCode)
 }
 
 // connect establishes a fresh in-process client<->server MCP session bound to

--- a/pkg/openlore/mcp_http_api.go
+++ b/pkg/openlore/mcp_http_api.go
@@ -110,15 +110,8 @@ func (a *MCPHTTPAPI) callTool(w http.ResponseWriter, ctx context.Context, name s
 }
 
 func resultExitCode(result *mcp.CallToolResult) int {
-	structured, ok := result.StructuredContent.(map[string]any)
-	if !ok {
-		return 0
-	}
-	exitCode, ok := structured["exit_code"].(float64)
-	if !ok {
-		return 0
-	}
-	return int(exitCode)
+	exitCode, _ := exitCodeFromStructured(result.StructuredContent)
+	return exitCode
 }
 
 // connect establishes a fresh in-process client<->server MCP session bound to

--- a/pkg/openlore/mcp_http_api_test.go
+++ b/pkg/openlore/mcp_http_api_test.go
@@ -48,8 +48,41 @@ func TestMCPHTTPAPI_Shell(t *testing.T) {
 	if resp.IsError {
 		t.Fatalf("unexpected is_error=true: %q", resp.Output)
 	}
+	if resp.ExitCode != 0 {
+		t.Fatalf("exit_code = %d, want 0", resp.ExitCode)
+	}
 	if !strings.Contains(resp.Output, "world") {
 		t.Fatalf("output %q does not contain %q", resp.Output, "world")
+	}
+}
+
+func TestMCPHTTPAPI_ShellFailure(t *testing.T) {
+	h := newTestAPI(t)
+
+	body := strings.NewReader(`{"command":"cat /does/not/exist"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/shell", body)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp toolResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatalf("is_error = false, want true: %q", resp.Output)
+	}
+	if resp.ExitCode != 1 {
+		t.Fatalf("exit_code = %d, want 1", resp.ExitCode)
+	}
+	if strings.HasPrefix(resp.Output, "\n") {
+		t.Fatalf("output starts with a blank line: %q", resp.Output)
+	}
+	if !strings.HasSuffix(resp.Output, "exit code: 1") {
+		t.Fatalf("output %q does not end with %q", resp.Output, "exit code: 1")
 	}
 }
 

--- a/pkg/openlore/mcp_http_sessions.go
+++ b/pkg/openlore/mcp_http_sessions.go
@@ -1,12 +1,10 @@
 package openlore
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -213,14 +211,10 @@ func randomHTTPSessionID() (string, error) {
 }
 
 func executeSessionShell(sh *shell.Shell, command string) toolResponse {
-	var stdout, stderr bytes.Buffer
-	exitCode := sh.ExecPipeline(command, &stdout, &stderr, nil)
-	output := stdout.String()
-	if stderr.Len() > 0 {
-		output += "\n" + stderr.String()
+	output, exitCode := execShellTranscript(sh, command)
+	return toolResponse{
+		Output:   output,
+		IsError:  exitCode != 0,
+		ExitCode: exitCode,
 	}
-	if exitCode != 0 {
-		output += fmt.Sprintf("\nexit code: %d", exitCode)
-	}
-	return toolResponse{Output: output}
 }

--- a/pkg/openlore/mcp_http_sessions_test.go
+++ b/pkg/openlore/mcp_http_sessions_test.go
@@ -104,6 +104,42 @@ func TestMCPHTTPSessionLifecyclePreservesShellState(t *testing.T) {
 	}
 }
 
+func TestMCPHTTPSessionShellReportsFailure(t *testing.T) {
+	_, handler := newSessionTestAPI(t)
+	identity := Identity{IdentityName: "adil", Principal: AuthenticatedPrincipal{Subject: "adil"}, Attribution: Attribution{Principal: "adil"}, Scopes: []string{ScopeFull}}
+	created := createSession(t, handler, identity)
+	path := "/api/sessions/" + created.ID + "/shell"
+
+	w := sessionRequest(t, handler, identity, http.MethodPost, path, `{"command":"cat /does/not/exist"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+	}
+	var resp toolResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.IsError {
+		t.Fatalf("is_error = false, want true; body = %+v", resp)
+	}
+	if resp.ExitCode != 1 {
+		t.Fatalf("exit_code = %d, want 1", resp.ExitCode)
+	}
+	if strings.HasPrefix(resp.Output, "\n") {
+		t.Fatalf("output starts with a blank line: %q", resp.Output)
+	}
+	if !strings.HasSuffix(resp.Output, "exit code: 1") {
+		t.Fatalf("output %q does not end with %q", resp.Output, "exit code: 1")
+	}
+
+	w = sessionRequest(t, handler, identity, http.MethodPost, path, `{"command":"pwd"}`)
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.IsError || resp.ExitCode != 0 {
+		t.Fatalf("success reported as failure: %+v", resp)
+	}
+}
+
 func TestMCPHTTPSessionIsBoundToIdentity(t *testing.T) {
 	_, handler := newSessionTestAPI(t)
 	owner := Identity{IdentityName: "owner", Principal: AuthenticatedPrincipal{Subject: "owner"}, Attribution: Attribution{Principal: "owner"}, Scopes: []string{ScopeFull}}

--- a/pkg/openlore/mcp_test.go
+++ b/pkg/openlore/mcp_test.go
@@ -1,10 +1,12 @@
 package openlore
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"testing/fstest"
 
+	"github.com/aakarim/go-openlore/pkg/shell"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -130,11 +132,68 @@ func TestMCPShellFailureIsError(t *testing.T) {
 	if !strings.HasSuffix(output, "exit code: 1") {
 		t.Fatalf("output %q does not end with %q", output, "exit code: 1")
 	}
-	structured, ok := result.StructuredContent.(map[string]any)
+	exitCode, ok := exitCodeFromStructured(result.StructuredContent)
 	if !ok {
-		t.Fatalf("StructuredContent = %T, want map[string]any", result.StructuredContent)
+		t.Fatalf("StructuredContent = %#v, want a map with an integer exit_code", result.StructuredContent)
 	}
-	if got := structured["exit_code"]; got != float64(1) {
-		t.Fatalf("exit_code = %#v, want 1", got)
+	if exitCode != 1 {
+		t.Fatalf("exit_code = %d, want 1", exitCode)
+	}
+}
+
+func TestExecShellTranscriptNeverStartsWithBlankLine(t *testing.T) {
+	sh := shell.NewShell(NewFSAdapter(fstest.MapFS{
+		"docs/a.md": &fstest.MapFile{Data: []byte("hello\n")},
+	}))
+
+	cases := []struct {
+		name       string
+		command    string
+		wantPrefix string
+		wantSuffix string
+		wantExit   int
+	}{
+		{name: "stdout only", command: "cat /docs/a.md", wantPrefix: "hello\n", wantSuffix: "hello\n"},
+		{name: "stderr only", command: "cat /does/not/exist", wantPrefix: "cat: ", wantSuffix: "\nexit code: 1", wantExit: 1},
+		{name: "exit code only", command: "false", wantPrefix: "exit code: 1", wantSuffix: "exit code: 1", wantExit: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, exitCode := execShellTranscript(sh, tc.command)
+			if exitCode != tc.wantExit {
+				t.Fatalf("exit code = %d, want %d", exitCode, tc.wantExit)
+			}
+			if strings.HasPrefix(got, "\n") {
+				t.Fatalf("transcript starts with a blank line: %q", got)
+			}
+			if !strings.HasPrefix(got, tc.wantPrefix) || !strings.HasSuffix(got, tc.wantSuffix) {
+				t.Fatalf("transcript = %q, want prefix %q and suffix %q", got, tc.wantPrefix, tc.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestExitCodeFromStructured(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     any
+		want   int
+		wantOK bool
+	}{
+		{name: "float64", in: map[string]any{"exit_code": float64(2)}, want: 2, wantOK: true},
+		{name: "int", in: map[string]any{"exit_code": 3}, want: 3, wantOK: true},
+		{name: "int64", in: map[string]any{"exit_code": int64(4)}, want: 4, wantOK: true},
+		{name: "json.Number", in: map[string]any{"exit_code": json.Number("5")}, want: 5, wantOK: true},
+		{name: "missing", in: map[string]any{}, want: 0, wantOK: false},
+		{name: "not a map", in: "nope", want: 0, wantOK: false},
+		{name: "wrong type", in: map[string]any{"exit_code": "1"}, want: 0, wantOK: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := exitCodeFromStructured(tc.in)
+			if ok != tc.wantOK || got != tc.want {
+				t.Fatalf("exitCodeFromStructured(%#v) = (%d, %v), want (%d, %v)", tc.in, got, ok, tc.want, tc.wantOK)
+			}
+		})
 	}
 }

--- a/pkg/openlore/mcp_test.go
+++ b/pkg/openlore/mcp_test.go
@@ -1,6 +1,7 @@
 package openlore
 
 import (
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -92,5 +93,48 @@ func TestMCPToolAnnotations(t *testing.T) {
 				t.Errorf("list_commands openWorldHint = %v, want false", listAnnotations.OpenWorldHint)
 			}
 		})
+	}
+}
+
+func TestMCPShellFailureIsError(t *testing.T) {
+	fs := NewFSAdapter(fstest.MapFS{})
+	server := NewMCPServer(fs)
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(t.Context(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	clientSession, err := client.Connect(t.Context(), clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	result, err := clientSession.CallTool(t.Context(), &mcp.CallToolParams{
+		Name:      "shell",
+		Arguments: map[string]any{"command": "cat /does/not/exist"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Fatal("IsError = false, want true")
+	}
+	output := result.Content[0].(*mcp.TextContent).Text
+	if strings.HasPrefix(output, "\n") {
+		t.Fatalf("output starts with a blank line: %q", output)
+	}
+	if !strings.HasSuffix(output, "exit code: 1") {
+		t.Fatalf("output %q does not end with %q", output, "exit code: 1")
+	}
+	structured, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("StructuredContent = %T, want map[string]any", result.StructuredContent)
+	}
+	if got := structured["exit_code"]; got != float64(1) {
+		t.Fatalf("exit_code = %#v, want 1", got)
 	}
 }


### PR DESCRIPTION
## What / why

The v0.6.0 MCP/HTTP smoke found that shell failures such as folder-rule rejections returned HTTP 200 with `is_error:false`. MCP clients therefore treated failed commands as successful unless they parsed the trailing `exit code:` text.

## Behavior change

- Mark non-zero shell exits as MCP tool errors with `IsError: true`.
- Publish the exit code through MCP structured content and expose it as `exit_code` from `/api/shell` (`0` on success).
- Keep HTTP 200 for commands that ran and failed, following MCP tool-result semantics.
- Avoid a leading blank line for pure-stderr output while preserving the existing stdout/stderr text and trailing `exit code: N` compatibility format.

This is additive for MCP and JSON clients; text output is unchanged except for removal of the unintended leading blank line on pure-stderr results.

## Verification

Go was not on `PATH`, so each command was run inside the repository's Nix development shell:

- `go vet ./...`
- `go build ./...`
- `GOOS=windows go build ./...`
- `go test -race -count=1 ./...`
- `go generate ./docs/... && git diff --exit-code docs/`

All passed. The race suite completed with every package `ok` (or `[no test files]`); the known flaky test did not fail. The remaining commands exited 0 with no diagnostic output.
