### PR TITLE
fix(config): let an explicit config file take precedence over the embedded openlore.yml

### DIFF
--- a/cmd/openlore/main.go
+++ b/cmd/openlore/main.go
@@ -402,7 +402,7 @@ func main() {
 
 			// Try loading config file for file filters. A loaded file replaces the
 			// embedded config; the embedded config is used only when no file exists.
-			embeddedCfg, hasEmbeddedCfg := assets.EmbeddedConfig()
+			embeddedCfg, _ := assets.EmbeddedConfig()
 			cfgOpts := []config.Option{
 				config.WithConfigFile(*mcpConfig),
 				config.WithEmbeddedConfig(embeddedCfg, ""),
@@ -410,7 +410,7 @@ func main() {
 			var resolvedCfg config.Config
 			if cfg, err := config.New(cfgOpts...); err == nil {
 				resolvedCfg = cfg
-				fmt.Fprintf(os.Stderr, "config: %s\n", configSource(*mcpConfig, hasEmbeddedCfg))
+				fmt.Fprintf(os.Stderr, "config: %s\n", cfg.Source())
 				if len(files.Allowed) == 0 {
 					files.Allowed = cfg.Files.Allowed
 				}
@@ -673,7 +673,7 @@ func main() {
 	// 2. Embedded config (from assets/config/openlore.yml, only without a file)
 	// 3. Built-in defaults
 	// CLI flag overrides are applied last and always win.
-	embeddedCfg, hasEmbeddedCfg := assets.EmbeddedConfig()
+	embeddedCfg, _ := assets.EmbeddedConfig()
 	opts := []openlore.Option{
 		openlore.WithConfigFile(*configFile),
 		openlore.WithEmbeddedConfig(embeddedCfg, assets.DefaultMOTD()),
@@ -783,7 +783,7 @@ func main() {
 	} else if assets.Lore() != nil {
 		fmt.Printf("  Directory:  (embedded docs)\n")
 	}
-	fmt.Printf("  config: %s\n", configSource(*configFile, hasEmbeddedCfg))
+	fmt.Printf("  config: %s\n", cfg.Source())
 	fmt.Printf("  SSH:        ssh -p %d localhost\n", cfg.Port)
 	if cfg.MetricsPort > 0 {
 		fmt.Printf("  Metrics:    http://localhost:%d/metrics\n", cfg.MetricsPort)
@@ -806,16 +806,6 @@ func main() {
 		slog.Error("server exited with error", "error", err)
 		os.Exit(1)
 	}
-}
-
-func configSource(path string, hasEmbedded bool) string {
-	if _, err := os.ReadFile(path); err == nil {
-		return "loaded " + path
-	}
-	if hasEmbedded {
-		return "using embedded openlore.yml"
-	}
-	return "defaults"
 }
 
 func inboxTokenCommand(args []string, stdout, stderr io.Writer, now func() time.Time) error {

--- a/cmd/openlore/main.go
+++ b/cmd/openlore/main.go
@@ -400,8 +400,9 @@ func main() {
 				files.Ignore = splitAndTrim(*mcpIgnore)
 			}
 
-			// Try loading config file for file filters
-			embeddedCfg, _ := assets.EmbeddedConfig()
+			// Try loading config file for file filters. A loaded file replaces the
+			// embedded config; the embedded config is used only when no file exists.
+			embeddedCfg, hasEmbeddedCfg := assets.EmbeddedConfig()
 			cfgOpts := []config.Option{
 				config.WithConfigFile(*mcpConfig),
 				config.WithEmbeddedConfig(embeddedCfg, ""),
@@ -409,6 +410,7 @@ func main() {
 			var resolvedCfg config.Config
 			if cfg, err := config.New(cfgOpts...); err == nil {
 				resolvedCfg = cfg
+				fmt.Fprintf(os.Stderr, "config: %s\n", configSource(*mcpConfig, hasEmbeddedCfg))
 				if len(files.Allowed) == 0 {
 					files.Allowed = cfg.Files.Allowed
 				}
@@ -666,12 +668,12 @@ func main() {
 		rootDir = absDir
 	}
 
-	// Build config options.
-	// 1. Config file (from disk)
-	// 2. Embedded config (from assets/config/openlore.yml, if present)
-	// 3. CLI flag overrides (always win)
-	// Using both a config file and embedded config is an error.
-	embeddedCfg, _ := assets.EmbeddedConfig()
+	// Build config options in precedence order.
+	// 1. Config file (from disk), replacing embedded config when loaded
+	// 2. Embedded config (from assets/config/openlore.yml, only without a file)
+	// 3. Built-in defaults
+	// CLI flag overrides are applied last and always win.
+	embeddedCfg, hasEmbeddedCfg := assets.EmbeddedConfig()
 	opts := []openlore.Option{
 		openlore.WithConfigFile(*configFile),
 		openlore.WithEmbeddedConfig(embeddedCfg, assets.DefaultMOTD()),
@@ -781,6 +783,7 @@ func main() {
 	} else if assets.Lore() != nil {
 		fmt.Printf("  Directory:  (embedded docs)\n")
 	}
+	fmt.Printf("  config: %s\n", configSource(*configFile, hasEmbeddedCfg))
 	fmt.Printf("  SSH:        ssh -p %d localhost\n", cfg.Port)
 	if cfg.MetricsPort > 0 {
 		fmt.Printf("  Metrics:    http://localhost:%d/metrics\n", cfg.MetricsPort)
@@ -803,6 +806,16 @@ func main() {
 		slog.Error("server exited with error", "error", err)
 		os.Exit(1)
 	}
+}
+
+func configSource(path string, hasEmbedded bool) string {
+	if _, err := os.ReadFile(path); err == nil {
+		return "loaded " + path
+	}
+	if hasEmbedded {
+		return "using embedded openlore.yml"
+	}
+	return "defaults"
 }
 
 func inboxTokenCommand(args []string, stdout, stderr io.Writer, now func() time.Time) error {

--- a/docs/configuration-and-identity.md
+++ b/docs/configuration-and-identity.md
@@ -7,6 +7,11 @@ and docset policy (`lore.json`).
 
 Create `openlore.yml` in the project root or pass `--config`:
 
+An explicitly loaded config file takes precedence over an embedded
+`openlore.yml` and replaces it rather than merging with it. If no file is
+loaded, OpenLore uses the embedded config when present, then built-in defaults;
+command-line flags always win.
+
 ```yaml
 version: "1"
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,9 @@ ssh -p 2222 localhost "cat /docs/api-reference.md"
 
 Use `--allowed '*.md,*.txt'` and `--ignore '.git,node_modules'` to constrain the
 served tree from the command line, or configure these rules in `openlore.yml`.
+An explicitly loaded `--config` file replaces (rather than merges with) an
+embedded `openlore.yml`; otherwise the embedded config takes precedence over
+built-in defaults. Command-line flags always win.
 
 ## Connect an agent
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,10 +98,8 @@ type Config struct {
 	// hence openlore.yml.
 	OIDCIssuers []OIDCIssuer
 
-	// Track sources for conflict detection.
-	configFileLoaded   bool
-	embeddedConfigUsed bool
-	warnings           []string
+	configFileLoaded bool
+	warnings         []string
 }
 
 type RulesConfig struct {
@@ -609,8 +607,9 @@ type filesYAML struct {
 	Ignore  []string `yaml:"ignore"`
 }
 
-// New creates a Config by applying options to the defaults.
-// Returns an error if both a config file and embedded config are used.
+// New creates a Config by applying options to the defaults. When WithConfigFile
+// precedes WithEmbeddedConfig, a loaded file replaces the embedded config.
+// Later options (typically CLI flags) take precedence over both.
 func New(opts ...Option) (Config, error) {
 	cfg := Config{
 		Port:                2222,
@@ -659,9 +658,6 @@ func New(opts ...Option) (Config, error) {
 		}
 	}
 
-	if cfg.configFileLoaded && cfg.embeddedConfigUsed {
-		return Config{}, errors.New("conflict: cannot use both a config file and embedded config")
-	}
 	if cfg.MCPEnabled && cfg.MCPRequireAuth != nil && *cfg.MCPRequireAuth && cfg.Tokens == nil {
 		return Config{}, errors.New("mcp.require_auth requires tokens to be configured")
 	}
@@ -669,9 +665,10 @@ func New(opts ...Option) (Config, error) {
 	return cfg, nil
 }
 
-// WithConfigFile loads configuration from a YAML file.
-// Fields in the file override defaults. If the file does not exist,
-// no error is returned and the config is unchanged.
+// WithConfigFile loads configuration from a YAML file. Fields in the file
+// override defaults. If the file does not exist, no error is returned and the
+// config is unchanged. Apply this option before WithEmbeddedConfig so a loaded
+// file replaces, rather than merges with, the embedded config.
 func WithConfigFile(path string) Option {
 	return func(cfg *Config) error {
 		data, err := os.ReadFile(path)
@@ -807,13 +804,16 @@ func applyTokensConfig(cfg *Config, tokens *AuthTokensConfig, oidc []OIDCIssuer)
 	}
 }
 
-// WithEmbeddedConfig loads config from an embedded YAML byte slice.
-// The MOTD fallback is set separately from the config fields.
+// WithEmbeddedConfig loads config from an embedded YAML byte slice when no
+// config file has been loaded. WithConfigFile must be applied first when both
+// options are used. The MOTD fallback is set separately from the config fields.
 func WithEmbeddedConfig(data []byte, motdFallback string) Option {
 	return func(cfg *Config) error {
-		if len(data) > 0 {
-			cfg.embeddedConfigUsed = true
+		if cfg.configFileLoaded {
+			return nil
+		}
 
+		if len(data) > 0 {
 			fc, warnings, err := decodeFileConfig(data)
 			if err != nil {
 				return fmt.Errorf("parsing embedded config: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,7 +99,23 @@ type Config struct {
 	OIDCIssuers []OIDCIssuer
 
 	configFileLoaded bool
+	configFilePath   string
+	embeddedLoaded   bool
 	warnings         []string
+}
+
+// Source describes where the configuration came from, for startup banners:
+// "loaded <path>" when WithConfigFile read a file, "using embedded openlore.yml"
+// when WithEmbeddedConfig applied an embedded config, otherwise "defaults".
+func (c Config) Source() string {
+	switch {
+	case c.configFileLoaded:
+		return "loaded " + c.configFilePath
+	case c.embeddedLoaded:
+		return "using embedded openlore.yml"
+	default:
+		return "defaults"
+	}
 }
 
 type RulesConfig struct {
@@ -686,6 +702,7 @@ func WithConfigFile(path string) Option {
 		cfg.warnings = append(cfg.warnings, warnings...)
 
 		cfg.configFileLoaded = true
+		cfg.configFilePath = path
 		if fc.Rules.Tokenizer != "" {
 			return errors.New("rules.tokenizer is not supported yet")
 		}
@@ -819,6 +836,7 @@ func WithEmbeddedConfig(data []byte, motdFallback string) Option {
 				return fmt.Errorf("parsing embedded config: %w", err)
 			}
 			cfg.warnings = append(cfg.warnings, warnings...)
+			cfg.embeddedLoaded = true
 
 			if fc.ConfigVersion != "" {
 				cfg.ConfigVersion = fc.ConfigVersion

--- a/internal/config/config_source_test.go
+++ b/internal/config/config_source_test.go
@@ -27,6 +27,9 @@ func TestConfigSourcePrecedence(t *testing.T) {
 		if cfg.MOTD != "" {
 			t.Fatalf("motd = %q, want empty (embedded fallback must be ignored)", cfg.MOTD)
 		}
+		if got, want := cfg.Source(), "loaded "+file; got != want {
+			t.Fatalf("Source() = %q, want %q", got, want)
+		}
 	})
 
 	t.Run("embedded config applies without file", func(t *testing.T) {
@@ -37,6 +40,9 @@ func TestConfigSourcePrecedence(t *testing.T) {
 		if cfg.Port != 3333 {
 			t.Fatalf("port = %d, want embedded value 3333", cfg.Port)
 		}
+		if got := cfg.Source(); got != "using embedded openlore.yml" {
+			t.Fatalf("Source() = %q, want %q", got, "using embedded openlore.yml")
+		}
 	})
 
 	t.Run("defaults apply without file or embedded config", func(t *testing.T) {
@@ -46,6 +52,19 @@ func TestConfigSourcePrecedence(t *testing.T) {
 		}
 		if cfg.Port != 2222 {
 			t.Fatalf("port = %d, want default 2222", cfg.Port)
+		}
+		if got := cfg.Source(); got != "defaults" {
+			t.Fatalf("Source() = %q, want %q", got, "defaults")
+		}
+	})
+
+	t.Run("empty embedded config counts as defaults", func(t *testing.T) {
+		cfg, err := New(WithConfigFile(filepath.Join(t.TempDir(), "missing.yml")), WithEmbeddedConfig(nil, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := cfg.Source(); got != "defaults" {
+			t.Fatalf("Source() = %q, want %q", got, "defaults")
 		}
 	})
 }

--- a/internal/config/config_source_test.go
+++ b/internal/config/config_source_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigSourcePrecedence(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "openlore.yml")
+	if err := os.WriteFile(file, []byte("debug: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	embedded := []byte("port: 3333\n")
+
+	t.Run("file replaces embedded config", func(t *testing.T) {
+		cfg, err := New(WithConfigFile(file), WithEmbeddedConfig(embedded, "embedded motd"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !cfg.Debug {
+			t.Fatal("file config was not applied")
+		}
+		if cfg.Port != 2222 {
+			t.Fatalf("port = %d, want default 2222 (embedded config must be ignored)", cfg.Port)
+		}
+		if cfg.MOTD != "" {
+			t.Fatalf("motd = %q, want empty (embedded fallback must be ignored)", cfg.MOTD)
+		}
+	})
+
+	t.Run("embedded config applies without file", func(t *testing.T) {
+		cfg, err := New(WithConfigFile(filepath.Join(t.TempDir(), "missing.yml")), WithEmbeddedConfig(embedded, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Port != 3333 {
+			t.Fatalf("port = %d, want embedded value 3333", cfg.Port)
+		}
+	})
+
+	t.Run("defaults apply without file or embedded config", func(t *testing.T) {
+		cfg, err := New()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Port != 2222 {
+			t.Fatalf("port = %d, want default 2222", cfg.Port)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the v0.6.0 startup failure when a public/release binary (which embeds `assets/config/openlore.yml`) is run with `--config` or finds `./openlore.yml`:

```text
error: invalid config: conflict: cannot use both a config file and embedded config
```

Configuration now resolves with this precedence:

1. an actually loaded config file (replaces, does not merge with, embedded config)
2. embedded `openlore.yml`
3. built-in defaults

CLI options are still applied last and always win. The same ordering is used by `openlore mcp`, and startup now reports the selected source (`config: loaded ...`, `config: using embedded openlore.yml`, or `config: defaults`). Option docs explicitly require `WithConfigFile` before `WithEmbeddedConfig` when both are supplied.

## Production impact

Production behavior is unchanged. `railpack.json` and the checked-in `railpack-plan.json` explicitly remove `assets/config/openlore.yml` before compiling. The runtime deploy input includes only the `out` binary, so the application working directory has no `openlore.yml` beside it. `fly.toml` mounts persistent storage at `/var/lib/openlore`, and the Railpack start command remains:

```text
./out --config /var/lib/openlore/config/openlore.yml
```

The container workflow builds that same `railpack-plan.json`; there is no Dockerfile or entrypoint that adds a working-directory config file.

## Tests

Added coverage for:

- file + embedded config: file wins and embedded-only port/MOTD values are ignored
- missing file + embedded config: embedded values apply
- neither source: built-in defaults apply

End-to-end smoke (binary includes the repository's embedded production config):

```sh
go build -o ./openlore ./cmd/openlore
./openlore --config /tmp/t.yml --http-port 0 --metrics-port 0 /tmp/openlore-e2e-docs
```

Decisive output before terminating the process:

```text
  config: loaded /tmp/t.yml
  SSH:        ssh -p 2222 localhost
{"level":"INFO","msg":"starting openlore","port":2222,"metrics_port":0,"allow_keyless":true}
```

## Verification

All commands passed (run inside the repository's Nix dev shell because Go is not on the orb's base PATH):

```sh
go vet ./...
go build ./...
GOOS=windows go build ./...
go test -race -count=1 ./...
go generate ./docs/... && git diff --exit-code docs/
```

Decisive output:

```text
go vet ./...: PASS
go build ./...: PASS
GOOS=windows go build ./...: PASS
ok  github.com/aakarim/go-openlore/internal/config  1.029s
ok  github.com/aakarim/go-openlore/pkg/openlore      3.633s
ok  github.com/aakarim/go-openlore/pkg/vfs           1.016s
go generate ./docs/... && git diff --exit-code docs/: PASS
```
