### PR TITLE
fix(http): apply mcp.require_auth to the JSON API as well as /mcp

### DIFF
--- a/assets/config/openlore.yml
+++ b/assets/config/openlore.yml
@@ -56,8 +56,9 @@ passkeys:
 # instance mints/verifies tokens), so it lives here, not in lore.json. Enabling
 # it mounts the OAuth flow (/authorize, /oauth/token), Dynamic Client
 # Registration (/register), and discovery (/.well-known/oauth-*), so OAuth-native
-# MCP clients (Claude Desktop, Cowork) can log in. MCP's require_auth setting
-# overrides the default posture inherited from lore.json's allow_keyless.
+# MCP clients (Claude Desktop, Cowork) can log in. The mcp.require_auth setting
+# governs both MCP-over-HTTP and the JSON API, overriding the default posture
+# inherited from lore.json's allow_keyless.
 # The ES256 signing key is generated on first boot under <data_dir>/auth/.
 tokens:
   issuer: https://openlore.sh

--- a/docs/configuration-and-identity.md
+++ b/docs/configuration-and-identity.md
@@ -80,6 +80,11 @@ mcp:
   require_auth: true
 ```
 
+If the resolved posture requires a token (`allow_keyless: false` inherited, or
+`require_auth: true`) but no `tokens` block is configured, `/mcp` and `/api`
+fail closed with 401 and the server logs a warning at startup. Configure
+`tokens`, or set `require_auth: false` to serve anonymous HTTP callers.
+
 ## Roles, docsets, and identities
 
 ```json

--- a/docs/configuration-and-identity.md
+++ b/docs/configuration-and-identity.md
@@ -70,7 +70,8 @@ Unknown SSH keys are controlled in `lore.json`:
 Keyless and unknown allowed callers use `guest`, which can receive only
 read-only grants.
 
-MCP-over-HTTP can inherit this posture or independently require OAuth:
+MCP-over-HTTP and the JSON API can inherit this posture or jointly require
+OAuth. The existing `mcp.require_auth` setting governs both HTTP transports:
 
 ```yaml
 mcp:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -129,8 +129,11 @@ mcp:
 `require_auth: true` forces OAuth login for both MCP-over-HTTP and the JSON API
 while retaining the separately configured SSH posture. `false` permits
 anonymous access to both HTTP transports. If omitted, both inherit the keyless
-posture. `--mcp-path /custom` changes the MCP path; MCP over HTTP requires the
-HTTP server to remain enabled.
+posture. When the posture requires a token but no `tokens` block is configured,
+both transports fail closed and answer every request with 401 (the server logs
+a warning at startup); configure `tokens` or set `require_auth: false`.
+`--mcp-path /custom` changes the MCP path; MCP over HTTP requires the HTTP
+server to remain enabled.
 
 The MCP server exposes:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -126,10 +126,11 @@ mcp:
   require_auth: true
 ```
 
-`require_auth: true` forces OAuth login for MCP while retaining the separately
-configured SSH posture. `false` permits anonymous MCP. If omitted, MCP inherits
-the keyless posture. `--mcp-path /custom` changes the path; MCP over HTTP
-requires the HTTP server to remain enabled.
+`require_auth: true` forces OAuth login for both MCP-over-HTTP and the JSON API
+while retaining the separately configured SSH posture. `false` permits
+anonymous access to both HTTP transports. If omitted, both inherit the keyless
+posture. `--mcp-path /custom` changes the MCP path; MCP over HTTP requires the
+HTTP server to remain enabled.
 
 The MCP server exposes:
 

