### PR TITLE
Fix MCP shell structured output (OPE-17)

### DIFF
--- a/pkg/openlore/mcp.go
+++ b/pkg/openlore/mcp.go
@@ -160,7 +160,7 @@ func newMCPShellHandler(fs vfs.FileSystem, envVars map[string]string, factory fu
 
 		return &mcp.CallToolResult{
 			Content:           []mcp.Content{&mcp.TextContent{Text: output}},
-			StructuredContent: map[string]any{"exit_code": exitCode},
+			StructuredContent: map[string]any{"output": output, "exit_code": exitCode},
 			IsError:           exitCode != 0,
 		}, nil, nil
 	}

--- a/pkg/openlore/mcp_test.go
+++ b/pkg/openlore/mcp_test.go
@@ -117,7 +117,7 @@ func TestMCPShellFailureIsError(t *testing.T) {
 
 	result, err := clientSession.CallTool(t.Context(), &mcp.CallToolParams{
 		Name:      "shell",
-		Arguments: map[string]any{"command": "cat /does/not/exist"},
+		Arguments: map[string]any{"command": "echo structured-output; cat /does/not/exist"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -129,6 +129,9 @@ func TestMCPShellFailureIsError(t *testing.T) {
 	if strings.HasPrefix(output, "\n") {
 		t.Fatalf("output starts with a blank line: %q", output)
 	}
+	if !strings.Contains(output, "structured-output") {
+		t.Fatalf("output %q does not contain stdout", output)
+	}
 	if !strings.HasSuffix(output, "exit code: 1") {
 		t.Fatalf("output %q does not end with %q", output, "exit code: 1")
 	}
@@ -138,6 +141,10 @@ func TestMCPShellFailureIsError(t *testing.T) {
 	}
 	if exitCode != 1 {
 		t.Fatalf("exit_code = %d, want 1", exitCode)
+	}
+	structured := result.StructuredContent.(map[string]any)
+	if structured["output"] != output {
+		t.Fatalf("structured output = %#v, want %q", structured["output"], output)
 	}
 }
 


### PR DESCRIPTION
## Linear

[OPE-17](https://linear.app/oiya/issue/OPE-17/mcp-shell-tool-puts-only-exit-code-in-structuredcontent-so-structured)

## Diagnosis

The MCP shell handler returned the full command transcript only through `content[].text`. Its `structuredContent` contained only `exit_code`, so clients that consume structured results could not see stdout or stderr.

## Fix

- Add the exact merged shell transcript as `structuredContent.output`.
- Preserve `structuredContent.exit_code` and existing text content for compatibility.
- Extend the MCP transport regression test to verify that structured output matches text output for a command containing stdout, an error, and a nonzero exit code.

## Verification

- `go test ./pkg/openlore -run 'TestMCPShellFailureIsError|TestMCPHTTPAPI_Shell|TestExitCodeFromStructured' -count=1`
- `go test -race ./...`
- `go build ./...`
- `go generate ./docs/...` (no generated diff)
- `git diff --check`

Implemented by aakarim in [this Amp thread](https://ampcode.com/threads/T-01a08f0d-4ac4-71da-8e1b-48555628b64f).
