### PR TITLE
fix(oauth): preserve sessions on stale refresh retries

### DIFF
--- a/docs/authenticated-oauth-clients.md
+++ b/docs/authenticated-oauth-clients.md
@@ -59,5 +59,7 @@ chain, while already-issued access tokens expire at their normal short TTL.
 Access tokens last one hour by default. Refresh tokens rotate on use. OpenLore
 returns the same successor refresh token when a client retries within two minutes,
 so a lost response or concurrent reconnect does not revoke an otherwise valid
-session. A later retry is rejected without revoking the current refresh token,
-which lets another client worker continue using the valid session.
+session. For clients authenticated with `private_key_jwt`, a later stale retry is
+rejected without revoking the current refresh token, which lets another authenticated
+client worker continue using the valid session. Public-client reuse still revokes
+the full refresh chain as required for rotation-based replay detection.

--- a/docs/authenticated-oauth-clients.md
+++ b/docs/authenticated-oauth-clients.md
@@ -57,6 +57,7 @@ posting their refresh token to `/oauth/revoke`; OpenLore revokes the full refres
 chain, while already-issued access tokens expire at their normal short TTL.
 
 Access tokens last one hour by default. Refresh tokens rotate on use. OpenLore
-returns the same successor refresh token when a client retries within 30 seconds,
+returns the same successor refresh token when a client retries within two minutes,
 so a lost response or concurrent reconnect does not revoke an otherwise valid
-session. Reuse after that grace period still revokes the full refresh chain.
+session. A later retry is rejected without revoking the current refresh token,
+which lets another client worker continue using the valid session.

--- a/pkg/openlore/refreshstore.go
+++ b/pkg/openlore/refreshstore.go
@@ -10,18 +10,22 @@ import (
 	"time"
 )
 
+// ErrRefreshReuse signals that an already-used refresh token was presented by
+// a public client when it could no longer be handled as an idempotent retry.
+// The store revokes the whole chain when this happens.
+var ErrRefreshReuse = errors.New("refresh token reuse detected")
+
 // ErrRefreshInvalid signals an unknown or expired refresh token.
 var ErrRefreshInvalid = errors.New("invalid refresh token")
 
 // ErrRefreshStaleRetry signals that an already-used refresh token can no longer
-// return its successor. The current chain remains valid and is not revoked.
+// return its successor. Authenticated clients retain their current chain because
+// client authentication already binds the refresh token to that client.
 var ErrRefreshStaleRetry = errors.New("stale refresh retry")
 
 // refreshRetryGrace lets an OAuth client safely retry a refresh request whose
 // response was lost, or issue concurrent refreshes during reconnect. Both
-// requests receive the same successor refresh token. Later retries are rejected
-// without revoking the current token, because distributed clients can retain an
-// older token after another worker has completed rotation.
+// requests receive the same successor refresh token.
 const refreshRetryGrace = 2 * time.Minute
 
 // RefreshToken is a stateful, revocable credential. Tokens in the same ChainID
@@ -46,7 +50,7 @@ type RefreshRotation struct {
 	Retried bool
 }
 
