### PR TITLE
fix(history): migrate legacy commit journals

### DIFF
--- a/pkg/openlore/history.go
+++ b/pkg/openlore/history.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -76,6 +77,103 @@ type JSONLHistoryStore struct {
 
 func NewJSONLHistoryStore(dir string) *JSONLHistoryStore {
 	return &JSONLHistoryStore{dir: dir}
+}
+
+// legacyCommitRecord is the on-disk schema written to commits.jsonl before
+// history was split into a metadata journal and per-file shards.
+type legacyCommitRecord struct {
+	Time        time.Time     `json:"time"`
+	Attribution Attribution   `json:"attribution"`
+	ChangeSet   vfs.ChangeSet `json:"change_set"`
+	Hash        string        `json:"hash,omitempty"`
+}
+
+// migrateLegacy builds a complete replacement index when only the legacy
+// commit journal exists. events.jsonl is installed last and acts as the
+// completion marker: an interrupted migration is safely rebuilt on restart.
+func (s *JSONLHistoryStore) migrateLegacy() (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	eventsPath := filepath.Join(s.dir, "events.jsonl")
+	if _, err := os.Stat(eventsPath); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	legacyPath := filepath.Join(s.dir, "commits.jsonl")
+	legacy, err := os.Open(legacyPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer legacy.Close()
+
+	stagingDir := filepath.Join(s.dir, ".migration")
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Join(stagingDir, "files"), 0o700); err != nil {
+		return false, err
+	}
+	staging := NewJSONLHistoryStore(stagingDir)
+	decoder := json.NewDecoder(legacy)
+	for i := 0; ; i++ {
+		var commit legacyCommitRecord
+		if err := decoder.Decode(&commit); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return false, fmt.Errorf("decoding legacy history record %d: %w", i+1, err)
+		}
+		leaves := commit.ChangeSet.Leaves()
+		records := make([]HistoryRecord, 0, len(leaves))
+		for _, leaf := range leaves {
+			records = append(records, HistoryRecord{
+				Time: commit.Time, Attribution: commit.Attribution,
+				FileKey: vfs.CleanPath(leaf.Target), Action: string(leaf.Action), ContentHash: commit.Hash,
+			})
+		}
+		if err := staging.Record(context.Background(), records); err != nil {
+			return false, fmt.Errorf("building migrated history record %d: %w", i+1, err)
+		}
+	}
+	stagedEvents := filepath.Join(stagingDir, "events.jsonl")
+	if _, err := os.Stat(stagedEvents); errors.Is(err, os.ErrNotExist) {
+		if err := os.WriteFile(stagedEvents, nil, 0o600); err != nil {
+			return false, err
+		}
+	} else if err != nil {
+		return false, err
+	}
+
+	// A files directory without events.jsonl can only be an interrupted index
+	// build. Replace it, then publish the global journal as the final step.
+	filesPath := filepath.Join(s.dir, "files")
+	if err := os.RemoveAll(filesPath); err != nil {
+		return false, err
+	}
+	if err := os.Rename(filepath.Join(stagingDir, "files"), filesPath); err != nil {
+		return false, err
+	}
+	if err := os.Rename(stagedEvents, eventsPath); err != nil {
+		return false, err
+	}
+	if dir, err := os.Open(s.dir); err != nil {
+		return false, err
+	} else {
+		err = dir.Sync()
+		_ = dir.Close()
+		if err != nil {
+			return false, err
+		}
+	}
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *JSONLHistoryStore) Record(_ context.Context, records []HistoryRecord) error {

--- a/pkg/openlore/history.go
+++ b/pkg/openlore/history.go
@@ -158,22 +158,47 @@ func (s *JSONLHistoryStore) migrateLegacy() (bool, error) {
 	if err := os.Rename(filepath.Join(stagingDir, "files"), filesPath); err != nil {
 		return false, err
 	}
+	if err := syncHistoryDirectories(filesPath); err != nil {
+		return false, err
+	}
+	if err := syncDirectory(s.dir); err != nil {
+		return false, err
+	}
 	if err := os.Rename(stagedEvents, eventsPath); err != nil {
 		return false, err
 	}
-	if dir, err := os.Open(s.dir); err != nil {
+	if err := syncDirectory(s.dir); err != nil {
 		return false, err
-	} else {
-		err = dir.Sync()
-		_ = dir.Close()
-		if err != nil {
-			return false, err
-		}
 	}
 	if err := os.RemoveAll(stagingDir); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func syncHistoryDirectories(root string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		return syncDirectory(path)
+	})
+}
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	err = dir.Sync()
+	closeErr := dir.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
 }
 
 func (s *JSONLHistoryStore) Record(_ context.Context, records []HistoryRecord) error {

--- a/pkg/openlore/history_test.go
+++ b/pkg/openlore/history_test.go
@@ -5,13 +5,109 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/aakarim/go-openlore/internal/config"
 	"github.com/aakarim/go-openlore/pkg/vfs"
 )
