### PR TITLE
Fix sed replacement semicolon truncation

### DIFF
--- a/pkg/shell/cmds/sed.go
+++ b/pkg/shell/cmds/sed.go
@@ -214,7 +214,7 @@ func parseSedCommands(expressions []string) []sedCmd {
 				break
 			}
 
-			separator := strings.IndexByte(expr, ';')
+			separator := indexSedCommandSeparator(expr)
 			if separator < 0 {
 				cmds = append(cmds, parseSedExpr(expr))
 				break
@@ -237,6 +237,62 @@ func parseSedCommands(expressions []string) []sedCmd {
 		}
 	}
 	return cmds
+}
+
+// indexSedCommandSeparator returns the first semicolon separating sed
+// commands. Semicolons within an address, substitution pattern, or
+// substitution replacement belong to that delimited value.
+func indexSedCommandSeparator(expr string) int {
+	skipDelimited := func(start int, delim byte) int {
+		escaped := false
+		for i := start; i < len(expr); i++ {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if expr[i] == '\\' {
+				escaped = true
+				continue
+			}
+			if expr[i] == delim {
+				return i + 1
+			}
+		}
+		return len(expr)
+	}
+
+	i := 0
+	if i < len(expr) && expr[i] == '/' {
+		i = skipDelimited(i+1, '/')
+	} else if i < len(expr) && expr[i] == '$' {
+		i++
+	} else {
+		for i < len(expr) && expr[i] >= '0' && expr[i] <= '9' {
+			i++
+		}
+	}
+	if i < len(expr) && expr[i] == ',' {
+		i++
+		if i < len(expr) && expr[i] == '/' {
+			i = skipDelimited(i+1, '/')
+		} else if i < len(expr) && expr[i] == '$' {
+			i++
+		} else {
+			for i < len(expr) && expr[i] >= '0' && expr[i] <= '9' {
+				i++
+			}
+		}
+	}
+
+	if i < len(expr) && expr[i] == 's' && i+1 < len(expr) {
+		delim := expr[i+1]
+		i = skipDelimited(i+2, delim)
+		i = skipDelimited(i, delim)
+	}
+	if separator := strings.IndexByte(expr[i:], ';'); separator >= 0 {
+		return i + separator
+	}
+	return -1
 }
 
 func parseSedExpr(expr string) sedCmd {

--- a/pkg/shell/cmds/sed.go
+++ b/pkg/shell/cmds/sed.go
@@ -243,27 +243,13 @@ func parseSedCommands(expressions []string) []sedCmd {
 // commands. Semicolons within an address, substitution pattern, or
 // substitution replacement belong to that delimited value.
 func indexSedCommandSeparator(expr string) int {
-	skipDelimited := func(start int, delim byte) int {
-		escaped := false
-		for i := start; i < len(expr); i++ {
-			if escaped {
-				escaped = false
-				continue
-			}
-			if expr[i] == '\\' {
-				escaped = true
-				continue
-			}
-			if expr[i] == delim {
-				return i + 1
-			}
-		}
-		return len(expr)
-	}
-
 	i := 0
 	if i < len(expr) && expr[i] == '/' {
-		i = skipDelimited(i+1, '/')
+		end := indexUnescapedSedDelimiter(expr, i+1, '/')
+		if end < 0 {
+			return -1
+		}
+		i = end + 1
 	} else if i < len(expr) && expr[i] == '$' {
 		i++
 	} else {
@@ -274,7 +260,11 @@ func indexSedCommandSeparator(expr string) int {
 	if i < len(expr) && expr[i] == ',' {
 		i++
 		if i < len(expr) && expr[i] == '/' {
-			i = skipDelimited(i+1, '/')
+			end := indexUnescapedSedDelimiter(expr, i+1, '/')
+			if end < 0 {
+				return -1
+			}
+			i = end + 1
 		} else if i < len(expr) && expr[i] == '$' {
 			i++
 		} else {
@@ -286,11 +276,36 @@ func indexSedCommandSeparator(expr string) int {
 
 	if i < len(expr) && expr[i] == 's' && i+1 < len(expr) {
 		delim := expr[i+1]
-		i = skipDelimited(i+2, delim)
-		i = skipDelimited(i, delim)
+		end := indexUnescapedSedDelimiter(expr, i+2, delim)
+		if end < 0 {
+			return -1
+		}
+		end = indexUnescapedSedDelimiter(expr, end+1, delim)
+		if end < 0 {
+			return -1
+		}
+		i = end + 1
 	}
 	if separator := strings.IndexByte(expr[i:], ';'); separator >= 0 {
 		return i + separator
+	}
+	return -1
+}
+
+func indexUnescapedSedDelimiter(expr string, start int, delim byte) int {
+	escaped := false
+	for i := start; i < len(expr); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if expr[i] == '\\' {
+			escaped = true
+			continue
+		}
+		if expr[i] == delim {
+			return i
+		}
 	}
 	return -1
 }
@@ -301,10 +316,10 @@ func parseSedExpr(expr string) sedCmd {
 
 	// Parse address
 	if i < len(expr) && expr[i] == '/' {
-		end := strings.Index(expr[i+1:], "/")
+		end := indexUnescapedSedDelimiter(expr, i+1, '/')
 		if end >= 0 {
-			cmd.addrRegex = expr[i+1 : i+1+end]
-			i = i + 1 + end + 1
+			cmd.addrRegex = strings.ReplaceAll(expr[i+1:end], `\/`, "/")
+			i = end + 1
 		}
 	} else if i < len(expr) && expr[i] == '$' {
 		cmd.addrStart = -1
@@ -325,10 +340,10 @@ func parseSedExpr(expr string) sedCmd {
 			cmd.addrEnd = -1
 			i++
 		} else if i < len(expr) && expr[i] == '/' {
-			end := strings.Index(expr[i+1:], "/")
+			end := indexUnescapedSedDelimiter(expr, i+1, '/')
 			if end >= 0 {
-				cmd.addrEndRegex = expr[i+1 : i+1+end]
-				i = i + 1 + end + 1
+				cmd.addrEndRegex = strings.ReplaceAll(expr[i+1:end], `\/`, "/")
+				i = end + 1
 			}
 		} else {
 			j := i

--- a/pkg/shell/cmds/sed_test.go
+++ b/pkg/shell/cmds/sed_test.go
@@ -44,6 +44,34 @@ func TestSedSubstitutionGlobal(t *testing.T) {
 	}
 }
 
+func TestSedSubstitutionPreservesSemicolonsInReplacement(t *testing.T) {
+	fs := testFS()
+	command := "sed -i '3s/.*/- **Status:** artifacts drafted; Glama submitted; remaining publishes blocked/' /docs/readme.md"
+	_, errOut, code := execCmd(t, fs, command)
+	if code != 0 {
+		t.Fatalf("sed substitution failed: code=%d stderr=%s", code, errOut)
+	}
+
+	content, err := fs.ReadFile("/docs/readme.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# Hello World\nThis is a test file.\n- **Status:** artifacts drafted; Glama submitted; remaining publishes blocked\nLine 4\nLine 5\n"
+	if string(content) != want {
+		t.Fatalf("content = %q, want %q", content, want)
+	}
+}
+
+func TestSedSubstitutionCommandSeparator(t *testing.T) {
+	out, errOut, code := execCmd(t, testFS(), "sed -n 's/apple/orange/g;p' /docs/notes.txt")
+	if code != 0 {
+		t.Fatalf("sed commands failed: code=%d stderr=%s", code, errOut)
+	}
+	if strings.Contains(out, "apple") || strings.Count(out, "orange") != 2 {
+		t.Fatalf("output = %q, want substitution followed by print", out)
+	}
+}
+
 func TestSedAppendMultilineInPlace(t *testing.T) {
 	fs := testFS()
 	command := "sed -i '/This is/a\\\n* idea, with context (important); keep it\n* another idea' /docs/readme.md"

--- a/pkg/shell/cmds/sed_test.go
+++ b/pkg/shell/cmds/sed_test.go
@@ -72,6 +72,29 @@ func TestSedSubstitutionCommandSeparator(t *testing.T) {
 	}
 }
 
+func TestSedPreservesSemicolonsInDelimitedValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{"address", "echo 'left;right' | sed -n '/left;right/p'", "left;right\n"},
+		{"pattern", "echo 'foo;bar' | sed 's/foo;bar/matched/'", "matched\n"},
+		{"escaped address delimiter", "echo 'path/with;semi' | sed -n '/path\\/with;semi/p'", "path/with;semi\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, errOut, code := execCmd(t, testFS(), tt.command)
+			if code != 0 {
+				t.Fatalf("sed command failed: code=%d stderr=%s", code, errOut)
+			}
+			if out != tt.want {
+				t.Fatalf("output = %q, want %q", out, tt.want)
+			}
+		})
+	}
+}
+
 func TestSedAppendMultilineInPlace(t *testing.T) {
 	fs := testFS()
 	command := "sed -i '/This is/a\\\n* idea, with context (important); keep it\n* another idea' /docs/readme.md"


### PR DESCRIPTION
## Linear

Fixes [OPE-10](https://linear.app/oiya/issue/OPE-10/semicolon-in-a-sed-replacement-string-truncates-the-line).

## Diagnosis

The shell lexer preserved the quoted `sed` expression correctly, but `parseSedCommands` subsequently treated every semicolon as a command separator. A semicolon inside the delimited replacement therefore truncated the replacement while the command still returned success.

## Fix

Locate sed command separators only after parsing the address and the complete delimited substitution pattern and replacement. Semicolons inside addresses, patterns, and replacements remain payload, while legitimate command separators such as `s/.../.../;p` continue to work.

Added regression coverage for the reported in-place Markdown edit and for a real substitution/print command separator.

## Verification

- `go test ./pkg/shell/cmds -count=1`
- `go test ./...`
- `go vet ./...`

All pass in the repository Nix development shell.

## Amp

Implemented in [this scheduled Amp child thread](https://ampcode.com/threads/T-01a09433-8c4a-70e3-a729-76216c827150).
