### PR TITLE
Support direct file editing over SFTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ See [Installation](#installation) for more ways to install and package OpenLore.
 - **Agent-native retrieval** — Agents use the shell tools and composition
   patterns they already understand instead of learning a bespoke retrieval API.
 - **One knowledge surface, multiple transports** — Serve the same virtual
-  filesystem over SSH, SFTP/SSHFS, MCP, and a human-friendly web view.
+  filesystem over SSH, SFTP/SSHFS (including direct VS Code browsing and
+  editing), MCP, and a human-friendly web view.
 - **Live, governed knowledge** — Keep content read-only, allow scoped publishing,
   or enable full writes per docset. Writes are atomic, conflict-aware, and can
   require human approval.
@@ -205,8 +206,8 @@ Produce cross-platform binaries with your docs embedded:
     config: ./openlore.yml
 ```
 
-See [Ways to use OpenLore](docs/usage.md) for MCP stdio, MCPB desktop
-packaging, SSHFS, and Go library usage.
+See [Ways to use OpenLore](docs/usage.md) for direct VS Code editing, MCP stdio,
+MCPB desktop packaging, SSHFS, and Go library usage.
 
 ### Create a customized deployment
 
@@ -270,6 +271,7 @@ The container workflow publishes `latest` from `main`; releases also publish
 | Guide | Contents |
 |---|---|
 | [Ways to use OpenLore](docs/usage.md) | SSH, MCP, web, SSHFS, embedded binaries, GitHub Action, MCPB, and library usage |
+| [Editing OpenLore files](docs/editors.md) | Direct VS Code and SFTP editor setup without a local project mirror |
 | [Command reference](docs/commands.md) | Complete shell, introspection, publishing, syntax, CLI command, and flag reference |
 | [Configuration and identity](docs/configuration-and-identity.md) | `openlore.yml`, authentication, roles, docsets, aliases, homes, and host verification |
 | [HTTP inbox uploads](docs/inbox.md) | Upload documents with bearer or HMAC credentials |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,12 +62,15 @@ SSH transport is handled by [charmbracelet/ssh](https://github.com/charmbracelet
 
 ### 4. SFTP Subsystem
 
-The SFTP server provides read-only file access for `sshfs` mounting.
+The SFTP server provides filesystem access for direct editor integrations and
+read-only `sshfs` mounts.
 
-**Read-only enforcement:**
-- Write operations (`Create`, `Remove`, `Rename`, `Mkdir`, `Chmod`, etc.) return `os.ErrPermission`
-- Only `Open` (read), `ReadDir`, and `Stat` are functional
-- The SFTP handler wraps the same VFS used by the shell, so file filtering and path protection apply
+**Enforcement:**
+- `Open` (read), `ReadDir`, and `Stat` use the identity-scoped session VFS, so file filtering and path protection apply
+- A writable file handle stages offset writes privately and submits one atomic whole-file write when the handle closes
+- The commit passes through the same identity grants, admission middleware, validation, approvals, size limits, ordered write log, and compare-and-swap protection as shell writes
+- An interrupted transfer is discarded, and a concurrent change makes the close fail instead of overwriting newer content
+- Namespace and metadata operations (`Remove`, `Rename`, `Mkdir`, `Chmod`, etc.) remain unsupported and return permission denied
 
 ### 5. In-Memory Bash Interpreter
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -1,0 +1,99 @@
+# Editing OpenLore Files
+
+OpenLore exposes its virtual filesystem through SFTP, so a compatible editor
+can browse the remote directory tree and save individual files without cloning
+or synchronizing the whole tree into a local project folder. An editor may
+cache files while they are open, but OpenLore remains the source of truth.
+
+OpenLore is read-only by default. To save from an editor, the server must run
+with `readonly: false` (or `--readonly=false`). When authentication is enforced,
+the connected identity must also have an `rw` grant for the target docset. See
+[Writing and Publishing](writing.md) for configuration details. Read-only
+deployments and identities can still browse and open files.
+
+## VS Code
+
+Use an SFTP filesystem extension rather than Microsoft's **Remote - SSH**. For
+example, install
+[SFTP FS](https://marketplace.visualstudio.com/items?itemName=LewLie.sftpfs):
+
+```bash
+code --install-extension LewLie.sftpfs
+```
+
+Then:
+
+1. Verify the connection from a terminal, for example with
+   `ssh -p 2222 user@server`.
+2. In VS Code, open the Command Palette and run **SFTP FS: Add Remote**.
+3. Enter the same hostname, SSH port, username, and private key used by the
+   terminal connection. Set the remote path to `/` or to one docset such as
+   `/docs`.
+4. Connect from the SFTP FS view, expand the tree, and open a file. Saving the
+   editor writes that file directly back to OpenLore.
+
+SFTP FS saves an existing file using the SFTP operations OpenLore supports:
+stat, open with create/truncate, offset writes, and close. It does not need a
+remote shell, remote temporary file, or rename for an ordinary save.
+
+Microsoft's **Remote - SSH** extension is not compatible with OpenLore. It
+expects a general-purpose remote operating system where it can install and run
+VS Code Server, extensions, terminals, and port forwarding. OpenLore instead
+provides a restricted shell and virtual filesystem with no arbitrary process
+execution.
+
+## Other editors
+
+These editors can access individual files through SFTP without installing an
+editor server on the OpenLore host:
+
+| Editor | Platform | SFTP workflow |
+|---|---|---|
+| Vim or GVim with netrw | Windows, macOS, Linux | Open an `sftp://` file or directory |
+| [Nova](https://help.nova.app/remote-files/servers/) | macOS | Use its built-in SSH/SFTP remote sidebar |
+| [UltraEdit](https://www.ultraedit.com/support/tutorials-power-tips/ultraedit/configure-ftp/) | Windows, macOS, Linux | Use its built-in SFTP browser and remote open/save |
+| WinSCP's built-in editor | Windows | Open and save a file from an SFTP session |
+| Kate or KWrite through KDE KIO | Linux | Open an `sftp://` location |
+| Editors opened from GNOME Files/GVfs | Linux | Connect to an SFTP location and open an individual file |
+
+For Vim installations that include netrw, open a file with:
+
+```bash
+vim 'sftp://user@server:2222//docs/notes.md'
+```
+
+The second slash before `docs` selects an absolute remote path.
+
+Except for the documented VS Code workflow, these clients are not tested by
+the OpenLore project. Some editors implement a “safe save” by uploading a
+temporary file and renaming it over the destination. OpenLore does not currently
+support SFTP rename, so disable atomic/safe-save behavior if the editor offers
+that setting. A client that cannot save directly to the final path will not yet
+work.
+
+## Save behavior and limitations
+
+An SFTP save is staged privately and submitted when the file handle closes as
+one governed whole-file write. The same authorization, validation, approval,
+size-limit, ordered-write, and conflict checks used by shell writes still
+apply. An interrupted transfer is discarded. If a file changed after the
+editor opened it, the save fails rather than overwriting newer content; reload
+the latest version and retry the edit.
+
+Editors can update existing files and create files in existing folders.
+OpenLore deliberately rejects SFTP rename, directory creation, deletion, and
+metadata changes such as `chmod`. Continue to use OpenLore shell commands for
+governed namespace changes.
+
+## Troubleshooting
+
+- **Permission denied on save:** confirm `readonly: false` and, when
+  authentication is enforced, a named identity with an `rw` grant for the
+  target docset.
+- **Save fails after uploading:** the file may have changed concurrently or a
+  validation/approval rule may have rejected or deferred the write. Re-open the
+  file and inspect the server logs or pending requests.
+- **The editor can browse but not save:** check whether it uses a temporary
+  remote file followed by rename. Select direct overwrite or disable safe save.
+- **Remote - SSH tries to install VS Code Server:** use an SFTP filesystem
+  extension instead.

--- a/docs/shellm.md
+++ b/docs/shellm.md
@@ -121,7 +121,8 @@ growing `trajectory.jsonl` can instead append only new lines with `tee -a`,
 which is always a conflict-safe CAS append. Do **not** point
 `SHELLM_TRAJ_DIR` at an SSHFS mount of OpenLore: shellm's trajectory writer
 relies on `mkdir`-based locking and atomic renames that are not guaranteed
-over SFTP/FUSE (and OpenLore's SFTP interface is read-only).
+over SFTP/FUSE. OpenLore accepts governed whole-file SFTP saves but deliberately
+does not expose those namespace operations.
 
 ### Reading
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -177,9 +177,17 @@ go build -o openlore ./cmd/openlore
 If the binary does not contain embedded docs, installation prompts for a docs
 directory. Pass `--docs-dir ./docs` to bundle one during packaging.
 
+## Browse and edit with VS Code
+
+An SFTP filesystem extension can open OpenLore's directory tree directly in VS
+Code without cloning, mounting, or synchronizing it into a local project
+folder. Saving an editor writes the individual file back through OpenLore's
+governed write path. See [Editing OpenLore Files](editors.md) for VS Code setup,
+other compatible editors, save behavior, and limitations.
+
 ## Mount with SSHFS
 
-SFTP support lets editors and local tools mount the virtual filesystem:
+SFTP also lets local tools mount a read-only view of the virtual filesystem:
 
 ```bash
 mkdir -p /mnt/docs

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -632,6 +632,7 @@ func (s *Server) sftpSubsystem(sess ssh.Session) {
 	// outside their grants over SFTP.
 	id := s.resolveIdentity(sess)
 	handler := NewSFTPHandler(s.buildSessionFS(id))
+	handler.writesDisabled = s.config.Readonly
 	server := sftp.NewRequestServer(sess, sftp.Handlers{
 		FileGet:  handler,
 		FilePut:  handler,

--- a/pkg/openlore/sftp.go
+++ b/pkg/openlore/sftp.go
@@ -2,9 +2,13 @@ package openlore
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/aakarim/go-openlore/pkg/vfs"
@@ -13,7 +17,8 @@ import (
 
 // SFTPHandler implements the SFTP server interfaces using a vfs.FileSystem.
 type SFTPHandler struct {
-	fs vfs.FileSystem
+	fs             vfs.FileSystem
+	writesDisabled bool
 }
 
 // NewSFTPHandler creates a new SFTP handler backed by the given filesystem.
@@ -35,12 +40,64 @@ func (h *SFTPHandler) Fileread(r *sftp.Request) (io.ReaderAt, error) {
 	return bytes.NewReader(data), nil
 }
 
-// Filewrite rejects all write requests (read-only filesystem).
+// Filewrite stages an SFTP upload in memory. Closing the returned writer
+// commits the complete file through the same atomic, policy-controlled write
+// seam used by the shell.
 func (h *SFTPHandler) Filewrite(r *sftp.Request) (io.WriterAt, error) {
-	return nil, sftp.ErrSSHFxPermissionDenied
+	if h.writesDisabled {
+		return nil, os.ErrPermission
+	}
+	wfs, ok := h.fs.(vfs.WritableFS)
+	if !ok {
+		return nil, os.ErrPermission
+	}
+	if scope, ok := h.fs.(vfs.WriteScopeFS); ok && !scope.CanWrite(r.Filepath) {
+		return nil, os.ErrPermission
+	}
+
+	flags := r.Pflags()
+	info, statErr := h.fs.Stat(r.Filepath)
+	exists := statErr == nil
+	if exists && info.Dir {
+		return nil, os.ErrInvalid
+	}
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return nil, statErr
+	}
+	if exists && flags.Creat && flags.Excl {
+		return nil, os.ErrExist
+	}
+	if !exists && !flags.Creat {
+		return nil, os.ErrNotExist
+	}
+
+	var base []byte
+	if exists {
+		var err error
+		base, err = h.fs.ReadFile(r.Filepath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var data []byte
+	if !flags.Trunc {
+		data = base
+	}
+
+	return &sftpAtomicWriter{
+		fs:      wfs,
+		path:    r.Filepath,
+		data:    append([]byte(nil), data...),
+		base:    append([]byte(nil), base...),
+		existed: exists,
+		append:  flags.Append,
+		dirty:   flags.Trunc || !exists,
+	}, nil
 }
 
-// Filecmd rejects all file commands (read-only filesystem).
+// Filecmd rejects namespace and metadata changes. File contents are writable
+// through Filewrite, but OpenLore does not expose general SFTP filesystem
+// mutation semantics such as rename, chmod, or recursive deletion.
 func (h *SFTPHandler) Filecmd(r *sftp.Request) error {
 	return sftp.ErrSSHFxPermissionDenied
 }
@@ -105,4 +162,75 @@ func (l listAt) ListAt(ls []os.FileInfo, offset int64) (int, error) {
 		return n, io.EOF
 	}
 	return n, nil
+}
+
+// sftpAtomicWriter adapts SFTP's offset writes to OpenLore's whole-file atomic
+// write contract. pkg/sftp calls Close and returns its error to the client.
+type sftpAtomicWriter struct {
+	mu      sync.Mutex
+	fs      vfs.WritableFS
+	path    string
+	data    []byte
+	base    []byte
+	existed bool
+	append  bool
+	dirty   bool
+	closed  bool
+	aborted error
+}
+
+func (w *sftpAtomicWriter) WriteAt(p []byte, offset int64) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return 0, os.ErrClosed
+	}
+	if w.aborted != nil {
+		return 0, w.aborted
+	}
+	if w.append {
+		offset = int64(len(w.data))
+	}
+	if offset < 0 || offset > int64(^uint(0)>>1)-int64(len(p)) {
+		return 0, os.ErrInvalid
+	}
+	end := int(offset) + len(p)
+	if end > len(w.data) {
+		w.data = append(w.data, make([]byte, end-len(w.data))...)
+	}
+	copy(w.data[int(offset):], p)
+	w.dirty = true
+	return len(p), nil
+}
+
+func (w *sftpAtomicWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	if w.aborted != nil || !w.dirty {
+		return w.aborted
+	}
+
+	opts := vfs.WriteOpts{IfNoneMatch: !w.existed}
+	if w.existed {
+		sum := sha256.Sum256(w.base)
+		hash := hex.EncodeToString(sum[:])
+		opts.IfMatch = &hash
+	}
+	_, err := w.fs.WriteFileAtomic(w.path, w.data, opts)
+	if errors.Is(err, vfs.ErrReadOnly) {
+		return os.ErrPermission
+	}
+	return err
+}
+
+// TransferError prevents a partially transferred file from being committed if
+// the SFTP connection ends before the handle is closed normally.
+func (w *sftpAtomicWriter) TransferError(err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.aborted = err
 }

--- a/pkg/openlore/sftp.go
+++ b/pkg/openlore/sftp.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -14,6 +15,8 @@ import (
 	"github.com/aakarim/go-openlore/pkg/vfs"
 	"github.com/pkg/sftp"
 )
+
+const maxSFTPStagedFileBytes = int64(defaultMaxWriteBytes)
 
 // SFTPHandler implements the SFTP server interfaces using a vfs.FileSystem.
 type SFTPHandler struct {
@@ -44,6 +47,9 @@ func (h *SFTPHandler) Fileread(r *sftp.Request) (io.ReaderAt, error) {
 // commits the complete file through the same atomic, policy-controlled write
 // seam used by the shell.
 func (h *SFTPHandler) Filewrite(r *sftp.Request) (io.WriterAt, error) {
+	if r.Method != "Put" {
+		return nil, sftp.ErrSSHFxOpUnsupported
+	}
 	if h.writesDisabled {
 		return nil, os.ErrPermission
 	}
@@ -77,6 +83,9 @@ func (h *SFTPHandler) Filewrite(r *sftp.Request) (io.WriterAt, error) {
 		base, err = h.fs.ReadFile(r.Filepath)
 		if err != nil {
 			return nil, err
+		}
+		if int64(len(base)) > maxSFTPStagedFileBytes {
+			return nil, fmt.Errorf("write rejected: staged file exceeds limit of %d bytes", maxSFTPStagedFileBytes)
 		}
 	}
 	var data []byte
@@ -191,8 +200,8 @@ func (w *sftpAtomicWriter) WriteAt(p []byte, offset int64) (int, error) {
 	if w.append {
 		offset = int64(len(w.data))
 	}
-	if offset < 0 || offset > int64(^uint(0)>>1)-int64(len(p)) {
-		return 0, os.ErrInvalid
+	if offset < 0 || offset > maxSFTPStagedFileBytes || int64(len(p)) > maxSFTPStagedFileBytes-offset {
+		return 0, fmt.Errorf("write rejected: staged file exceeds limit of %d bytes", maxSFTPStagedFileBytes)
 	}
 	end := int(offset) + len(p)
 	if end > len(w.data) {

--- a/pkg/openlore/sftp_test.go
+++ b/pkg/openlore/sftp_test.go
@@ -139,6 +139,33 @@ func TestSFTPWriteCanBeDisabledForReadonlyServer(t *testing.T) {
 	}
 }
 
+func TestSFTPWriteRejectsUnexpectedMethod(t *testing.T) {
+	fsys := NewDirFS(t.TempDir(), config.FilesConfig{})
+	req := sftp.NewRequest("Get", "/note.md")
+	if _, err := NewSFTPHandler(fsys).Filewrite(req); !errors.Is(err, sftp.ErrSSHFxOpUnsupported) {
+		t.Fatalf("Filewrite error = %v, want unsupported operation", err)
+	}
+}
+
+func TestSFTPWriteRejectsOffsetBeyondStagingLimit(t *testing.T) {
+	fsys := NewDirFS(t.TempDir(), config.FilesConfig{})
+	if err := fsys.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	req := sftp.NewRequest("Put", "/note.md")
+	req.Flags = sftpWrite | sftpCreat | sftpTrunc
+	writer, err := NewSFTPHandler(fsys).Filewrite(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.WriteAt([]byte("x"), 1<<62); err == nil {
+		t.Fatal("oversized offset was accepted")
+	}
+	if got := len(writer.(*sftpAtomicWriter).data); got != 0 {
+		t.Fatalf("oversized offset allocated %d bytes", got)
+	}
+}
+
 func mustReadFile(t *testing.T, fsys vfs.FileSystem, path string) []byte {
 	t.Helper()
 	data, err := fsys.ReadFile(path)

--- a/pkg/openlore/sftp_test.go
+++ b/pkg/openlore/sftp_test.go
@@ -1,0 +1,149 @@
+package openlore
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aakarim/go-openlore/internal/config"
+	"github.com/aakarim/go-openlore/pkg/vfs"
+	"github.com/pkg/sftp"
+)
+
+const (
+	sftpWrite = 1 << 1
+	sftpCreat = 1 << 3
+	sftpTrunc = 1 << 4
+)
+
+func TestSFTPWriteCommitsCompleteFileOnClose(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "note.md"), []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewDirFS(dir, config.FilesConfig{})
+	if err := fsys.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+
+	req := sftp.NewRequest("Put", "/note.md")
+	req.Flags = sftpWrite | sftpTrunc
+	writer, err := NewSFTPHandler(fsys).Filewrite(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.WriteAt([]byte("world"), 6); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.WriteAt([]byte("hello "), 0); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(mustReadFile(t, fsys, "/note.md")); got != "original" {
+		t.Fatalf("write became visible before close: %q", got)
+	}
+	if err := writer.(io.Closer).Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(mustReadFile(t, fsys, "/note.md")); got != "hello world" {
+		t.Fatalf("committed content = %q", got)
+	}
+}
+
+func TestSFTPWriteCreatesEmptyFile(t *testing.T) {
+	fsys := NewDirFS(t.TempDir(), config.FilesConfig{})
+	if err := fsys.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	req := sftp.NewRequest("Put", "/empty.md")
+	req.Flags = sftpWrite | sftpCreat
+	writer, err := NewSFTPHandler(fsys).Filewrite(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.(io.Closer).Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustReadFile(t, fsys, "/empty.md"); len(got) != 0 {
+		t.Fatalf("empty file contains %q", got)
+	}
+}
+
+func TestSFTPWriteRejectsConcurrentChange(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "note.md")
+	if err := os.WriteFile(file, []byte("base"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fsys := NewDirFS(dir, config.FilesConfig{})
+	if err := fsys.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	req := sftp.NewRequest("Put", "/note.md")
+	req.Flags = sftpWrite | sftpTrunc
+	writer, err := NewSFTPHandler(fsys).Filewrite(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.WriteAt([]byte("editor"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("newer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = writer.(io.Closer).Close()
+	var conflict *vfs.PreconditionError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("close error = %v, want precondition error", err)
+	}
+	if got := string(mustReadFile(t, fsys, "/note.md")); got != "newer" {
+		t.Fatalf("concurrent content was overwritten: %q", got)
+	}
+}
+
+func TestSFTPWriteAbortsIncompleteTransfer(t *testing.T) {
+	fsys := NewDirFS(t.TempDir(), config.FilesConfig{})
+	if err := fsys.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	req := sftp.NewRequest("Put", "/partial.md")
+	req.Flags = sftpWrite | sftpCreat | sftpTrunc
+	writer, err := NewSFTPHandler(fsys).Filewrite(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.WriteAt([]byte("partial"), 0); err != nil {
+		t.Fatal(err)
+	}
+	writer.(*sftpAtomicWriter).TransferError(io.ErrUnexpectedEOF)
+	if err := writer.(io.Closer).Close(); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("close error = %v", err)
+	}
+	if _, err := fsys.Stat("/partial.md"); err == nil {
+		t.Fatal("partial transfer was committed")
+	}
+}
+
+func TestSFTPWriteCanBeDisabledForReadonlyServer(t *testing.T) {
+	fsys := NewDirFS(t.TempDir(), config.FilesConfig{})
+	if err := fsys.SetWriteable(); err != nil {
+		t.Fatal(err)
+	}
+	handler := NewSFTPHandler(fsys)
+	handler.writesDisabled = true
+	req := sftp.NewRequest("Put", "/note.md")
+	req.Flags = sftpWrite | sftpCreat | sftpTrunc
+	if _, err := handler.Filewrite(req); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("Filewrite error = %v, want permission denied", err)
+	}
+}
+
+func mustReadFile(t *testing.T, fsys vfs.FileSystem, path string) []byte {
+	t.Helper()
+	data, err := fsys.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}


### PR DESCRIPTION
## Summary

- add governed SFTP file writes that stage offset writes and commit atomically on close
- preserve read-only and identity-scoped authorization while rejecting interrupted or conflicting saves
- add `editors.md` with VS Code setup, other SFTP-capable editors, limitations, and troubleshooting
- link the editor guide from the README and usage docs

## Validation

- `go test ./...`