+
+func TestServerStartupMigratesLegacyShellAndBrowserHistory(t *testing.T) {
+	dataDir := t.TempDir()
+	historyDir := filepath.Join(dataDir, "history")
+	if err := os.MkdirAll(historyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Date(2026, 8, 18, 10, 0, 0, 123, time.FixedZone("BST", 3600))
+	newTime := oldTime.Add(time.Hour)
+	attribution := Attribution{Principal: "alice", Actor: "agent", ClientAuth: AuthCIMD}
+	legacy := []legacyCommitRecord{
+		{
+			Time: oldTime, Attribution: attribution, Hash: "batch-hash",
+			ChangeSet: vfs.ChangeSet{Changes: []vfs.Change{
+				{Target: "/docs/note.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("old body")}},
+				{Target: "/docs/archive", Action: vfs.ChangeActionMkdir},
+			}},
+		},
+		{
+			Time: newTime, Attribution: Attribution{Principal: "bob"}, Hash: "new-hash",
+			ChangeSet: vfs.ChangeSet{Target: "/docs/note.md", Action: vfs.ChangeActionWrite, Write: &vfs.WriteChange{Bytes: []byte("new body")}},
+		},
+	}
+	f, err := os.OpenFile(filepath.Join(historyDir, "commits.jsonl"), os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoder := json.NewEncoder(f)
+	for _, record := range legacy {
+		if err := encoder.Encode(record); err != nil {
+			_ = f.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewServerWithRootFS(&wlRecordingFS{}, WithReadonly(false), config.WithDataDir(dataDir))
+	if err != nil {
+		t.Fatalf("NewServerWithRootFS: %v", err)
+	}
+	t.Cleanup(func() { _ = s.writeLog.Close(context.Background()) })
+
+	// The shell history backend reads the migrated global journal.
+	shellJSONL, err := (scopedHistory{store: s.history, roots: []string{"/docs"}}).Query("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var shellRecords []struct {
+		Attribution string `json:"attribution"`
+		Target      string `json:"target"`
+		Action      string `json:"action"`
+		Hash        string `json:"hash"`
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(shellJSONL)), "\n") {
+		var record struct {
+			Attribution string `json:"attribution"`
+			Target      string `json:"target"`
+			Action      string `json:"action"`
+			Hash        string `json:"hash"`
+		}
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatal(err)
+		}
+		shellRecords = append(shellRecords, record)
+	}
+	if len(shellRecords) != 3 {
+		t.Fatalf("shell history records=%d, want 3: %s", len(shellRecords), shellJSONL)
+	}
+	if got := []string{
+		shellRecords[0].Attribution + ":" + shellRecords[0].Target + ":" + shellRecords[0].Action + ":" + shellRecords[0].Hash,
+		shellRecords[1].Attribution + ":" + shellRecords[1].Target + ":" + shellRecords[1].Action + ":" + shellRecords[1].Hash,
+		shellRecords[2].Attribution + ":" + shellRecords[2].Target + ":" + shellRecords[2].Action + ":" + shellRecords[2].Hash,
+	}; !reflect.DeepEqual(got, []string{
+		"bob:/docs/note.md:write:new-hash",
+		"alice/agent:/docs/archive:mkdir:batch-hash",
+		"alice/agent:/docs/note.md:write:batch-hash",
+	}) {
+		t.Fatalf("shell history=%v", got)
+	}
+
+	// The browser callback uses a FileKey query, which must read its shard.
+	page, err := s.history.Query(context.Background(), HistoryQuery{FileKey: "/docs/note.md", Roots: []string{"/docs"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Records) != 2 || page.Records[0].ContentHash != "new-hash" || page.Records[1].ContentHash != "batch-hash" {
+		t.Fatalf("browser history=%+v", page.Records)
+	}
+	if !page.Records[1].Time.Equal(oldTime) || !reflect.DeepEqual(page.Records[1].Attribution, attribution) || page.Records[1].Action != string(vfs.ChangeActionWrite) {
+		t.Fatalf("migrated record did not preserve metadata: %+v", page.Records[1])
+	}
+}
 
 func TestHistoryRecordsExcludeWritePayloads(t *testing.T) {
 	content := []byte(strings.Repeat("private payload", 10_000))

--- a/pkg/openlore/server.go
+++ b/pkg/openlore/server.go
@@ -312,8 +312,16 @@ func newServerWithRoot(rootDir string, rootFS, lowerFS vfs.FileSystem, opts ...c
 		// substrate. Every session routes its mutations here (via middlewareFS),
 		// so it is the sole writer and gives globally ordered writes/removes. The
 		// applier runs the post-commit chain after each durable commit.
+		history := NewJSONLHistoryStore(filepath.Join(dataDir, "history"))
+		migrated, err := history.migrateLegacy()
+		if err != nil {
+			return nil, fmt.Errorf("migrating legacy history: %w", err)
+		}
+		if migrated {
+			logger.Info("legacy history migrated")
+		}
 		s.writeLog = newWriteLog(s.merge, s.postCommitChain(), logger, 0)
-		s.history = NewJSONLHistoryStore(filepath.Join(dataDir, "history"))
+		s.history = history
 		s.writeLog.SetHistoryRecorder(s.history)
 		s.writeLog.SetCommitState(rulesPlugin.CommitState)
 		s.writeLog.SetPreApply(func(identity *Identity, attribution Attribution, changes vfs.ChangeSet) error {


### PR DESCRIPTION
## Summary
- detect legacy `history/commits.jsonl` during writable server initialization when the new global index is absent
- convert every committed leaf into the metadata-only history schema while preserving timestamp, attribution, action, and legacy hash
- stage and durably install per-file shards before publishing `events.jsonl` as a resumable completion marker
- verify migrated data through both global shell history and per-file browser history paths

## Testing
- `nix develop --command go test ./...`