-// RefreshTokenStore persists refresh tokens with rotation and stale-retry detection.
+// RefreshTokenStore persists refresh tokens with rotation and reuse detection.
 // The flat-file default lives in DataDir; knowledge-backend supplies a SQLite
 // implementation (docs/mcp-bearer-auth.md §9).
 type RefreshTokenStore interface {
@@ -55,8 +59,8 @@ type RefreshTokenStore interface {
 	// Lookup returns the token if present.
 	Lookup(token string) (RefreshToken, bool, error)
 	// Rotate consumes oldToken and stores newToken (same chain) atomically.
-	// Immediate retries return the previously stored successor. Later retries
-	// return ErrRefreshStaleRetry without revoking the current chain;
+	// Immediate retries return the previously stored successor. Stale retries by
+	// authenticated clients preserve the chain; reuse by public clients revokes it.
 	// unknown or expired tokens return ErrRefreshInvalid.
 	Rotate(oldToken string, newToken RefreshToken) (RefreshRotation, error)
 	// RevokeChain deletes every token descending from one login.
@@ -129,14 +133,21 @@ func (s *fileRefreshStore) Rotate(oldToken string, newToken RefreshToken) (Refre
 		elapsed := time.Since(old.RotatedAt)
 		if elapsed >= 0 && elapsed <= refreshRetryGrace {
 			if successor, ok := s.tokens[old.ReplacedBy]; ok {
-				if successor.Used || (!successor.ExpiresAt.IsZero() && successor.ExpiresAt.Before(time.Now())) {
-					return RefreshRotation{}, ErrRefreshStaleRetry
+				if !successor.Used && (successor.ExpiresAt.IsZero() || !successor.ExpiresAt.Before(time.Now())) {
+					return RefreshRotation{Token: successor, Retried: true}, nil
 				}
-				return RefreshRotation{Token: successor, Retried: true}, nil
 			}
+		}
+		if newToken.ClientAuth == AuthPrivateKeyJWT || newToken.ClientAuth == AuthPrivateKeyJWTMTLS {
 			return RefreshRotation{}, ErrRefreshStaleRetry
 		}
-		return RefreshRotation{}, ErrRefreshStaleRetry
+		// Public clients rely on rotation for replay detection. Once this can no
+		// longer be an idempotent retry, revoke the active token per RFC 9700.
+		s.revokeChainLocked(old.ChainID)
+		if err := s.persist(); err != nil {
+			return RefreshRotation{}, err
+		}
+		return RefreshRotation{}, ErrRefreshReuse
 	}
 	if !old.ExpiresAt.IsZero() && old.ExpiresAt.Before(time.Now()) {
 		delete(s.tokens, oldToken)

--- a/pkg/openlore/refreshstore.go
+++ b/pkg/openlore/refreshstore.go
@@ -10,22 +10,18 @@ import (
 	"time"
 )
 
-// ErrRefreshReuse signals that an already-used refresh token was presented
-// outside the short retry window. The store revokes the whole chain when this
-// happens.
-var ErrRefreshReuse = errors.New("refresh token reuse detected")
-
 // ErrRefreshInvalid signals an unknown or expired refresh token.
 var ErrRefreshInvalid = errors.New("invalid refresh token")
 
-// ErrRefreshStaleRetry signals that an immediate retry's successor has already
-// been consumed or expired. The current chain remains valid and is not revoked.
+// ErrRefreshStaleRetry signals that an already-used refresh token can no longer
+// return its successor. The current chain remains valid and is not revoked.
 var ErrRefreshStaleRetry = errors.New("stale refresh retry")
 
 // refreshRetryGrace lets an OAuth client safely retry a refresh request whose
 // response was lost, or issue concurrent refreshes during reconnect. Both
-// requests receive the same successor refresh token. Reuse after this window
-// remains a theft signal and revokes the chain.
+// requests receive the same successor refresh token. Later retries are rejected
+// without revoking the current token, because distributed clients can retain an
+// older token after another worker has completed rotation.
 const refreshRetryGrace = 2 * time.Minute
 
 // RefreshToken is a stateful, revocable credential. Tokens in the same ChainID
@@ -50,7 +46,7 @@ type RefreshRotation struct {
 	Retried bool
 }
 
-// RefreshTokenStore persists refresh tokens with rotation and reuse detection.
+// RefreshTokenStore persists refresh tokens with rotation and stale-retry detection.
 // The flat-file default lives in DataDir; knowledge-backend supplies a SQLite
 // implementation (docs/mcp-bearer-auth.md §9).
 type RefreshTokenStore interface {
@@ -59,9 +55,9 @@ type RefreshTokenStore interface {
 	// Lookup returns the token if present.
 	Lookup(token string) (RefreshToken, bool, error)
 	// Rotate consumes oldToken and stores newToken (same chain) atomically.
-	// Immediate retries return the previously stored successor. Reuse outside
-	// the retry window revokes the chain and returns ErrRefreshReuse;
-	// unknown/expired tokens return ErrRefreshInvalid.
+	// Immediate retries return the previously stored successor. Later retries
+	// return ErrRefreshStaleRetry without revoking the current chain;
+	// unknown or expired tokens return ErrRefreshInvalid.
 	Rotate(oldToken string, newToken RefreshToken) (RefreshRotation, error)
 	// RevokeChain deletes every token descending from one login.
 	RevokeChain(chainID string) error
@@ -140,12 +136,7 @@ func (s *fileRefreshStore) Rotate(oldToken string, newToken RefreshToken) (Refre
 			}
 			return RefreshRotation{}, ErrRefreshStaleRetry
 		}
-		// Reuse of a rotated token → theft. Revoke the whole chain.
-		s.revokeChainLocked(old.ChainID)
-		if err := s.persist(); err != nil {
-			return RefreshRotation{}, err
-		}
-		return RefreshRotation{}, ErrRefreshReuse
+		return RefreshRotation{}, ErrRefreshStaleRetry
 	}
 	if !old.ExpiresAt.IsZero() && old.ExpiresAt.Before(time.Now()) {
 		delete(s.tokens, oldToken)

--- a/pkg/openlore/refreshstore_test.go
+++ b/pkg/openlore/refreshstore_test.go
@@ -116,27 +116,29 @@ func TestRefreshStore_StaleRetryDoesNotRevokeCurrentChain(t *testing.T) {
 	}
 }
 
-func TestRefreshStore_ReuseAfterGraceRevokesChain(t *testing.T) {
+func TestRefreshStore_DelayedRetryDoesNotRevokeCurrentChain(t *testing.T) {
 	rs := testRefreshStore(t)
-	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
-	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+	expires := time.Now().Add(time.Hour)
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "current", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
 		t.Fatal(err)
 	}
 	old := rs.tokens["old"]
 	old.RotatedAt = time.Now().Add(-refreshRetryGrace - time.Second)
 	rs.tokens["old"] = old
 
-	// Re-presenting the used token after the retry grace is theft → revoke.
-	_, err := rs.Rotate("old", RefreshToken{Token: "attacker", Subject: "alice", ChainID: "c1", ExpiresAt: time.Now().Add(time.Hour)})
-	if !errors.Is(err, ErrRefreshReuse) {
-		t.Fatalf("expected ErrRefreshReuse, got %v", err)
+	_, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	if !errors.Is(err, ErrRefreshStaleRetry) {
+		t.Fatalf("expected ErrRefreshStaleRetry, got %v", err)
 	}
-	// The entire chain is revoked: the previously-valid "new" is gone.
-	if _, ok, _ := rs.Lookup("new"); ok {
-		t.Fatalf("reuse must revoke the whole chain; 'new' still present")
+	if current, ok, _ := rs.Lookup("current"); !ok || current.Used {
+		t.Fatalf("delayed retry revoked current token: ok=%v token=%+v", ok, current)
 	}
-	if _, ok, _ := rs.Lookup("attacker"); ok {
-		t.Fatalf("attacker token must not be stored")
+	if _, err := rs.Rotate("current", RefreshToken{Token: "next", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+		t.Fatalf("current chain is unusable after delayed retry: %v", err)
+	}
+	if _, ok, _ := rs.Lookup("discarded"); ok {
+		t.Fatal("retry candidate must not be stored")
 	}
 }
 

--- a/pkg/openlore/refreshstore_test.go
+++ b/pkg/openlore/refreshstore_test.go
@@ -93,52 +93,72 @@ func TestRefreshStore_RetryAfterClientBackoffReturnsSameSuccessor(t *testing.T) 
 	}
 }
 
-func TestRefreshStore_StaleRetryDoesNotRevokeCurrentChain(t *testing.T) {
+func TestRefreshStore_AuthenticatedClientStaleRetryDoesNotRevokeCurrentChain(t *testing.T) {
 	rs := testRefreshStore(t)
 	expires := time.Now().Add(time.Hour)
-	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
-	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := rs.Rotate("new", RefreshToken{Token: "newest", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+	if _, err := rs.Rotate("new", RefreshToken{Token: "newest", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires}); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	_, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires})
 	if !errors.Is(err, ErrRefreshStaleRetry) {
 		t.Fatalf("expected ErrRefreshStaleRetry, got %v", err)
 	}
 	if current, ok, _ := rs.Lookup("newest"); !ok || current.Used {
 		t.Fatalf("stale retry revoked current token: ok=%v token=%+v", ok, current)
 	}
-	if _, err := rs.Rotate("newest", RefreshToken{Token: "next", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+	if _, err := rs.Rotate("newest", RefreshToken{Token: "next", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires}); err != nil {
 		t.Fatalf("current chain is unusable after stale retry: %v", err)
 	}
 }
 
-func TestRefreshStore_DelayedRetryDoesNotRevokeCurrentChain(t *testing.T) {
+func TestRefreshStore_AuthenticatedClientDelayedRetryDoesNotRevokeCurrentChain(t *testing.T) {
 	rs := testRefreshStore(t)
 	expires := time.Now().Add(time.Hour)
-	rs.Save(RefreshToken{Token: "old", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
-	if _, err := rs.Rotate("old", RefreshToken{Token: "current", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "current", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires}); err != nil {
 		t.Fatal(err)
 	}
 	old := rs.tokens["old"]
 	old.RotatedAt = time.Now().Add(-refreshRetryGrace - time.Second)
 	rs.tokens["old"] = old
 
-	_, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ChainID: "c1", ExpiresAt: expires})
+	_, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires})
 	if !errors.Is(err, ErrRefreshStaleRetry) {
 		t.Fatalf("expected ErrRefreshStaleRetry, got %v", err)
 	}
 	if current, ok, _ := rs.Lookup("current"); !ok || current.Used {
 		t.Fatalf("delayed retry revoked current token: ok=%v token=%+v", ok, current)
 	}
-	if _, err := rs.Rotate("current", RefreshToken{Token: "next", Subject: "alice", ChainID: "c1", ExpiresAt: expires}); err != nil {
+	if _, err := rs.Rotate("current", RefreshToken{Token: "next", Subject: "alice", ClientAuth: AuthPrivateKeyJWT, ChainID: "c1", ExpiresAt: expires}); err != nil {
 		t.Fatalf("current chain is unusable after delayed retry: %v", err)
 	}
 	if _, ok, _ := rs.Lookup("discarded"); ok {
 		t.Fatal("retry candidate must not be stored")
+	}
+}
+
+func TestRefreshStore_PublicClientStaleRetryRevokesChain(t *testing.T) {
+	rs := testRefreshStore(t)
+	expires := time.Now().Add(time.Hour)
+	rs.Save(RefreshToken{Token: "old", Subject: "alice", ClientAuth: AuthCIMD, ChainID: "c1", ExpiresAt: expires})
+	if _, err := rs.Rotate("old", RefreshToken{Token: "new", Subject: "alice", ClientAuth: AuthCIMD, ChainID: "c1", ExpiresAt: expires}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rs.Rotate("new", RefreshToken{Token: "current", Subject: "alice", ClientAuth: AuthCIMD, ChainID: "c1", ExpiresAt: expires}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := rs.Rotate("old", RefreshToken{Token: "discarded", Subject: "alice", ClientAuth: AuthCIMD, ChainID: "c1", ExpiresAt: expires})
+	if !errors.Is(err, ErrRefreshReuse) {
+		t.Fatalf("expected ErrRefreshReuse, got %v", err)
+	}
+	if _, ok, _ := rs.Lookup("current"); ok {
+		t.Fatal("public-client token reuse must revoke the active token")
 	}
 }
 

--- a/pkg/openlore/tokenendpoint.go
+++ b/pkg/openlore/tokenendpoint.go
@@ -350,8 +350,8 @@ func (t *tokenEndpoint) handleRefreshToken(w http.ResponseWriter, r *http.Reques
 	}
 	rotation, err := t.refresh.Rotate(presented, newRefresh)
 	if err != nil {
-		// Stale or invalid credentials are denied without changing a valid
-		// successor token that another client worker may already hold.
+		// A stale credential from an authenticated client is denied without
+		// changing its successor. Public-client reuse revokes the chain.
 		t.recordRefresh(r.Context(), "rotation_rejected", old, err)
 		oauthError(w, http.StatusBadRequest, "invalid_grant", "refresh token rejected")
 		return

--- a/pkg/openlore/tokenendpoint.go
+++ b/pkg/openlore/tokenendpoint.go
@@ -350,7 +350,8 @@ func (t *tokenEndpoint) handleRefreshToken(w http.ResponseWriter, r *http.Reques
 	}
 	rotation, err := t.refresh.Rotate(presented, newRefresh)
 	if err != nil {
-		// Reuse or invalid → deny (chain already revoked on reuse).
+		// Stale or invalid credentials are denied without changing a valid
+		// successor token that another client worker may already hold.
 		t.recordRefresh(r.Context(), "rotation_rejected", old, err)
 		oauthError(w, http.StatusBadRequest, "invalid_grant", "refresh token rejected")
 		return


### PR DESCRIPTION
## Summary

- reject stale refresh attempts from `private_key_jwt`-authenticated clients without revoking the valid successor chain
- retain full-chain replay revocation for public clients, per RFC 9700 §4.14.2
- retain the two-minute idempotent retry window for lost responses and concurrent refresh requests
- document the authenticated-client behavior and correct the documented grace period

## Production evidence

`openlore.sh` showed ChatGPT successfully rotating a refresh token, retrying it, and then presenting an older token 68 seconds later. The reuse detector revoked the complete chain, after which every ChatGPT refresh returned `unknown_token`. The same sequence occurred twice on 2026-09-09.

ChatGPT authenticates its token requests using `private_key_jwt`, so its refresh token is bound to an authenticated client. The stale caller remains denied, but another authenticated ChatGPT worker holding the current token can continue. Public clients still rely on rotation for replay detection and therefore revoke the active chain when stale-token reuse cannot be handled as an idempotent retry. Explicit revocation also continues to delete the complete chain.

## Standards rationale

[RFC 9700 §4.14.2](https://www.rfc-editor.org/rfc/rfc9700.html#section-4.14.2) requires public-client refresh tokens to be sender-constrained or rotated with active-token revocation on detected replay. This change preserves that behavior for public clients. Confidential clients authenticate at the token endpoint; ChatGPT does so with asymmetric `private_key_jwt` assertions, and this exception applies only after that authentication succeeds.

## Verification

- `go test ./...`
- `go test -race ./pkg/openlore -run 'TestRefreshStore|TestTokenEndpoint_Refresh' -count=1`
- `git diff --check`