### PR TITLE
fix(shell): print rule rejections verbatim instead of redirect: <path>: rules: <path>

### DIFF
--- a/pkg/shell/cmds/patch.go
+++ b/pkg/shell/cmds/patch.go
@@ -83,6 +83,9 @@ func CmdPatch(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin 
 	}
 
 	if _, err := wfs.WriteFileAtomic(resolved, newContent, opts); err != nil {
+		if writeRuleRejection(errW, err) {
+			return 1
+		}
 		var pchg *vfs.PendingChangeError
 		if errors.As(err, &pchg) {
 			// Not a failure: a middleware parked the patch as a pending change.

--- a/pkg/shell/cmds/publish.go
+++ b/pkg/shell/cmds/publish.go
@@ -93,6 +93,9 @@ func CmdPublish(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdi
 	}
 
 	if _, err := WriteFile(ctx, dest, data, false); err != nil {
+		if writeRuleRejection(errW, err) {
+			return 1
+		}
 		var pchg *vfs.PendingChangeError
 		if errors.As(err, &pchg) {
 			// Not a failure: a middleware parked the publish as a pending change.

--- a/pkg/shell/cmds/write.go
+++ b/pkg/shell/cmds/write.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/aakarim/go-openlore/pkg/rules"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
 
@@ -161,6 +162,9 @@ func writeResultMsg(errW io.Writer, cmdName, p string, err error) int {
 	if err == nil {
 		return 0
 	}
+	if writeRuleRejection(errW, err) {
+		return 1
+	}
 	var pce *vfs.PendingChangeError
 	if errors.As(err, &pce) {
 		// Not a failure: a middleware parked the write as a pending change.
@@ -178,4 +182,13 @@ func writeResultMsg(errW io.Writer, cmdName, p string, err error) int {
 		fmt.Fprintf(errW, "%s: %s: %s\n", cmdName, p, err)
 	}
 	return 1
+}
+
+func writeRuleRejection(errW io.Writer, err error) bool {
+	var rejection *rules.Rejection
+	if !errors.As(err, &rejection) {
+		return false
+	}
+	fmt.Fprintln(errW, rejection.Error())
+	return true
 }

--- a/pkg/shell/cmds/write_test.go
+++ b/pkg/shell/cmds/write_test.go
@@ -1,0 +1,43 @@
+package cmds
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aakarim/go-openlore/pkg/rules"
+)
+
+func TestWriteResultMsgPrintsRuleRejectionVerbatim(t *testing.T) {
+	rejection := &rules.Rejection{
+		Path:   "/docs/six.md",
+		Rule:   "doc-size",
+		Member: "size/lines",
+		Origin: "lore.json#docsets.docs",
+		Findings: []rules.Finding{{
+			Measured: "6 lines exceeds the limit of 5 (max: 5)",
+			Limit:    "this file cannot grow past 5 lines under this rule",
+		}},
+	}
+
+	var errOut bytes.Buffer
+	if code := writeResultMsg(&errOut, "redirect", "/docs/six.md", fmt.Errorf("admission: %w", rejection)); code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	want := rejection.Error() + "\n"
+	if got := errOut.String(); got != want {
+		t.Fatalf("stderr:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestWriteResultMsgKeepsPlainErrorPrefix(t *testing.T) {
+	var errOut bytes.Buffer
+	if code := writeResultMsg(&errOut, "redirect", "/docs/six.md", errors.New("permission denied")); code != 1 {
+		t.Fatalf("exit code = %d, want 1", code)
+	}
+	const want = "redirect: /docs/six.md: permission denied\n"
+	if got := errOut.String(); got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Print `*rules.Rejection` errors verbatim across shell write paths instead of adding a command/path prefix.

Before:

```text
redirect: /docs/six.md: rules: /docs/six.md: size/lines (doc-size @ lore.json#docsets.docs)
  6 lines exceeds ...
```

After:

```text
rules: /docs/six.md: size/lines (doc-size @ lore.json#docsets.docs)
  6 lines exceeds ...
```

The first line of a rejection is a documented, agent-facing contract. Keeping `rules:` (or legacy `okf:`) at the start avoids repeating the path and makes the guidance directly recognizable to agents.

## Scope

- Detect wrapped `*rules.Rejection` values with `errors.As` and print the matched rejection block unchanged.
- Apply the handling to the shared redirect/tee/sed/mv write result path and the separate patch and publish write paths.
- Preserve all existing formatting for read-only, permission, precondition, pending-change, and other errors.
- Leave the already-correct folder-rules documentation and `Rejection.Error()` unchanged.

A direct `pkg/rules` import was used because the package dependency graph is cycle-free; this avoids adding a marker interface solely for shell formatting.

## Verification

```text
go vet ./...
go vet ./...: PASS

go build ./...
go build ./...: PASS

GOOS=windows go build ./...
GOOS=windows go build ./...: PASS

go test -race -count=1 ./...
ok  github.com/aakarim/go-openlore/pkg/openlore  3.751s
ok  github.com/aakarim/go-openlore/pkg/rules     1.019s
ok  github.com/aakarim/go-openlore/pkg/shell     1.025s
ok  github.com/aakarim/go-openlore/pkg/shell/cmds 1.144s
go test -race -count=1 ./...: PASS

go generate ./docs/... && git diff --exit-code docs/
go generate ./docs/... && git diff --exit-code docs/: PASS
```

The orb did not have Go on `PATH`, so each command was executed inside the repository's Nix development shell using:

```text
nix --extra-experimental-features 'nix-command flakes' develop --command bash -c '<command>'
```