--- a/docs/workload-identity-federation.md
+++ b/docs/workload-identity-federation.md
@@ -203,9 +203,10 @@ curl -X POST https://openlore.example/api/shell \
 ```
 
 Every call runs with the resolved identity's lore, capabilities, and home —
-identical to what that identity gets over SSH. A public/anonymous caller (no
-token) still works wherever anonymous SSH does, landing in the read-only
-`default` lore.
+identical to what that identity gets over SSH. When `mcp.require_auth` is false
+or omitted and anonymous SSH is allowed, a public/anonymous caller (no token)
+still works on both HTTP transports, landing in the read-only `default` lore.
+When `mcp.require_auth` is true, both `/mcp` and `/api` require a token.
 
 ## Relationship to the rest of auth
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,8 +85,10 @@ type Config struct {
 	// Tokens configures bearer-token issuance/verification for the MCP + HTTP
 	// API. This is server infrastructure (issuer identity, audience, signing
 	// key, TTLs) — not per-lore access policy — so it lives in openlore.yml
-	// alongside passkeys, not in lore.json. When nil, token auth is disabled
-	// and the MCP/HTTP endpoints behave as anonymous callers (Phase 0).
+	// alongside passkeys, not in lore.json. When nil, token auth is disabled:
+	// under a public posture the MCP/HTTP endpoints serve anonymous callers
+	// (Phase 0); under a token-required posture (HTTPAuthRequired) they fail
+	// closed with 401, since no caller can present a token.
 	Tokens  *AuthTokensConfig
 	Inbox   InboxConfig
 	Plugins PluginsConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,8 +45,8 @@ type Config struct {
 	MCPEnabled bool
 	MCPPath    string
 	// MCPRequireAuth overrides the SSH-derived authentication posture for the
-	// MCP endpoint. Nil inherits !AllowKeyless; true forces OAuth so clients
-	// such as Claude open the browser login flow.
+	// MCP and JSON API HTTP endpoints. Nil inherits !AllowKeyless; true forces
+	// OAuth so HTTP clients must authenticate.
 	MCPRequireAuth *bool
 	// APIEnabled controls whether the plain JSON HTTP API (backed by the MCP
 	// server) runs. Default true. It is mounted at APIPath on the HTTP server.
@@ -583,9 +583,11 @@ func applySkillsConfig(cfg *Config, in skillsPluginYAML) error {
 }
 
 type mcpYAML struct {
-	Enabled     *bool  `yaml:"enabled"`
-	Path        string `yaml:"path"`
-	RequireAuth *bool  `yaml:"require_auth"`
+	Enabled *bool  `yaml:"enabled"`
+	Path    string `yaml:"path"`
+	// RequireAuth governs bearer authentication for both MCP-over-HTTP and the
+	// JSON HTTP API. The setting remains under mcp for configuration compatibility.
+	RequireAuth *bool `yaml:"require_auth"`
 }
 
 type apiYAML struct {
@@ -662,7 +664,7 @@ func New(opts ...Option) (Config, error) {
 	if cfg.configFileLoaded && cfg.embeddedConfigUsed {
 		return Config{}, errors.New("conflict: cannot use both a config file and embedded config")
 	}
-	if cfg.MCPEnabled && cfg.MCPRequireAuth != nil && *cfg.MCPRequireAuth && cfg.Tokens == nil {
+	if (cfg.MCPEnabled || cfg.APIEnabled) && cfg.MCPRequireAuth != nil && *cfg.MCPRequireAuth && cfg.Tokens == nil {
 		return Config{}, errors.New("mcp.require_auth requires tokens to be configured")
 	}
 
@@ -1140,13 +1142,19 @@ func applyMCPConfig(cfg *Config, m *mcpYAML) {
 	}
 }
 
-// MCPAuthRequired resolves the MCP-specific override. When it is omitted, MCP
-// retains the historical behavior of mirroring the SSH keyless posture.
-func (cfg Config) MCPAuthRequired() bool {
+// HTTPAuthRequired resolves the authentication posture shared by MCP-over-HTTP
+// and the JSON HTTP API. When omitted, both mirror the SSH keyless posture.
+func (cfg Config) HTTPAuthRequired() bool {
 	if cfg.MCPRequireAuth != nil {
 		return *cfg.MCPRequireAuth
 	}
 	return !cfg.AllowKeyless
+}
+
+// MCPAuthRequired is kept for compatibility. Use HTTPAuthRequired for the
+// shared MCP-over-HTTP and JSON API posture.
+func (cfg Config) MCPAuthRequired() bool {
+	return cfg.HTTPAuthRequired()
 }
 
 // WithMCPPath sets the path the MCP-over-HTTP endpoint is mounted at on the

--- a/internal/config/mcp_test.go
+++ b/internal/config/mcp_test.go
@@ -26,8 +26,8 @@ tokens:
 	if !cfg.AllowKeyless {
 		t.Fatal("MCP override must not change the SSH keyless posture")
 	}
-	if !cfg.MCPAuthRequired() {
-		t.Fatal("MCPAuthRequired() = false, want true")
+	if !cfg.HTTPAuthRequired() {
+		t.Fatal("HTTPAuthRequired() = false, want true")
 	}
 }
 
@@ -36,16 +36,16 @@ func TestMCPRequireAuthDefaultsToKeylessPosture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.MCPAuthRequired() {
-		t.Fatal("MCPAuthRequired() = true for default keyless config, want false")
+	if cfg.HTTPAuthRequired() {
+		t.Fatal("HTTPAuthRequired() = true for default keyless config, want false")
 	}
 
 	cfg, err = New(WithAllowKeyless(false))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !cfg.MCPAuthRequired() {
-		t.Fatal("MCPAuthRequired() = false when keyless is disabled, want true")
+	if !cfg.HTTPAuthRequired() {
+		t.Fatal("HTTPAuthRequired() = false when keyless is disabled, want true")
 	}
 }
 
@@ -57,5 +57,17 @@ func TestMCPRequireAuthRequiresTokenIssuer(t *testing.T) {
 
 	if _, err := New(WithConfigFile(path)); err == nil {
 		t.Fatal("expected mcp.require_auth without tokens to be rejected")
+	}
+}
+
+func TestMCPRequireAuthRequiresTokenIssuerWhenOnlyAPIEnabled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "openlore.yml")
+	contents := []byte("mcp:\n  enabled: false\n  require_auth: true\napi:\n  enabled: true\n")
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New(WithConfigFile(path)); err == nil {
+		t.Fatal("expected mcp.require_auth without tokens to be rejected when the JSON API is enabled")
 	}
 }

--- a/openlore.yml.example
+++ b/openlore.yml.example
@@ -45,7 +45,8 @@ metrics_port: 3000
 mcp:
   enabled: true
   path: /mcp
-  # Force OAuth login even when lore.json allows keyless/anonymous access.
+  # Force OAuth login for MCP-over-HTTP and the JSON API even when lore.json
+  # allows keyless/anonymous access.
   # Omit this setting to inherit the SSH posture from allow_keyless.
   require_auth: true
 
@@ -149,7 +150,7 @@ host_key_path: .ssh/openlore_ed25519
 # lives here, not in lore.json (which is access policy). When omitted,
 # the MCP/HTTP endpoints serve anonymous callers (Phase 0). Posture
 # (public vs token-required) derives from lore.json's allow_keyless by default;
-# mcp.require_auth can override it for the MCP endpoint.
+# mcp.require_auth can override it for both HTTP transports.
 #
 # The ES256 signing key is generated on first boot under <data_dir>/auth/.
 # Public keys are published at /.well-known/jwks.json. Passkey login mints

--- a/openlore.yml.example
+++ b/openlore.yml.example
@@ -147,10 +147,12 @@ host_key_path: .ssh/openlore_ed25519
 #
 # Enable bearer-token auth for the MCP + HTTP API. This is SERVER
 # infrastructure — how this instance mints and verifies tokens — so it
-# lives here, not in lore.json (which is access policy). When omitted,
-# the MCP/HTTP endpoints serve anonymous callers (Phase 0). Posture
+# lives here, not in lore.json (which is access policy). Posture
 # (public vs token-required) derives from lore.json's allow_keyless by default;
-# mcp.require_auth can override it for both HTTP transports.
+# mcp.require_auth can override it for both HTTP transports. When this block
+# is omitted and the posture is public, /mcp and /api serve anonymous callers
+# (Phase 0); when it is omitted but the posture requires a token (allow_keyless:
+# false, or mcp.require_auth: true), those endpoints fail closed with 401.
 #
 # The ES256 signing key is generated on first boot under <data_dir>/auth/.
 # Public keys are published at /.well-known/jwks.json. Passkey login mints

--- a/pkg/openlore/auth_middleware.go
+++ b/pkg/openlore/auth_middleware.go
@@ -10,7 +10,12 @@ import (
 // The caller supplies whether a token is required so transports may override
 // the SSH-derived default.
 //
-//   - No issuer configured → no-op; callers resolve to anonymous (Phase 0).
+//   - No issuer configured, optional posture → no-op; callers resolve to
+//     anonymous (Phase 0).
+//   - No issuer configured, required posture → fail closed: there is no way to
+//     present a token, so every request gets 401. Serving anonymously here
+//     would silently widen a deployment whose SSH posture rejects keyless
+//     callers (allow_keyless: false) but which has not configured tokens.
 //   - Optional-token posture → verify a token if present (reject if invalid);
 //     if absent, proceed anonymously.
 //   - Required-token posture → a valid token is required; missing or invalid
@@ -21,7 +26,12 @@ import (
 // exactly as an SSH session (docs/mcp-bearer-auth.md §4, §6).
 func (s *Server) authMiddleware(next http.Handler, required bool) http.Handler {
 	if s.issuer == nil {
-		return next
+		if !required {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "authentication required, but this instance has no token issuer configured (set tokens in openlore.yml, or allow anonymous access with mcp.require_auth: false)", http.StatusUnauthorized)
+		})
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/openlore/mcp_http_api_test.go
+++ b/pkg/openlore/mcp_http_api_test.go
@@ -53,6 +53,40 @@ func TestMCPHTTPAPI_Shell(t *testing.T) {
 	}
 }
 
+func TestMCPHTTPAPI_RequireAuthPosture(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		requireAuth bool
+		wantStatus  int
+	}{
+		{name: "required", requireAuth: true, wantStatus: http.StatusUnauthorized},
+		{name: "optional", requireAuth: false, wantStatus: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTokenTestServer(t, true, "allow")
+			s.config.MCPRequireAuth = &tc.requireAuth
+			mcpServer := NewMCPServer(s.merge, withMCPShellFactory(s.shellForContext))
+			api := NewMCPHTTPAPI(mcpServer, s.shellForContext)
+			h := s.authMiddleware(api.Handler("/api"), s.config.HTTPAuthRequired())
+
+			req := httptest.NewRequest(http.MethodPost, "/api/shell", strings.NewReader(`{"command":"cat /public/hello.txt"}`))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.requireAuth {
+				if challenge := rec.Header().Get("WWW-Authenticate"); !strings.Contains(challenge, "resource_metadata=") {
+					t.Fatalf("WWW-Authenticate = %q, want OAuth resource metadata challenge", challenge)
+				}
+			} else if !strings.Contains(rec.Body.String(), "public") {
+				t.Fatalf("anonymous response %q does not contain public docset output", rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestMCPHTTPAPI_ShellMissingCommand(t *testing.T) {
 	h := newTestAPI(t)
 

--- a/pkg/openlore/mcp_http_api_test.go
+++ b/pkg/openlore/mcp_http_api_test.go
@@ -80,10 +80,49 @@ func TestMCPHTTPAPI_RequireAuthPosture(t *testing.T) {
 				if challenge := rec.Header().Get("WWW-Authenticate"); !strings.Contains(challenge, "resource_metadata=") {
 					t.Fatalf("WWW-Authenticate = %q, want OAuth resource metadata challenge", challenge)
 				}
-			} else if !strings.Contains(rec.Body.String(), "public") {
-				t.Fatalf("anonymous response %q does not contain public docset output", rec.Body.String())
+				return
+			}
+			var resp toolResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decoding response: %v; body=%s", err, rec.Body.String())
+			}
+			if resp.IsError {
+				t.Fatalf("unexpected is_error=true: %q", resp.Output)
+			}
+			if strings.TrimSpace(resp.Output) != "public" {
+				t.Fatalf("anonymous output = %q, want %q", resp.Output, "public")
 			}
 		})
+	}
+}
+
+// With allow_keyless: false and no tokens block, the resolved posture requires
+// a token that no caller can obtain. The middleware must fail closed rather
+// than fall through to anonymous access.
+func TestMCPHTTPAPI_RequiredPostureWithoutIssuerFailsClosed(t *testing.T) {
+	s := newTokenTestServer(t, false, "deny")
+	s.config.Tokens = nil
+	s.issuer = nil
+	if !s.config.HTTPAuthRequired() {
+		t.Fatal("HTTPAuthRequired() = false with allow_keyless: false, want true")
+	}
+
+	mcpServer := NewMCPServer(s.merge, withMCPShellFactory(s.shellForContext))
+	api := NewMCPHTTPAPI(mcpServer, s.shellForContext)
+	h := s.authMiddleware(api.Handler("/api"), s.config.HTTPAuthRequired())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/shell", strings.NewReader(`{"command":"cat /public/hello.txt"}`))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "no token issuer configured") {
+		t.Fatalf("body = %q, want an explanation that no token issuer is configured", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "public") {
+		t.Fatalf("body = %q leaked docset content without authentication", rec.Body.String())
 	}
 }
 

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -1566,7 +1566,7 @@ func (s *Server) ListenAndServe() error {
 				// Posture-aware bearer auth (§4): identity from a verified token
 				// (or anonymous) is placed on the request context, which the
 				// Streamable transport carries into the tool handler.
-				h := s.authMiddleware(mcpHandler, s.config.MCPAuthRequired())
+				h := s.authMiddleware(mcpHandler, s.config.HTTPAuthRequired())
 				httpCfg.ExtraHandlers[mcpPath] = h
 				httpCfg.ExtraHandlers[mcpPath+"/"] = h
 				s.logger.Info("MCP endpoint mounted", "path", mcpPath, "http_port", s.config.HTTPPort)
@@ -1578,7 +1578,7 @@ func (s *Server) ListenAndServe() error {
 			if s.config.APIEnabled && s.config.APIPath != "" {
 				apiPath := "/" + strings.Trim(s.config.APIPath, "/")
 				api := NewMCPHTTPAPI(mcpServer, s.shellForContext)
-				httpCfg.ExtraHandlers[apiPath+"/"] = s.authMiddleware(api.Handler(apiPath), !s.config.AllowKeyless)
+				httpCfg.ExtraHandlers[apiPath+"/"] = s.authMiddleware(api.Handler(apiPath), s.config.HTTPAuthRequired())
 				s.logger.Info("HTTP API mounted", "path", apiPath, "http_port", s.config.HTTPPort)
 			}
 

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -1555,6 +1555,17 @@ func (s *Server) ListenAndServe() error {
 				)
 			}
 
+			// Both bearer-token transports share one posture. If it requires a
+			// token but no issuer exists, authMiddleware fails closed (401 on
+			// every request); say so once at boot so the operator can either
+			// configure tokens or opt into anonymous access explicitly.
+			httpAuthRequired := s.config.HTTPAuthRequired()
+			if httpAuthRequired && s.issuer == nil && (s.config.MCPEnabled || s.config.APIEnabled) {
+				s.logger.Warn("HTTP auth posture requires a token but no token issuer is configured; /mcp and /api will reject every request with 401",
+					"allow_keyless", s.config.AllowKeyless,
+					"hint", "set tokens in openlore.yml, or set mcp.require_auth: false to allow anonymous access")
+			}
+
 			// Mount the MCP-over-HTTP (Streamable HTTP) endpoint on the HTTP
 			// server at the configured path, so it reuses the same port/TLS as
 			// the front page (and any load balancer rule fronting it).
@@ -1566,7 +1577,7 @@ func (s *Server) ListenAndServe() error {
 				// Posture-aware bearer auth (§4): identity from a verified token
 				// (or anonymous) is placed on the request context, which the
 				// Streamable transport carries into the tool handler.
-				h := s.authMiddleware(mcpHandler, s.config.HTTPAuthRequired())
+				h := s.authMiddleware(mcpHandler, httpAuthRequired)
 				httpCfg.ExtraHandlers[mcpPath] = h
 				httpCfg.ExtraHandlers[mcpPath+"/"] = h
 				s.logger.Info("MCP endpoint mounted", "path", mcpPath, "http_port", s.config.HTTPPort)
@@ -1578,7 +1589,7 @@ func (s *Server) ListenAndServe() error {
 			if s.config.APIEnabled && s.config.APIPath != "" {
 				apiPath := "/" + strings.Trim(s.config.APIPath, "/")
 				api := NewMCPHTTPAPI(mcpServer, s.shellForContext)
-				httpCfg.ExtraHandlers[apiPath+"/"] = s.authMiddleware(api.Handler(apiPath), s.config.HTTPAuthRequired())
+				httpCfg.ExtraHandlers[apiPath+"/"] = s.authMiddleware(api.Handler(apiPath), httpAuthRequired)
 				s.logger.Info("HTTP API mounted", "path", apiPath, "http_port", s.config.HTTPPort)
 			}
 


### PR DESCRIPTION
## Summary

- apply the resolved `mcp.require_auth` posture to both bearer-token HTTP transports (`/mcp` and `/api/...`)
- rename the config resolver to transport-neutral `HTTPAuthRequired`, retaining `MCPAuthRequired` as a compatibility alias
- document that the existing YAML key governs both transports and cover required/optional JSON API behavior

## Why

The MCP-over-HTTP mount honored `mcp.require_auth`, but the plain JSON API independently derived its posture from `allow_keyless`. With production-style configuration (`allow_keyless: true`, `unknown_identity: allow`, `mcp.require_auth: true`), anonymous MCP requests were challenged while anonymous `POST /api/shell` requests still executed read-only commands. As a result, setting `require_auth: true` did not actually force login across the bearer-token HTTP surface.

This is an intentional tightening for deployments with `mcp.require_auth: true`: anonymous callers of `/api` will now receive `401 Unauthorized` with a `WWW-Authenticate` challenge, matching `/mcp`. Deployments that explicitly set `require_auth: false`, or omit it while allowing keyless access, retain anonymous JSON API access.

## Follow-up (e25444d, from review)

Copilot noted that `HTTPAuthRequired()` can be true with `allow_keyless: false`, `require_auth` omitted and no `tokens` block, in which case `authMiddleware` was a no-op (`issuer == nil`) and silently allowed anonymous access. The middleware now **fails closed** in that state: every `/mcp` and `/api` request gets `401` with a message pointing at `tokens` / `mcp.require_auth: false`, and `ListenAndServe` logs one warning at boot. Second behaviour change to be aware of: deployments with `allow_keyless: false` and no `tokens` block go from anonymous HTTP access to 401 (SSH is unaffected).

The posture test now decodes `toolResponse` instead of matching a raw substring, and `TestMCPHTTPAPI_RequiredPostureWithoutIssuerFailsClosed` covers the new branch. Full gate set (vet, build, windows build, `go test -race -count=1 ./...`, `go generate ./docs/...` drift check) re-run and green.

## Documentation

Updated the configuration/identity guide, usage guide, workload identity federation guide, example YAML, and embedded production config comments to describe the shared posture.

## Verification

Because Go is not directly on PATH in the orb, each requested command was run through the repository's Nix dev shell:

- `nix --extra-experimental-features 'nix-command flakes' develop --command bash -c 'go vet ./...'`
- `nix --extra-experimental-features 'nix-command flakes' develop --command bash -c 'go build ./...'`
- `nix --extra-experimental-features 'nix-command flakes' develop --command bash -c 'GOOS=windows go build ./...'`
- `nix --extra-experimental-features 'nix-command flakes' develop --command bash -c 'go test -race -count=1 ./...'`
- `git add docs/ && nix --extra-experimental-features 'nix-command flakes' develop --command bash -c 'go generate ./docs/... && git diff --exit-code docs/'`
- `nix --extra-experimental-features 'nix-command flakes' develop --command bash -c 'go test ./pkg/openlore -run TestMCPHTTPAPI_RequireAuthPosture -v -count=1'`

All passed. The focused test passed both `required` and `optional` subtests; the full race suite passed all packages.

