### PR TITLE
fix(shell): support head and tail byte counts

### DIFF
--- a/pkg/shell/cmds/head.go
+++ b/pkg/shell/cmds/head.go
@@ -3,24 +3,54 @@ package cmds
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
 func CmdHead(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	n := 10
+	byteCount := -1
 	var files []string
 	for i := 0; i < len(args); i++ {
 		if args[i] == "-n" && i+1 < len(args) {
 			fmt.Sscanf(args[i+1], "%d", &n)
+			byteCount = -1
 			i++
+		} else if args[i] == "-c" {
+			if i+1 >= len(args) {
+				fmt.Fprintln(errW, "head: option requires an argument -- 'c'")
+				return 1
+			}
+			count, err := strconv.Atoi(args[i+1])
+			if err != nil || count < 0 {
+				fmt.Fprintf(errW, "head: invalid number of bytes: %s\n", args[i+1])
+				return 1
+			}
+			byteCount = count
+			i++
+		} else if strings.HasPrefix(args[i], "-c") && len(args[i]) > 2 {
+			count, err := strconv.Atoi(args[i][2:])
+			if err != nil || count < 0 {
+				fmt.Fprintf(errW, "head: invalid number of bytes: %s\n", args[i][2:])
+				return 1
+			}
+			byteCount = count
 		} else if strings.HasPrefix(args[i], "-") && len(args[i]) > 1 {
 			fmt.Sscanf(args[i][1:], "%d", &n)
+			byteCount = -1
 		} else {
 			files = append(files, args[i])
 		}
 	}
 	if len(files) == 0 && stdin != nil {
 		data, _ := io.ReadAll(stdin)
+		if byteCount >= 0 {
+			if byteCount > len(data) {
+				byteCount = len(data)
+			}
+			_, _ = w.Write(data[:byteCount])
+			return 0
+		}
 		lines := strings.SplitN(string(data), "\n", n+1)
 		if len(lines) > n {
 			lines = lines[:n]
@@ -38,6 +68,14 @@ func CmdHead(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin i
 		if err != nil {
 			fmt.Fprintf(errW, "head: %s: %s\n", f, err)
 			return 1
+		}
+		if byteCount >= 0 {
+			end := byteCount
+			if end > len(content) {
+				end = len(content)
+			}
+			_, _ = w.Write(content[:end])
+			continue
 		}
 		lines := strings.SplitN(string(content), "\n", n+1)
 		if len(lines) > n {

--- a/pkg/shell/cmds/head_test.go
+++ b/pkg/shell/cmds/head_test.go
@@ -12,3 +12,23 @@ func TestHead(t *testing.T) {
 		t.Errorf("head -n 2: got %d lines, want 2", len(lines))
 	}
 }
+
+func TestHeadBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{name: "stdin", cmd: "echo hello | head -c 3", want: "hel"},
+		{name: "file and attached count", cmd: "head -c7 /docs/readme.md", want: "# Hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, errOut, code := execCmd(t, testFS(), tt.cmd)
+			if code != 0 || errOut != "" || out != tt.want {
+				t.Errorf("code=%d stdout=%q stderr=%q, want code=0 stdout=%q stderr empty", code, out, errOut, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/shell/cmds/head_test.go
+++ b/pkg/shell/cmds/head_test.go
@@ -32,3 +32,25 @@ func TestHeadBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestHeadInvalidByteCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     string
+		wantErr string
+	}{
+		{name: "missing", cmd: "head -c", wantErr: "head: option requires an argument -- 'c'\n"},
+		{name: "non-numeric", cmd: "head -c nope", wantErr: "head: invalid number of bytes: nope\n"},
+		{name: "negative separated", cmd: "head -c -1", wantErr: "head: invalid number of bytes: -1\n"},
+		{name: "negative attached", cmd: "head -c-1", wantErr: "head: invalid number of bytes: -1\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, errOut, code := execCmd(t, testFS(), tt.cmd)
+			if code != 1 || out != "" || errOut != tt.wantErr {
+				t.Errorf("code=%d stdout=%q stderr=%q, want code=1 stdout empty stderr=%q", code, out, errOut, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/shell/cmds/tail.go
+++ b/pkg/shell/cmds/tail.go
@@ -3,24 +3,55 @@ package cmds
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 )
 
 func CmdTail(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin io.Reader) int {
 	n := 10
+	byteCount := -1
 	var files []string
 	for i := 0; i < len(args); i++ {
 		if args[i] == "-n" && i+1 < len(args) {
 			fmt.Sscanf(args[i+1], "%d", &n)
+			byteCount = -1
 			i++
+		} else if args[i] == "-c" {
+			if i+1 >= len(args) {
+				fmt.Fprintln(errW, "tail: option requires an argument -- 'c'")
+				return 1
+			}
+			count, err := strconv.Atoi(args[i+1])
+			if err != nil || count < 0 {
+				fmt.Fprintf(errW, "tail: invalid number of bytes: %s\n", args[i+1])
+				return 1
+			}
+			byteCount = count
+			i++
+		} else if strings.HasPrefix(args[i], "-c") && len(args[i]) > 2 {
+			count, err := strconv.Atoi(args[i][2:])
+			if err != nil || count < 0 {
+				fmt.Fprintf(errW, "tail: invalid number of bytes: %s\n", args[i][2:])
+				return 1
+			}
+			byteCount = count
 		} else if strings.HasPrefix(args[i], "-") && len(args[i]) > 1 {
 			fmt.Sscanf(args[i][1:], "%d", &n)
+			byteCount = -1
 		} else {
 			files = append(files, args[i])
 		}
 	}
 	if len(files) == 0 && stdin != nil {
 		data, _ := io.ReadAll(stdin)
+		if byteCount >= 0 {
+			start := len(data) - byteCount
+			if start < 0 {
+				start = 0
+			}
+			_, _ = w.Write(data[start:])
+			return 0
+		}
 		lines := strings.Split(string(data), "\n")
 		if len(lines) > n {
 			lines = lines[len(lines)-n:]
@@ -38,6 +69,14 @@ func CmdTail(ctx CmdContext, args []string, w io.Writer, errW io.Writer, stdin i
 		if err != nil {
 			fmt.Fprintf(errW, "tail: %s: %s\n", f, err)
 			return 1
+		}
+		if byteCount >= 0 {
+			start := len(content) - byteCount
+			if start < 0 {
+				start = 0
+			}
+			_, _ = w.Write(content[start:])
+			continue
 		}
 		lines := strings.Split(string(content), "\n")
 		if len(lines) > n {

--- a/pkg/shell/cmds/tail_test.go
+++ b/pkg/shell/cmds/tail_test.go
@@ -20,3 +20,23 @@ func TestTailPipe(t *testing.T) {
 		t.Errorf("tail pipe: got %q", out)
 	}
 }
+
+func TestTailBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{name: "stdin", cmd: "echo hello | tail -c 3", want: "lo\n"},
+		{name: "file and attached count", cmd: "tail -c6 /docs/readme.md", want: "ine 5\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, errOut, code := execCmd(t, testFS(), tt.cmd)
+			if code != 0 || errOut != "" || out != tt.want {
+				t.Errorf("code=%d stdout=%q stderr=%q, want code=0 stdout=%q stderr empty", code, out, errOut, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/shell/cmds/tail_test.go
+++ b/pkg/shell/cmds/tail_test.go
@@ -40,3 +40,25 @@ func TestTailBytes(t *testing.T) {
 		})
 	}
 }
+
+func TestTailInvalidByteCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     string
+		wantErr string
+	}{
+		{name: "missing", cmd: "tail -c", wantErr: "tail: option requires an argument -- 'c'\n"},
+		{name: "non-numeric", cmd: "tail -c nope", wantErr: "tail: invalid number of bytes: nope\n"},
+		{name: "negative separated", cmd: "tail -c -1", wantErr: "tail: invalid number of bytes: -1\n"},
+		{name: "negative attached", cmd: "tail -c-1", wantErr: "tail: invalid number of bytes: -1\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, errOut, code := execCmd(t, testFS(), tt.cmd)
+			if code != 1 || out != "" || errOut != tt.wantErr {
+				t.Errorf("code=%d stdout=%q stderr=%q, want code=1 stdout empty stderr=%q", code, out, errOut, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Linear

[OPE-5](https://linear.app/lookc/issue/OPE-5/shell-head-c-tail-c-treat-the-byte-count-as-a-file-path-access-denied)

## Diagnosis

The `head` and `tail` argument parsers treated every non-numeric `-...` argument as the legacy line-count shorthand. Parsing `-c` as an integer failed silently, so the following byte count fell through as a filename and produced a misleading access-denied error.

## Fix

- Support both `-c N` and `-cN` for `head` and `tail`.
- Write the selected bytes directly, preserving exact output without adding a newline.
- Validate missing, non-numeric, and negative byte counts.
- Add regression tests for piped and file input, covering separated and attached option forms.

## Verification

- `go test ./pkg/shell/cmds -run 'Test(Head|Tail)Bytes' -count=1`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

All checks pass.

Implementation thread: https://ampcode.com/threads/T-01a08676-7b62-719c-a24b-73da91b41701
