### PR TITLE
fix(shell): support attached cut option values

### DIFF
--- a/pkg/shell/cmds/cut.go
+++ b/pkg/shell/cmds/cut.go
@@ -47,7 +47,11 @@ func CmdCut(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io
 		}
 	}
 
-	positions := parsePositions(charPositions + fieldPositions)
+	positionsSpec := charPositions
+	if fieldPositions != "" {
+		positionsSpec = fieldPositions
+	}
+	positions := parsePositions(positionsSpec)
 	if len(positions) == 0 {
 		fmt.Fprintln(errW, "cut: you must specify a list of bytes, characters, or fields")
 		return 1

--- a/pkg/shell/cmds/cut.go
+++ b/pkg/shell/cmds/cut.go
@@ -34,18 +34,29 @@ func CmdCut(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io
 		case "-s":
 			suppress = true
 		default:
-			if !strings.HasPrefix(args[i], "-") {
+			switch {
+			case strings.HasPrefix(args[i], "-d") && len(args[i]) > 2:
+				delimiter = args[i][2:]
+			case strings.HasPrefix(args[i], "-c") && len(args[i]) > 2:
+				charPositions = args[i][2:]
+			case strings.HasPrefix(args[i], "-f") && len(args[i]) > 2:
+				fieldPositions = args[i][2:]
+			case !strings.HasPrefix(args[i], "-"):
 				files = append(files, args[i])
 			}
 		}
+	}
+
+	positions := parsePositions(charPositions + fieldPositions)
+	if len(positions) == 0 {
+		fmt.Fprintln(errW, "cut: you must specify a list of bytes, characters, or fields")
+		return 1
 	}
 
 	lines, code := ReadInputLines(ctx, files, stdin, errW, "cut")
 	if code != 0 {
 		return code
 	}
-
-	positions := parsePositions(charPositions + fieldPositions)
 
 	for _, line := range lines {
 		if fieldPositions != "" {

--- a/pkg/shell/cmds/cut_test.go
+++ b/pkg/shell/cmds/cut_test.go
@@ -20,3 +20,33 @@ func TestCutMultipleFields(t *testing.T) {
 		t.Errorf("cut -f 1,3: got %q", lines[0])
 	}
 }
+
+func TestCutAttachedOptionValues(t *testing.T) {
+	tests := []struct {
+		command string
+		want    string
+	}{
+		{"echo hello-world | cut -c1-5", "hello\n"},
+		{"echo hello-world | cut -d- -f1", "hello\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			out, errOut, code := execCmd(t, testFS(), tt.command)
+			if code != 0 || errOut != "" || out != tt.want {
+				t.Errorf("got stdout %q, stderr %q, exit %d; want stdout %q, empty stderr, exit 0", out, errOut, code, tt.want)
+			}
+		})
+	}
+}
+
+func TestCutRequiresPositions(t *testing.T) {
+	for _, command := range []string{"echo hello | cut", "echo hello | cut -c nope"} {
+		t.Run(command, func(t *testing.T) {
+			out, errOut, code := execCmd(t, testFS(), command)
+			if code != 1 || out != "" || errOut != "cut: you must specify a list of bytes, characters, or fields\n" {
+				t.Errorf("got stdout %q, stderr %q, exit %d", out, errOut, code)
+			}
+		})
+	}
+}

--- a/pkg/shell/cmds/cut_test.go
+++ b/pkg/shell/cmds/cut_test.go
@@ -40,6 +40,13 @@ func TestCutAttachedOptionValues(t *testing.T) {
 	}
 }
 
+func TestCutDoesNotCombineCharacterAndFieldPositions(t *testing.T) {
+	out, errOut, code := execCmd(t, testFS(), "echo a,b,c | cut -c1 -d, -f2")
+	if code != 0 || errOut != "" || out != "b\n" {
+		t.Errorf("got stdout %q, stderr %q, exit %d; want stdout %q, empty stderr, exit 0", out, errOut, code, "b\n")
+	}
+}
+
 func TestCutRequiresPositions(t *testing.T) {
 	for _, command := range []string{"echo hello | cut", "echo hello | cut -c nope"} {
 		t.Run(command, func(t *testing.T) {


### PR DESCRIPTION
## Linear issue

[OPE-4: shell: cut -cN-M / -dX / -fN (attached option values) silently produce no output](https://linear.app/lookc/issue/OPE-4/shell-cut-cn-m-dx-fn-attached-option-values-silently-produce-no-output)

## Diagnosis

`CmdCut` only recognized `-c`, `-d`, and `-f` when the value was a separate argument. Attached POSIX forms fell through as unknown option-like arguments, leaving the position list empty and returning success with no output.

## Fix

- Parse attached values for `-c`, `-d`, and `-f` while preserving the existing separated forms.
- Return exit 1 with a clear diagnostic when no character or field positions can be parsed.
- Add regression coverage for attached character, delimiter, and field values and missing/invalid lists.

## Verification

- `go test ./pkg/shell/cmds -run '^TestCut' -count=1`
- `go test -race ./...`
- `go vet ./...`

Implemented in [Amp child thread](https://ampcode.com/threads/T-01a07f9a-1cf0-71ed-b597-b6b67b6420c9).

## CI status

The `libghostty` check passed. The `build` check failed in unrelated `TestFolderRulesPermissionInheritanceInvalidationAndExemption`; all changed shell tests passed in that job, and the failing test passed locally with `-race -count=20`.
